### PR TITLE
修改基础镜像的apt源

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ RUN chmod 777 /MoneyPrinterTurbo
 
 ENV PYTHONPATH="/MoneyPrinterTurbo"
 
+# 改成国内的镜像, 避免连不上: deb.debian.org
+RUN echo "deb http://mirrors.aliyun.com/debian/ bullseye main" > /etc/apt/sources.list && \
+    echo "deb http://mirrors.aliyun.com/debian-security/ bullseye-security main" >> /etc/apt/sources.list && \
+    echo "deb http://mirrors.aliyun.com/debian/ bullseye-updates main" >> /etc/apt/sources.list
+    
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     git \


### PR DESCRIPTION
内网环境很容易出现: 
#6 0.350 Err:1 http://deb.debian.org/debian bullseye InRelease
#6 0.350   Connection failed [IP: 151.101.110.132 80]
#6 0.353 Err:2 http://deb.debian.org/debian-security bullseye-security InRelease
#6 0.353   Connection failed [IP: 151.101.110.132 80]
#6 0.356 Err:3 http://deb.debian.org/debian bullseye-updates InRelease
#6 0.356   Connection failed [IP: 151.101.110.132 80]