### PR TITLE
本地ollama问题

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -7,6 +7,8 @@ import g4f
 from loguru import logger
 from openai import AzureOpenAI, OpenAI
 from openai.types.chat import ChatCompletion
+from ollama import Client as ollamaClient
+from ollama import ChatResponse as ollamaChatResponse
 
 from app.config import config
 
@@ -39,6 +41,19 @@ def _generate_response(prompt: str) -> str:
                 base_url = config.app.get("ollama_base_url", "")
                 if not base_url:
                     base_url = "http://localhost:11434/v1"
+                
+
+                client = ollamaClient(host=base_url)
+                response: ollamaChatResponse = client.chat(model=model_name, messages=[
+                    {
+                        'role': 'user',
+                        'content': prompt,
+                    },
+                ])
+
+                return response.message.content.strip().split("</think>").pop().strip();
+
+                print(response['message']['content'])
             elif llm_provider == "openai":
                 api_key = config.app.get("openai_api_key")
                 model_name = config.app.get("openai_model_name")

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ redis==5.2.0
 python-multipart==0.0.19
 streamlit-authenticator==0.4.1
 pyyaml
+ollama


### PR DESCRIPTION
[#585 ](https://github.com/harry0703/MoneyPrinterTurbo/issues/585)
我本地使用docker跑也出现同样问题，查阅[ollama文档](https://github.com/ollama/ollama/blob/main/README.md#rest-api)后发现：
- 地址为http://localhost:11434/，没有`v1`
- 之前的代码使用的OpenAI的SDK请求，修改了配置base url也会404,因为SDK会在请求接口/chat/completions，而实际地址是/api/chat

(第一次改python代码，如有错误，望大佬指正)