### PR TITLE
fix: guard against None message in LiteLLM response path

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -366,6 +366,8 @@ def _generate_response(prompt: str) -> str:
 
                 if not response or not getattr(response, "choices", None):
                     raise ValueError(f"[{llm_provider}] returned empty response")
+                if response.choices[0].message is None:
+                    raise ValueError(f"[{llm_provider}] returned empty message")
 
                 content = response.choices[0].message.content
                 return _normalize_text_response(content, llm_provider)


### PR DESCRIPTION
## What

Add a `message is None` check in `app/services/llm.py` after the existing choices guard.

## Why

The existing guard:
```python
if not response or not getattr(response, "choices", None):
    raise ValueError(...)
content = response.choices[0].message.content
```

ensures choices is non-empty, but if `choices[0].message` is `None` (observed on Gemini via OpenAI-compatible endpoint on PROHIBITED_CONTENT, which returns HTTP 200 with `message: null`), accessing `.content` raises `AttributeError`.

## Fix

```python
if not response or not getattr(response, "choices", None):
    raise ValueError(f"[{llm_provider}] returned empty response")
if response.choices[0].message is None:
    raise ValueError(f"[{llm_provider}] returned empty message")
content = response.choices[0].message.content
```

No behaviour change for well-formed responses.