### PR TITLE
调整了搜索词生成的prompt，避免其生成非英文搜索词

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -169,6 +169,8 @@ Generate {amount} search terms for stock videos, depending on the subject of a v
 
 ### Video Script
 {video_script}
+
+Please note that you must use English for generating video search terms; Chinese is not accepted.
 """.strip()
 
     logger.info(f"subject: {video_subject}")


### PR DESCRIPTION
原先的prompt可能以中文文案结尾，有不小概率会因此生成中文搜索词，造成搜不到资源。