### PR TITLE
feat: add the support of docker compose to launch both web interface and api service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,19 @@
-# Use an official Python runtime as a parent image
+# ./base/Dockerfile
+# Base image with shared dependencies
 FROM python:3.10-slim
-
-# Set the working directory in the container
-WORKDIR /usr/src/app
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
-    git \
     imagemagick \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Fix security policy for ImageMagick
 RUN sed -i '/<policy domain="path" rights="none" pattern="@\*"/d' /etc/ImageMagick-6/policy.xml
 
-# Copy the current directory contents into the container at /usr/src/app
-COPY . .
-
 # Install Python dependencies
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Expose the port the app runs on
-EXPOSE 8080
-
-# Command to run the application
-CMD ["python", "main.py"]
-
 # At runtime, mount the config.toml file from the host into the container
-# using Docker volumes. Example usage:
-# docker run -v /path/to/your/config.toml:/usr/src/app/config.toml -p 8080:8080 moneyprinterturbo
+# docker build -f .\Dockerfile -t moneyprinterturbo-base .

--- a/README-en.md
+++ b/README-en.md
@@ -186,6 +186,14 @@ The effect is shown in the following image:
 python main.py
 ```
 
+### Use Docker Compose to launch both Web Interface and API Service
+
+```shell
+docker-compose up
+```
+
+> To stop and remove the containers, networks, and volumes created by up, you can run: `docker-compose down`
+
 After launching, you can view the `API documentation` at http://127.0.0.1:8080/docs and directly test the interface
 online for a quick experience.
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,14 @@ python main.py
 效果如下图：
 ![](docs/api.jpg)
 
+### 使用Docker Compose同时启动Web界面和API服务
+
+```shell
+docker-compose up
+```
+
+> 要停止并删除 up 创建的容器、网络和卷，您可以运行：`docker-compose down`
+
 ## 语音合成 🗣
 
 所有支持的声音列表，可以查看：[声音列表](./docs/voice-list.txt)

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,15 @@
+# ./app/Dockerfile
+FROM moneyprinterturbo-base:latest
+
+WORKDIR /app
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["python", "main.py"]
+
+# At runtime, mount the config.toml file from the host into the container
+# using Docker volumes. Example usage:
+# docker build -f .\app\Dockerfile -t moneyprinterturbo-app .
+# docker run -v /path/to/your/config.toml:/usr/src/app/config.toml -p 8080:8080 moneyprinterturbo-app

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  base:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    image: moneyprinterturbo-base:latest
+
+  app:
+    build:
+      context: .
+      dockerfile: ./app/Dockerfile
+    volumes:
+      - ./config.toml:/app/config.toml  # Update this path
+    ports:
+      - "8080:8080"
+    networks:
+      - moneyprinternet
+
+  webui:
+    build:
+      context: .
+      dockerfile: ./webui/Dockerfile
+    volumes:
+      - ./config.toml:/app/config.toml  # Update this path
+    ports:
+      - "8008:8008"
+    networks:
+      - moneyprinternet
+    depends_on:
+      - app
+
+networks:
+  moneyprinternet:
+    driver: bridge

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,0 +1,17 @@
+# ./webui/Dockerfile
+FROM moneyprinterturbo-base:latest
+
+WORKDIR /app
+
+COPY . .
+
+EXPOSE 8008
+
+ENV PYTHONPATH "${PYTHONPATH}:/app/webui"
+
+CMD ["streamlit", "run", "./webui/Main.py", "--server.port", "8008"]
+
+# At runtime, mount the config.toml file from the host into the container
+# using Docker volumes. Example usage:
+# docker build -f .\webui\Dockerfile -t moneyprinterturbo-webui .
+# docker run -p 8008:8008 -v /path/to/your/config.toml:/app/config.toml moneyprinterturbo-webui


### PR DESCRIPTION
1. Revise the root Dockerfile to act as a base Dockerfile for the installation of system packages and Python libraries;
2. Add .\app\Dockerfile for the api service;
3. Add .\webui\Dockerfile for the web interface.
4. Add readme.