### PR TITLE
Add fade in and fade out effects to video

### DIFF
--- a/app/services/video.py
+++ b/app/services/video.py
@@ -273,6 +273,8 @@ def generate_video(video_path: str,
             logger.error(f"failed to add bgm: {str(e)}")
 
     video_clip = video_clip.set_audio(audio_clip)
+    # Apply fade in and fade out effects
+    video_clip = video_clip.fadein(1).fadeout(1)
     video_clip.write_videofile(output_file,
                                audio_codec="aac",
                                temp_audiofile_path=output_dir,


### PR DESCRIPTION
Related to #374

Implements fade in and fade out effects to the video generation process to prevent an abrupt ending.

- Adds fade in and fade out effects to the `generate_video` function in `app/services/video.py` using `moviepy.editor`'s `fadein` and `fadeout` methods with a duration of 1 second for both effects. This change ensures a smoother transition at the beginning and end of the video.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harry0703/MoneyPrinterTurbo/issues/374?shareId=35b4a3da-fd1d-451b-94a2-e74ae2743323).