### PR TITLE
Update video.py - Fixing BackGround Music Volume Multiplier

### DIFF
--- a/app/services/video.py
+++ b/app/services/video.py
@@ -337,7 +337,7 @@ def generate_video(
         try:
             bgm_clip = AudioFileClip(bgm_file).with_effects(
                 [
-                    afx.MultiplyVolume(params.voice_volume),
+                    afx.MultiplyVolume(params.bgm_volume),
                     afx.AudioFadeOut(3),
                     afx.AudioLoop(duration=video_clip.duration),
                 ]


### PR DESCRIPTION
These was a typo in MuiliplyVolume function parameter. The name of the parameter should be bgm_voice