### PR TITLE
fix: ensure audio_clip is properly closed in combine_videos

### DIFF
--- a/app/services/video.py
+++ b/app/services/video.py
@@ -263,8 +263,11 @@ def combine_videos(
     max_clip_duration: int = 5,
     threads: int = 2,
 ) -> str:
-    audio_clip = AudioFileClip(audio_file)
-    audio_duration = audio_clip.duration
+        audio_clip = AudioFileClip(audio_file)
+    try:
+        audio_duration = audio_clip.duration
+    finally:
+        close_clip(audio_clip)
     logger.info(f"audio duration: {audio_duration} seconds")
     logger.info(f"maximum clip duration: {max_clip_duration} seconds")
 


### PR DESCRIPTION
## Summary
Fix a file descriptor leak in `combine_videos()` where `AudioFileClip` was created but never explicitly closed on certain exit paths.

## Bug Details
- **File:** `app/services/video.py`
- **Function:** `combine_videos()`
- **Issue:** `audio_clip = AudioFileClip(audio_file)` creates a file handle that was only closed at the end of the function, but early returns and exceptions could bypass the cleanup.

## Fix
Wrap the `audio_clip` usage in a `try/finally` block to ensure `close_clip(audio_clip)` is always called.

## Testing
- [ ] Tested with sample video generation
- [ ] Verified no regression in video concatenation