### PR TITLE
fix: update google-generativeai version for response_modalities support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ uvicorn==0.32.1
 openai==1.56.1
 faster-whisper==1.1.0
 loguru==0.7.3
-google.generativeai==0.8.3
+google.generativeai==0.8.6
 dashscope==1.20.14
 g4f==0.5.2.2
 azure-cognitiveservices-speech==1.41.1


### PR DESCRIPTION
## Summary

Fixes #836

The `response_modalities` field in `GenerationConfig` was introduced in a newer 
version of the `google-generativeai` SDK. The version previously pinned in 
`requirements.txt` was too old to support this field, causing Gemini TTS to fail 
immediately with:

Unknown field for GenerationConfig: response_modalities

## Changes

- Updated `google-generativeai` to a minimum version that supports 
  `response_modalities` in `GenerationConfig`

## How to Test

1. Set TTS provider to Gemini
2. Select any voice (e.g. Zephyr)
3. Start a task without a custom audio file
4. Confirm audio generates successfully without `Unknown field for GenerationConfig` error