### PR TITLE
Feat some apis

### DIFF
--- a/app/controllers/v1/video.py
+++ b/app/controllers/v1/video.py
@@ -1,11 +1,15 @@
-from fastapi import Request, Depends, Path, BackgroundTasks
+import os
+import glob
+from fastapi import Request, Depends, Path, BackgroundTasks, UploadFile
+from fastapi.params import File
 from loguru import logger
 
 from app.config import config
 from app.controllers import base
 from app.controllers.v1.base import new_router
 from app.models.exception import HttpException
-from app.models.schema import TaskVideoRequest, TaskQueryResponse, TaskResponse, TaskQueryRequest
+from app.models.schema import TaskVideoRequest, TaskQueryResponse, TaskResponse, TaskQueryRequest, BgmListResponse, \
+    BgmUploadResponse
 from app.services import task as tm
 from app.services import state as sm
 from app.utils import utils
@@ -52,6 +56,52 @@ def get_task(request: Request, task_id: str = Path(..., description="Task ID"),
                 uri_path = v.replace(task_dir, "tasks")
                 urls.append(f"{endpoint}/{uri_path}")
             task["videos"] = urls
+        if "combined_videos" in task:
+            combined_videos = task["combined_videos"]
+            task_dir = utils.task_dir()
+            urls = []
+            for v in combined_videos:
+                uri_path = v.replace(task_dir, "tasks")
+                urls.append(f"{endpoint}/{uri_path}")
+            task["combined_videos"] = urls
         return utils.get_response(200, task)
 
     raise HttpException(task_id=task_id, status_code=404, message=f"{request_id}: task not found")
+
+
+@router.get("/get_bgm_list", response_model=BgmListResponse, summary="get local bgm file list")
+def get_bgm_list(request: Request):
+    suffix = "*.mp3"
+    song_dir = utils.song_dir()
+    files = glob.glob(os.path.join(song_dir, suffix))
+    bgm_list = []
+    for file in files:
+        bgm_list.append({
+            "filename": os.path.basename(file),
+            "size": os.path.getsize(file),
+            "filepath": file,
+        })
+    response = {
+        "bgm_list": bgm_list
+    }
+    return utils.get_response(200, response)
+
+
+@router.post("/upload_bgm_file", response_model=BgmUploadResponse, summary="upload bgm file to songs directory")
+def upload_bgm_file(request: Request, file: UploadFile = File(...)):
+    request_id = base.get_task_id(request)
+    # check file ext
+    if file.filename.endswith('mp3'):
+        song_dir = utils.song_dir()
+        save_path = os.path.join(song_dir, file.filename)
+        # save file
+        with open(save_path, "wb+") as buffer:
+            # If the file already exists, it will be overwritten
+            file.file.seek(0)
+            buffer.write(file.file.read())
+        response = {
+            "uploaded_path": save_path
+        }
+        return utils.get_response(200, response)
+
+    raise HttpException('', status_code=400, message=f"{request_id}: Only *.mp3 files can be uploaded")

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -196,6 +196,9 @@ class TaskQueryResponse(BaseResponse):
                     "progress": 100,
                     "videos": [
                         "http://127.0.0.1:8080/tasks/6c85c8cc-a77a-42b9-bc30-947815aa0558/final-1.mp4"
+                    ],
+                    "combined_videos": [
+                        "http://127.0.0.1:8080/tasks/6c85c8cc-a77a-42b9-bc30-947815aa0558/combined-1.mp4"
                     ]
                 }
             },
@@ -222,7 +225,39 @@ class VideoTermsResponse(BaseResponse):
                 "status": 200,
                 "message": "success",
                 "data": {
-                    "video_terms": []
+                    "video_terms": ["sky", "tree"]
+                }
+            },
+        }
+
+
+class BgmListResponse(BaseResponse):
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "status": 200,
+                "message": "success",
+                "data": {
+                    "bgm_list": [
+                        {
+                            "filename": "output000.mp3",
+                            "size": 2249517,
+                            "filepath": "C:\\Users\\cathy\\Desktop\\MoneyPrinterTurbo\\resource\\songs\\output000.mp3"
+                        }
+                    ]
+                }
+            },
+        }
+
+
+class BgmUploadResponse(BaseResponse):
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "status": 200,
+                "message": "success",
+                "data": {
+                    "uploaded_path": "/root/home/MoneyPrinterTurbo/resource/songs/example.mp3"
                 }
             },
         }

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -127,6 +127,7 @@ def start(task_id, params: VideoParams):
     sm.update_task(task_id, state=const.TASK_STATE_PROCESSING, progress=50)
 
     final_video_paths = []
+    combined_video_paths = []
     video_concat_mode = params.video_concat_mode
     if params.video_count > 1:
         video_concat_mode = VideoConcatMode.random
@@ -162,11 +163,13 @@ def start(task_id, params: VideoParams):
         sm.update_task(task_id, progress=_progress)
 
         final_video_paths.append(final_video_path)
+        combined_video_paths.append(combined_video_path)
 
     logger.success(f"task {task_id} finished, generated {len(final_video_paths)} videos.")
 
     kwargs = {
         "videos": final_video_paths,
+        "combined_videos": combined_video_paths
     }
     sm.update_task(task_id, state=const.TASK_STATE_COMPLETE, progress=100, **kwargs)
     return kwargs


### PR DESCRIPTION
1.Return combined videos in get task api.
2.Add get_bgm_list and upload_bgm_file apis.
1.在/api/v1/tasks接口中返回了combined_videos字段(state=1的情况下)，用户可能会需要用到没有添加任何音效的源视频。
2.新增了获取背景音乐列表和上传背景音乐接口，其中上传背景音乐接口安装了python-multipart依赖，需注意的是由于create_video接口自定义背景音乐需要传入背景音乐的绝对路径，我担心修改create_video逻辑会造成破坏性变更，因此在获取背景音乐接口返回songs目录下背景音乐的绝对路径，这可能会造成服务器绝对路径信息的暴露。如果此更新会产生安全问题，请不要合并。