### PR TITLE
feat: add local AI image generation via ComfyUI (replacing Pexels)

### DIFF
--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -77,7 +77,7 @@ class VideoParams(BaseModel):
     video_clip_duration: Optional[int] = 5
     video_count: Optional[int] = 1
 
-    video_source: Optional[str] = "pexels"
+    video_source: Optional[str] = "pexels"  # pexels, pixabay, local, ai
     video_materials: Optional[List[MaterialInfo]] = (
         None  # Materials used to generate the video
     )

--- a/app/services/comfyui.py
+++ b/app/services/comfyui.py
@@ -1,0 +1,251 @@
+"""ComfyUI API client for local AI image/video generation."""
+import os
+import random
+import subprocess
+import time
+import uuid
+from typing import List
+
+import requests
+from loguru import logger
+
+from app.config import config
+from app.models.schema import VideoAspect
+
+
+def _get_comfyui_url() -> str:
+    return config.app.get("comfyui_api_url", "http://127.0.0.1:8188").rstrip("/")
+
+
+def _build_flux_workflow(prompt: str, width: int, height: int, seed: int = None) -> dict:
+    """Build a FLUX.1-schnell text-to-image workflow for ComfyUI API."""
+    if seed is None:
+        seed = random.randint(0, 2**32 - 1)
+
+    return {
+        "4": {
+            "class_type": "UNETLoader",
+            "inputs": {
+                "unet_name": config.app.get("comfyui_flux_model", "flux1-schnell.safetensors"),
+                "weight_dtype": "default",
+            },
+        },
+        "5": {
+            "class_type": "EmptySD3LatentImage",
+            "inputs": {"width": width, "height": height, "batch_size": 1},
+        },
+        "6": {
+            "class_type": "CLIPTextEncode",
+            "inputs": {"text": prompt, "clip": ["11", 0]},
+        },
+        "7": {
+            "class_type": "CLIPTextEncode",
+            "inputs": {"text": "", "clip": ["11", 0]},
+        },
+        "3": {
+            "class_type": "KSampler",
+            "inputs": {
+                "seed": seed,
+                "steps": 4,
+                "cfg": 1.0,
+                "sampler_name": "euler",
+                "scheduler": "simple",
+                "denoise": 1.0,
+                "model": ["4", 0],
+                "positive": ["6", 0],
+                "negative": ["7", 0],
+                "latent_image": ["5", 0],
+            },
+        },
+        "8": {
+            "class_type": "VAEDecode",
+            "inputs": {"samples": ["3", 0], "vae": ["10", 0]},
+        },
+        "9": {
+            "class_type": "SaveImage",
+            "inputs": {"filename_prefix": "mpt_gen", "images": ["8", 0]},
+        },
+        "10": {
+            "class_type": "VAELoader",
+            "inputs": {
+                "vae_name": config.app.get("comfyui_flux_vae", "ae.safetensors"),
+            },
+        },
+        "11": {
+            "class_type": "DualCLIPLoader",
+            "inputs": {
+                "clip_name1": config.app.get("comfyui_t5xxl", "t5xxl_fp16.safetensors"),
+                "clip_name2": config.app.get("comfyui_clip_l", "clip_l.safetensors"),
+                "type": "flux",
+            },
+        },
+    }
+
+
+def generate_image(prompt: str, aspect: VideoAspect, seed: int = None) -> str:
+    """Generate an image via ComfyUI FLUX.1-schnell. Returns image download URL."""
+    base_url = _get_comfyui_url()
+    width, height = VideoAspect(aspect).to_resolution()
+
+    workflow = _build_flux_workflow(prompt, width, height, seed)
+    payload = {"prompt": workflow, "client_id": str(uuid.uuid4())}
+
+    try:
+        r = requests.post(f"{base_url}/prompt", json=payload, timeout=30)
+        r.raise_for_status()
+        prompt_id = r.json()["prompt_id"]
+        logger.info(f"ComfyUI prompt queued: {prompt_id}")
+    except Exception as e:
+        logger.error(f"ComfyUI prompt failed: {e}")
+        return ""
+
+    max_wait = int(config.app.get("comfyui_timeout", 120))
+    for _ in range(max_wait):
+        time.sleep(1)
+        try:
+            hist = requests.get(f"{base_url}/history/{prompt_id}", timeout=10).json()
+            if prompt_id in hist:
+                outputs = hist[prompt_id].get("outputs", {})
+                for _node_id, node_out in outputs.items():
+                    images = node_out.get("images", [])
+                    if images:
+                        img = images[0]
+                        return (
+                            f"{base_url}/view?filename={img['filename']}"
+                            f"&subfolder={img.get('subfolder', '')}"
+                            f"&type={img.get('type', 'output')}"
+                        )
+                logger.error(f"ComfyUI: no images in output for {prompt_id}")
+                return ""
+        except Exception:
+            continue
+
+    logger.error(f"ComfyUI: timeout waiting for {prompt_id}")
+    return ""
+
+
+def download_image(image_url: str, save_path: str) -> bool:
+    """Download image from ComfyUI server."""
+    try:
+        r = requests.get(image_url, timeout=60)
+        r.raise_for_status()
+        with open(save_path, "wb") as f:
+            f.write(r.content)
+        return os.path.getsize(save_path) > 0
+    except Exception as e:
+        logger.error(f"download image failed: {e}")
+        return False
+
+
+def image_to_video_kenburns(
+    image_path: str,
+    output_path: str,
+    duration: float = 5.0,
+    fps: int = 25,
+    width: int = 1920,
+    height: int = 1080,
+) -> bool:
+    """Convert a still image to a video clip with Ken Burns (zoom+pan) effect."""
+    d = int(duration * fps)
+    effects = [
+        f"zoompan=z='min(zoom+0.002,1.8)':x='iw/2-(iw/zoom/2)':y='ih/2-(ih/zoom/2)':d={d}:s={width}x{height}:fps={fps}",
+        f"zoompan=z='if(eq(on,1),1.8,max(zoom-0.002,1.0))':x='iw/2-(iw/zoom/2)':y='ih/2-(ih/zoom/2)':d={d}:s={width}x{height}:fps={fps}",
+        f"zoompan=z=1.3:x='if(eq(on,1),0,min(x+2,iw-iw/zoom))':y='ih/2-(ih/zoom/2)':d={d}:s={width}x{height}:fps={fps}",
+        f"zoompan=z=1.3:x='if(eq(on,1),iw-iw/zoom,max(x-2,0))':y='ih/2-(ih/zoom/2)':d={d}:s={width}x{height}:fps={fps}",
+    ]
+    effect = random.choice(effects)
+
+    cmd = [
+        "ffmpeg", "-y", "-loop", "1", "-i", image_path,
+        "-filter_complex", effect,
+        "-t", str(duration),
+        "-c:v", "libx264", "-preset", "fast", "-pix_fmt", "yuv420p",
+        output_path,
+    ]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        if result.returncode != 0:
+            logger.error(f"ffmpeg Ken Burns failed: {result.stderr[:500]}")
+            return False
+        return os.path.exists(output_path) and os.path.getsize(output_path) > 0
+    except Exception as e:
+        logger.error(f"Ken Burns conversion failed: {e}")
+        return False
+
+
+def enhance_prompt(search_term: str) -> str:
+    """Enhance a search keyword into a detailed image generation prompt."""
+    prefix = config.app.get(
+        "comfyui_prompt_prefix",
+        "Professional cinematic photo, high quality, detailed, 4K, ",
+    )
+    suffix = config.app.get("comfyui_prompt_suffix", "")
+    return f"{prefix}{search_term}{suffix}"
+
+
+def generate_videos_ai(
+    search_terms: List[str],
+    video_aspect: VideoAspect,
+    audio_duration: float,
+    clip_duration: float = 5.0,
+    save_dir: str = "",
+) -> List[str]:
+    """Generate video clips using ComfyUI AI image generation + Ken Burns effect."""
+    if not save_dir:
+        from app.utils import utils
+
+        save_dir = utils.storage_dir("ai_materials")
+    os.makedirs(save_dir, exist_ok=True)
+
+    width, height = VideoAspect(video_aspect).to_resolution()
+    video_paths = []
+    total_duration = 0.0
+    clips_needed = max(1, int(audio_duration / clip_duration) + 2)
+
+    for idx, term in enumerate(search_terms):
+        if total_duration >= audio_duration:
+            break
+
+        prompt = enhance_prompt(term)
+        per_term = max(1, clips_needed // len(search_terms))
+
+        for j in range(per_term):
+            if total_duration >= audio_duration:
+                break
+
+            uid = uuid.uuid4().hex[:8]
+            img_path = os.path.join(save_dir, f"ai_{idx}_{j}_{uid}.png")
+            vid_path = os.path.join(save_dir, f"ai_{idx}_{j}_{uid}.mp4")
+
+            logger.info(
+                f"generating image {idx + 1}/{len(search_terms)} variant {j + 1}: {term}"
+            )
+            img_url = generate_image(prompt, video_aspect)
+            if not img_url:
+                logger.warning(f"failed to generate image for: {term}")
+                continue
+
+            if not download_image(img_url, img_path):
+                continue
+
+            logger.info(f"converting to video clip with Ken Burns effect: {vid_path}")
+            if image_to_video_kenburns(
+                img_path, vid_path, clip_duration, width=width, height=height
+            ):
+                video_paths.append(vid_path)
+                total_duration += clip_duration
+                logger.info(
+                    f"generated clip {len(video_paths)}, "
+                    f"total: {total_duration:.1f}s / {audio_duration:.1f}s"
+                )
+
+            try:
+                os.remove(img_path)
+            except OSError:
+                pass
+
+    logger.success(
+        f"AI generated {len(video_paths)} video clips, total {total_duration:.1f}s"
+    )
+    return video_paths

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -8,7 +8,7 @@ from loguru import logger
 from app.config import config
 from app.models import const
 from app.models.schema import VideoConcatMode, VideoParams
-from app.services import llm, material, subtitle, video, voice
+from app.services import comfyui, llm, material, subtitle, video, voice
 from app.services import state as sm
 from app.utils import utils
 
@@ -172,6 +172,19 @@ def get_video_materials(task_id, params, video_terms, audio_duration):
             )
             return None
         return [material_info.url for material_info in materials]
+    elif params.video_source == "ai":
+        logger.info("\n\n## generating AI video materials via ComfyUI")
+        ai_videos = comfyui.generate_videos_ai(
+            search_terms=video_terms,
+            video_aspect=params.video_aspect,
+            audio_duration=audio_duration * params.video_count,
+            clip_duration=params.video_clip_duration,
+        )
+        if not ai_videos:
+            sm.state.update_task(task_id, state=const.TASK_STATE_FAILED)
+            logger.error("failed to generate AI video materials via ComfyUI.")
+            return None
+        return ai_videos
     else:
         logger.info(f"\n\n## downloading videos from {params.video_source}")
         downloaded_videos = material.download_videos(

--- a/config.example.toml
+++ b/config.example.toml
@@ -221,3 +221,21 @@ api_key = ""
 # 是否隐藏日志信息
 # Whether to hide logs in the UI
 hide_log = false
+
+# ===== ComfyUI 本地 AI 生成配置 (video_source = "ai" 时使用) =====
+# ComfyUI API 地址
+comfyui_api_url = "http://127.0.0.1:8188"
+# FLUX.1-schnell 模型文件名
+comfyui_flux_model = "flux1-schnell.safetensors"
+# VAE 文件名
+comfyui_flux_vae = "ae.safetensors"
+# T5-XXL 文本编码器
+comfyui_t5xxl = "t5xxl_fp16.safetensors"
+# CLIP-L 文本编码器
+comfyui_clip_l = "clip_l.safetensors"
+# 生成超时（秒）
+comfyui_timeout = 120
+# prompt 前缀（自动加在搜索词前）
+comfyui_prompt_prefix = "Professional cinematic photo, high quality, detailed, 4K, "
+# prompt 后缀（自动加在搜索词后）
+comfyui_prompt_suffix = ""


### PR DESCRIPTION
## Summary

This PR adds a new `video_source="ai"` option that generates video materials **locally using ComfyUI**, instead of searching Pexels/Pixabay stock footage.

- **New file**: `app/services/comfyui.py` — ComfyUI API client with FLUX.1-schnell text-to-image workflow + Ken Burns effect (zoom/pan) for automatic image-to-video conversion
- **Modified**: `app/services/task.py` — added `elif video_source == "ai"` branch in `get_video_materials()`
- **Modified**: `app/models/schema.py` — documented `"ai"` as valid `video_source` value
- **Modified**: `config.example.toml` — added ComfyUI configuration section

### How it works

```
search_terms → enhance_prompt() → ComfyUI FLUX.1-schnell generate image
→ FFmpeg Ken Burns effect (random zoom-in/zoom-out/pan) → 5s video clip
→ repeat until audio duration is covered → return video paths (same interface as Pexels)
```

### Benefits

- Fully local generation, zero API costs
- Zero copyright concerns (all AI-generated)
- Content precisely matches the script (no keyword-to-stock-footage mismatch)
- Works with any ComfyUI-supported image model (FLUX, SD3, etc.)
- Configurable prompt prefix/suffix for style control
- Non-breaking: existing Pexels/Pixabay workflows remain unchanged

### Configuration

Add to `config.toml`:
```toml
comfyui_api_url = "http://127.0.0.1:8188"
comfyui_flux_model = "flux1-schnell.safetensors"
comfyui_flux_vae = "ae.safetensors"
comfyui_t5xxl = "t5xxl_fp16.safetensors"
comfyui_clip_l = "clip_l.safetensors"
comfyui_timeout = 120
comfyui_prompt_prefix = "Professional cinematic photo, high quality, detailed, 4K, "
```

Then set `video_source = "ai"` in WebUI or API request.

### Requirements

- A running ComfyUI instance with FLUX.1-schnell (or compatible) model loaded
- FFmpeg installed (for Ken Burns effect conversion)

Closes #586