### PR TITLE
fix: /docs redirect to homepage instead of showing Swagger UI

### DIFF
--- a/app/asgi.py
+++ b/app/asgi.py
@@ -5,7 +5,7 @@ import os
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from loguru import logger
 
@@ -69,7 +69,11 @@ app.mount(
 )
 
 public_dir = utils.public_dir()
-app.mount("/", StaticFiles(directory=public_dir, html=True), name="")
+
+
+@app.get("/", include_in_schema=False)
+async def index():
+    return FileResponse(os.path.join(public_dir, "index.html"))
 
 
 @app.on_event("shutdown")


### PR DESCRIPTION
## Summary

- **Fixes #801** - Accessing `/docs` (or `/redoc`, `/openapi.json`) was redirecting to the homepage instead of showing FastAPI's built-in Swagger UI.
- **Root cause**: `app.mount("/", StaticFiles(directory=public_dir, html=True))` acted as a catch-all that intercepted every unmatched path and served `index.html`, including FastAPI's built-in documentation routes.
- **Fix**: Replace the catch-all `StaticFiles` mount at `/` with an explicit `@app.get("/")` route that serves the homepage `index.html`. This allows FastAPI's built-in `/docs`, `/redoc`, and `/openapi.json` routes to be reached normally.

## Details

The `StaticFiles` middleware with `html=True` mounted at the root path `/` matches every incoming request path. When the requested file doesn't exist in the `public` directory (which only contains `index.html`), the `html=True` flag causes it to fall back to serving `index.html`. This means `/docs`, `/redoc`, and `/openapi.json` all got `index.html` instead of FastAPI's Swagger UI.

The fix is minimal: a single `@app.get("/")` endpoint replaces the broad `app.mount("/", ...)`, serving the same `index.html` at the root while no longer shadowing other routes.

## Test plan

- [ ] Start the API server (`python main.py`)
- [ ] Verify `http://localhost:8080/` still shows the homepage
- [ ] Verify `http://localhost:8080/docs` shows the Swagger UI
- [ ] Verify `http://localhost:8080/redoc` shows the ReDoc UI
- [ ] Verify `http://localhost:8080/openapi.json` returns the OpenAPI schema
- [ ] Verify API endpoints (e.g., video generation) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)