### PR TITLE
Feat/add litellm provider

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -186,9 +186,7 @@ def _generate_response(prompt: str) -> str:
                     raise Exception(f"[{llm_provider}] error: {str(e)}")
 
             elif llm_provider == "litellm":
-                api_key = config.app.get("litellm_api_key", "")
                 model_name = config.app.get("litellm_model_name")
-                base_url = config.app.get("litellm_base_url", "")
 
             if llm_provider not in ["pollinations", "ollama", "litellm"]:  # Skip validation for providers that don't require API key
                 if not api_key:
@@ -335,17 +333,11 @@ def _generate_response(prompt: str) -> str:
                         f"{llm_provider}: model_name is not set, please set it in the config.toml file."
                     )
 
-                kwargs = {
-                    "model": model_name,
-                    "messages": [{"role": "user", "content": prompt}],
-                    "drop_params": True,
-                }
-                if api_key:
-                    kwargs["api_key"] = api_key
-                if base_url:
-                    kwargs["api_base"] = base_url
-
-                response = litellm.completion(**kwargs)
+                response = litellm.completion(
+                    model=model_name,
+                    messages=[{"role": "user", "content": prompt}],
+                    drop_params=True,
+                )
 
                 if not response or not getattr(response, "choices", None):
                     raise ValueError(f"[{llm_provider}] returned empty response")

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -185,7 +185,12 @@ def _generate_response(prompt: str) -> str:
                 except Exception as e:
                     raise Exception(f"[{llm_provider}] error: {str(e)}")
 
-            if llm_provider not in ["pollinations", "ollama"]:  # Skip validation for providers that don't require API key
+            elif llm_provider == "litellm":
+                api_key = config.app.get("litellm_api_key", "")
+                model_name = config.app.get("litellm_model_name")
+                base_url = config.app.get("litellm_base_url", "")
+
+            if llm_provider not in ["pollinations", "ollama", "litellm"]:  # Skip validation for providers that don't require API key
                 if not api_key:
                     raise ValueError(
                         f"{llm_provider}: api_key is not set, please set it in the config.toml file."
@@ -321,6 +326,32 @@ def _generate_response(prompt: str) -> str:
                     "POST", url, headers=headers, data=payload
                 ).json()
                 return _normalize_text_response(response.get("result"), llm_provider)
+
+            if llm_provider == "litellm":
+                import litellm
+
+                if not model_name:
+                    raise ValueError(
+                        f"{llm_provider}: model_name is not set, please set it in the config.toml file."
+                    )
+
+                kwargs = {
+                    "model": model_name,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "drop_params": True,
+                }
+                if api_key:
+                    kwargs["api_key"] = api_key
+                if base_url:
+                    kwargs["api_base"] = base_url
+
+                response = litellm.completion(**kwargs)
+
+                if not response or not getattr(response, "choices", None):
+                    raise ValueError(f"[{llm_provider}] returned empty response")
+
+                content = response.choices[0].message.content
+                return _normalize_text_response(content, llm_provider)
 
             if llm_provider == "azure":
                 client = AzureOpenAI(

--- a/config.example.toml
+++ b/config.example.toml
@@ -32,6 +32,7 @@ pixabay_api_keys = []
 #   minimax
 #   ernie       (文心一言)
 #   modelscope  (魔搭社区)
+#   litellm     (100+ providers via LiteLLM gateway)
 llm_provider = "openai"
 
 ########## Pollinations AI Settings
@@ -120,6 +121,27 @@ deepseek_model_name = "deepseek-chat"
 modelscope_api_key = ""
 modelscope_base_url = "https://api-inference.modelscope.cn/v1/"
 modelscope_model_name = "Qwen/Qwen3-32B"
+
+########## LiteLLM (AI Gateway — 100+ providers)
+# LiteLLM routes to any LLM provider via a unified interface.
+# Use this for providers not directly supported above: Anthropic (native API),
+# AWS Bedrock, Google Vertex AI, Cohere, Mistral, Together AI, etc.
+# Visit https://docs.litellm.ai/docs/providers for the full list.
+#
+# LiteLLM reads provider API keys from environment variables automatically:
+#   OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, AWS_ACCESS_KEY_ID, etc.
+# Set the appropriate env var for your chosen provider before running.
+#
+# API Key: only needed when using a LiteLLM proxy server. Leave blank for direct provider access.
+litellm_api_key = ""
+# Base URL: only needed when using a LiteLLM proxy server (e.g. http://localhost:4000).
+# Leave blank for direct provider access.
+litellm_base_url = ""
+# Model name in LiteLLM format: "provider/model-name"
+# Examples: "openai/gpt-4o", "anthropic/claude-sonnet-4-20250514",
+#           "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+#           "gemini/gemini-2.5-flash", "ollama/llama3"
+litellm_model_name = "openai/gpt-4o-mini"
 
 # Subtitle Provider, "edge" or "whisper"
 # If empty, the subtitle will not be generated

--- a/config.example.toml
+++ b/config.example.toml
@@ -132,11 +132,6 @@ modelscope_model_name = "Qwen/Qwen3-32B"
 #   OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, AWS_ACCESS_KEY_ID, etc.
 # Set the appropriate env var for your chosen provider before running.
 #
-# API Key: only needed when using a LiteLLM proxy server. Leave blank for direct provider access.
-litellm_api_key = ""
-# Base URL: only needed when using a LiteLLM proxy server (e.g. http://localhost:4000).
-# Leave blank for direct provider access.
-litellm_base_url = ""
 # Model name in LiteLLM format: "provider/model-name"
 # Examples: "openai/gpt-4o", "anthropic/claude-sonnet-4-20250514",
 #           "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "requests==2.33.1",
     "socksio==1.0.0",
     "pydub==0.25.1",
+    "litellm>=1.55,<2.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pyyaml==6.0.3
 requests==2.33.1
 socksio==1.0.0
 pydub==0.25.1
+litellm>=1.55,<2.0

--- a/test/services/test_llm.py
+++ b/test/services/test_llm.py
@@ -18,12 +18,12 @@ FOUNDRY_MODEL = "azure_ai/claude-sonnet-4-6"
 requires_key = unittest.skipUnless(FOUNDRY_KEY, "ANTHROPIC_FOUNDRY_API_KEY not set")
 
 
-def _setup_litellm_config(model=FOUNDRY_MODEL, api_key=FOUNDRY_KEY, base_url=FOUNDRY_BASE):
+def _setup_litellm_config(model=FOUNDRY_MODEL):
     from app.config import config
     config.app["llm_provider"] = "litellm"
     config.app["litellm_model_name"] = model
-    config.app["litellm_api_key"] = api_key
-    config.app["litellm_base_url"] = base_url
+    os.environ["AZURE_AI_API_KEY"] = FOUNDRY_KEY
+    os.environ["AZURE_AI_API_BASE"] = FOUNDRY_BASE
 
 
 @requires_key
@@ -90,18 +90,6 @@ class TestLiteLLMEdgeCases(unittest.TestCase):
         self.assertIn("Error:", result)
         self.assertIn("model_name is not set", result)
 
-    def test_invalid_api_key(self):
-        _setup_litellm_config(api_key="invalid-key-12345")
-        from app.services.llm import _generate_response
-        result = _generate_response("test")
-        self.assertIn("Error:", result)
-
-    def test_invalid_base_url(self):
-        _setup_litellm_config(base_url="http://localhost:99999/nonexistent")
-        from app.services.llm import _generate_response
-        result = _generate_response("test")
-        self.assertIn("Error:", result)
-
     def test_nonexistent_model(self):
         _setup_litellm_config(model="azure_ai/nonexistent-model-xyz")
         from app.services.llm import _generate_response
@@ -131,28 +119,7 @@ class TestLiteLLMEdgeCases(unittest.TestCase):
 
 
 @requires_key
-class TestLiteLLMDirectAccess(unittest.TestCase):
-    """Test litellm without api_key/base_url — using env var fallback."""
-
-    def test_env_var_fallback_with_blank_key(self):
-        _setup_litellm_config(api_key="", base_url="")
-        os.environ["AZURE_AI_API_KEY"] = FOUNDRY_KEY
-        os.environ["AZURE_AI_API_BASE"] = FOUNDRY_BASE
-        try:
-            from app.services.llm import _generate_response
-            result = _generate_response("Say OK.")
-            # This may or may not work depending on litellm's env var resolution
-            # for azure_ai — the important thing is it doesn't crash with a
-            # confusing error about missing config
-            self.assertIsInstance(result, str)
-        finally:
-            os.environ.pop("AZURE_AI_API_KEY", None)
-            os.environ.pop("AZURE_AI_API_BASE", None)
-
-
-@requires_key
 class TestLiteLLMDoesNotBreakOtherProviders(unittest.TestCase):
-    """Verify that adding the litellm branch didn't break existing providers."""
 
     def test_openai_provider_still_works_structurally(self):
         from app.config import config
@@ -163,9 +130,7 @@ class TestLiteLLMDoesNotBreakOtherProviders(unittest.TestCase):
 
         from app.services.llm import _generate_response
         result = _generate_response("test")
-        # Will fail with auth error but should NOT crash with a code error
         self.assertIn("Error:", result)
-        # Should NOT contain litellm-related errors
         self.assertNotIn("litellm", result.lower())
 
 

--- a/test/services/test_llm.py
+++ b/test/services/test_llm.py
@@ -1,0 +1,173 @@
+"""Real integration tests for the litellm provider in app/services/llm.py.
+
+These tests hit a live Azure AI Foundry endpoint (amanrai-test-resource)
+via litellm. They require ANTHROPIC_FOUNDRY_API_KEY to be set in the
+environment. Skipped automatically if the key is missing.
+"""
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+FOUNDRY_KEY = os.environ.get("ANTHROPIC_FOUNDRY_API_KEY", "")
+FOUNDRY_BASE = "https://amanrai-test-resource.services.ai.azure.com/anthropic"
+FOUNDRY_MODEL = "azure_ai/claude-sonnet-4-6"
+
+requires_key = unittest.skipUnless(FOUNDRY_KEY, "ANTHROPIC_FOUNDRY_API_KEY not set")
+
+
+def _setup_litellm_config(model=FOUNDRY_MODEL, api_key=FOUNDRY_KEY, base_url=FOUNDRY_BASE):
+    from app.config import config
+    config.app["llm_provider"] = "litellm"
+    config.app["litellm_model_name"] = model
+    config.app["litellm_api_key"] = api_key
+    config.app["litellm_base_url"] = base_url
+
+
+@requires_key
+class TestLiteLLMBasicCompletion(unittest.TestCase):
+
+    def setUp(self):
+        _setup_litellm_config()
+
+    def test_simple_math_question(self):
+        from app.services.llm import _generate_response
+        result = _generate_response("What is 2+2? Reply with just the number.")
+        self.assertNotIn("Error:", result)
+        self.assertIn("4", result)
+
+    def test_response_is_string(self):
+        from app.services.llm import _generate_response
+        result = _generate_response("Say hello.")
+        self.assertIsInstance(result, str)
+        self.assertNotIn("Error:", result)
+        self.assertTrue(len(result) > 0)
+
+    def test_newlines_are_stripped(self):
+        from app.services.llm import _generate_response
+        result = _generate_response("Reply with exactly: line1\\nline2")
+        self.assertNotIn("\n", result)
+
+
+@requires_key
+class TestLiteLLMGenerateScript(unittest.TestCase):
+
+    def setUp(self):
+        _setup_litellm_config()
+
+    def test_generate_script_returns_nonempty(self):
+        from app.services.llm import generate_script
+        script = generate_script(
+            video_subject="The beauty of sunsets",
+            language="en",
+            paragraph_number=1,
+        )
+        self.assertIsInstance(script, str)
+        self.assertTrue(len(script) > 20, f"Script too short: {repr(script)}")
+        self.assertNotIn("Error:", script)
+
+    def test_generate_terms_returns_list(self):
+        from app.services.llm import generate_terms
+        terms = generate_terms(
+            video_subject="The beauty of sunsets",
+            video_script="Sunsets paint the sky in golden hues.",
+            amount=3,
+        )
+        self.assertIsInstance(terms, list)
+        self.assertTrue(len(terms) > 0, f"No terms returned: {terms}")
+        self.assertTrue(all(isinstance(t, str) for t in terms))
+
+
+@requires_key
+class TestLiteLLMEdgeCases(unittest.TestCase):
+
+    def test_missing_model_name(self):
+        _setup_litellm_config(model="")
+        from app.services.llm import _generate_response
+        result = _generate_response("test")
+        self.assertIn("Error:", result)
+        self.assertIn("model_name is not set", result)
+
+    def test_invalid_api_key(self):
+        _setup_litellm_config(api_key="invalid-key-12345")
+        from app.services.llm import _generate_response
+        result = _generate_response("test")
+        self.assertIn("Error:", result)
+
+    def test_invalid_base_url(self):
+        _setup_litellm_config(base_url="http://localhost:99999/nonexistent")
+        from app.services.llm import _generate_response
+        result = _generate_response("test")
+        self.assertIn("Error:", result)
+
+    def test_nonexistent_model(self):
+        _setup_litellm_config(model="azure_ai/nonexistent-model-xyz")
+        from app.services.llm import _generate_response
+        result = _generate_response("test")
+        self.assertIn("Error:", result)
+
+    def test_empty_prompt(self):
+        _setup_litellm_config()
+        from app.services.llm import _generate_response
+        result = _generate_response("")
+        self.assertIsInstance(result, str)
+
+    def test_very_long_prompt(self):
+        _setup_litellm_config()
+        from app.services.llm import _generate_response
+        long_prompt = "Tell me about AI. " * 100
+        result = _generate_response(long_prompt)
+        self.assertIsInstance(result, str)
+        self.assertNotIn("Error:", result)
+
+    def test_unicode_prompt(self):
+        _setup_litellm_config()
+        from app.services.llm import _generate_response
+        result = _generate_response("用中文回答：2加2等于几？只回答数字。")
+        self.assertIsInstance(result, str)
+        self.assertNotIn("Error:", result)
+
+
+@requires_key
+class TestLiteLLMDirectAccess(unittest.TestCase):
+    """Test litellm without api_key/base_url — using env var fallback."""
+
+    def test_env_var_fallback_with_blank_key(self):
+        _setup_litellm_config(api_key="", base_url="")
+        os.environ["AZURE_AI_API_KEY"] = FOUNDRY_KEY
+        os.environ["AZURE_AI_API_BASE"] = FOUNDRY_BASE
+        try:
+            from app.services.llm import _generate_response
+            result = _generate_response("Say OK.")
+            # This may or may not work depending on litellm's env var resolution
+            # for azure_ai — the important thing is it doesn't crash with a
+            # confusing error about missing config
+            self.assertIsInstance(result, str)
+        finally:
+            os.environ.pop("AZURE_AI_API_KEY", None)
+            os.environ.pop("AZURE_AI_API_BASE", None)
+
+
+@requires_key
+class TestLiteLLMDoesNotBreakOtherProviders(unittest.TestCase):
+    """Verify that adding the litellm branch didn't break existing providers."""
+
+    def test_openai_provider_still_works_structurally(self):
+        from app.config import config
+        config.app["llm_provider"] = "openai"
+        config.app["openai_api_key"] = "sk-test-fake-key"
+        config.app["openai_base_url"] = "https://api.openai.com/v1"
+        config.app["openai_model_name"] = "gpt-4o-mini"
+
+        from app.services.llm import _generate_response
+        result = _generate_response("test")
+        # Will fail with auth error but should NOT crash with a code error
+        self.assertIn("Error:", result)
+        # Should NOT contain litellm-related errors
+        self.assertNotIn("litellm", result.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -418,10 +418,9 @@ if not config.app.get("hide_config", False):
                 with llm_helper:
                     tips = """
                             ##### LiteLLM Configuration
-                            > [LiteLLM](https://github.com/BerriAI/litellm) routes to 100+ LLM providers via a unified interface
-                            - **API Key**: Only needed for LiteLLM proxy. For direct access, set provider env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
-                            - **Base Url**: Only needed for LiteLLM proxy (e.g. http://localhost:4000). Leave blank for direct provider access
-                            - **Model Name**: Use LiteLLM format, e.g. `openai/gpt-4o`, `anthropic/claude-sonnet-4-20250514`, `bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0`, `gemini/gemini-2.5-flash`. See [full provider list](https://docs.litellm.ai/docs/providers)
+                            > [LiteLLM](https://github.com/BerriAI/litellm) routes to 100+ LLM providers via a unified interface.
+                            > Set your provider's API key as an env var: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `AWS_ACCESS_KEY_ID`, etc.
+                            - **Model Name**: LiteLLM format — `openai/gpt-4o`, `anthropic/claude-sonnet-4-20250514`, `bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0`, `gemini/gemini-2.5-flash`. See [full provider list](https://docs.litellm.ai/docs/providers)
                             """
 
             if tips and config.ui["language"] == "zh":

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -243,6 +243,7 @@ if not config.app.get("hide_config", False):
                 "Cloudflare",
                 "ERNIE",
                 "Pollinations",
+                "LiteLLM",
             ]
             saved_llm_provider = config.app.get("llm_provider", "OpenAI").lower()
             saved_llm_provider_index = 0
@@ -409,6 +410,18 @@ if not config.app.get("hide_config", False):
                             - **API Key**: Optional - Leave empty for public access
                             - **Base Url**: Default is https://text.pollinations.ai/openai
                             - **Model Name**: Use 'openai-fast' or specify a model name
+                            """
+
+            if llm_provider == "litellm":
+                if not llm_model_name:
+                    llm_model_name = "openai/gpt-4o-mini"
+                with llm_helper:
+                    tips = """
+                            ##### LiteLLM Configuration
+                            > [LiteLLM](https://github.com/BerriAI/litellm) routes to 100+ LLM providers via a unified interface
+                            - **API Key**: Only needed for LiteLLM proxy. For direct access, set provider env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
+                            - **Base Url**: Only needed for LiteLLM proxy (e.g. http://localhost:4000). Leave blank for direct provider access
+                            - **Model Name**: Use LiteLLM format, e.g. `openai/gpt-4o`, `anthropic/claude-sonnet-4-20250514`, `bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0`, `gemini/gemini-2.5-flash`. See [full provider list](https://docs.litellm.ai/docs/providers)
                             """
 
             if tips and config.ui["language"] == "zh":


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
  - Adds [LiteLLM](https://github.com/BerriAI/litellm) as a native LLM provider, giving users access to 100+ LLM providers (Anthropic, AWS Bedrock, Google Vertex AI, Cohere, Mistral, Together AI, Groq, and more)  
  through a single `litellm` provider entry.                                                                                                                                                                         
  - Unlike the existing `openai + base_url` workaround, LiteLLM handles providers that are NOT OpenAI-compatible — Anthropic's native API, AWS Bedrock, Google Vertex AI, etc.
                                                                                                                                                                                                                     
  ## Changes                                                                                                                                                                                                         
  - `app/services/llm.py` — new `litellm` elif branch with `import litellm` and `litellm.completion()` call, `drop_params=True` for cross-provider compatibility
  - `webui/Main.py` — added "LiteLLM" to provider dropdown with configuration tips
  - `config.example.toml` — added litellm config section (only `litellm_model_name` needed — API keys are read from env vars automatically)                                                                          
  - `requirements.txt` / `pyproject.toml` — added `litellm>=1.55,<2.0`
  - `test/services/test_llm.py` — 11 real integration tests (no mocks, hits live Azure AI Foundry endpoint)                                                                                                          
                                                                                                                                                                                                                     
  ## Usage                                                                                                                                                                                                           
                                                                                                                                                                                                                     
  In `config.toml`:
  ```toml
  llm_provider = "litellm"
  litellm_model_name = "anthropic/claude-sonnet-4-20250514"
```
  Set your provider's API key as an environment variable:                                                                                                                                                            
  `export ANTHROPIC_API_KEY="sk-ant-..."`
                                                                                                                                                                                                                     
  LiteLLM reads provider API keys from environment variables automatically — no additional configuration needed.

  More model examples:                                                                                                                                                                                               
  - openai/gpt-4o — OpenAI (set OPENAI_API_KEY)
  - anthropic/claude-sonnet-4-20250514 — Anthropic (set ANTHROPIC_API_KEY)                                                                                                                                           
  - bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0 — AWS Bedrock (set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY)
  - gemini/gemini-2.5-flash — Google Gemini (set GEMINI_API_KEY)                                                   
  - groq/llama-3.1-70b-versatile — Groq (set GROQ_API_KEY)                                                                                                                                                           
                                                                                                                                                                                                                     
  Full provider list: https://docs.litellm.ai/docs/providers                                                                                                                                                         
                                                                                                                                                                                                                     
  ## Testing         
                                                                                                                                                                                                                     
  11 real integration tests in test/services/test_llm.py — no mocks, all hitting a live Azure AI Foundry endpoint via litellm.completion():                                                                          
 ``` 
  test_simple_math_question .............. ok    # basic completion returns correct answer                                                                                                                           
  test_response_is_string ................ ok    # response type check                                                                                                                                               
  test_newlines_are_stripped ............. ok    # matches existing provider behavior
  test_generate_script_returns_nonempty .. ok    # full generate_script() pipeline                                                                                                                                   
  test_generate_terms_returns_list ....... ok    # full generate_terms() pipeline                                                                                                                                    
  test_missing_model_name ................ ok    # error when model_name not set                                                                                                                                     
  test_nonexistent_model ................. ok    # error on invalid model                                                                                                                                            
  test_empty_prompt ...................... ok    # handles empty input
  test_very_long_prompt .................. ok    # handles large input                                                                                                                                               
  test_unicode_prompt .................... ok    # Chinese/unicode works
  test_openai_provider_still_works ....... ok    # existing providers not broken                                                                                                                                     
  ----------------------------------------------------------------------
  Ran 11 tests in 23.829s — OK                                                                                                                                                                                       
 ```
                                                                                                                                                                                                                     
 ### generation output via generate_script():
 ```
  llm provider: litellm                                                                                                                                                                                              
  subject: The beauty of sunsets
  completed:                    
  There is something almost otherworldly about the moment the sun begins                                                                                                                                             
  to sink below the horizon, painting the sky in shades of amber, rose, 
  and violet that no artist could ever truly replicate...                                                                                                                                                            
```                                                         
  ### search terms output via generate_terms():
`['sunset sky', 'golden sunset', 'sunset beauty']`                                                                                                                                                                   
   
  Risk / Compatibility                                                                                                                                                                                               
                  
  - Additive only — existing 14 providers untouched.                                                                                                                                                                 
  - litellm is a new dependency. Existing installs unaffected if not using the litellm provider.
  - drop_params=True silently drops provider-unsupported kwargs, preventing cross-provider errors.                                                                                                                   
