### PR TITLE
test: add regression test for null video transition mode

### DIFF
--- a/test/services/test_video.py
+++ b/test/services/test_video.py
@@ -226,6 +226,30 @@ class TestVideoService(unittest.TestCase):
                 )
 
         self.assertTrue(fake_audio_clip.reader.closed)
+
+    def test_combine_videos_handles_none_transition_mode(self):
+        """
+        Ensure `combine_videos` safely handles
+        `video_transition_mode=None`.
+        """
+        class _FakeAudioClip:
+            @property
+            def duration(self):
+                return 10.0
+
+            def close(self):
+                pass
+
+        with patch.object(vd, "AudioFileClip", return_value=_FakeAudioClip()):
+            # Use empty video_paths to avoid heavy video processing while
+            # still exercising transition mode normalization logic.
+            result = vd.combine_videos(
+                combined_video_path="/tmp/unused-combined.mp4",
+                video_paths=[],
+                audio_file="/tmp/unused-audio.mp3",
+                video_transition_mode=None,
+            )
+            self.assertEqual(result, "/tmp/unused-combined.mp4")
     
     def test_wrap_text(self):
         """test text wrapping function"""

--- a/test/services/test_video.py
+++ b/test/services/test_video.py
@@ -240,16 +240,20 @@ class TestVideoService(unittest.TestCase):
             def close(self):
                 pass
 
-        with patch.object(vd, "AudioFileClip", return_value=_FakeAudioClip()):
-            # Use empty video_paths to avoid heavy video processing while
-            # still exercising transition mode normalization logic.
-            result = vd.combine_videos(
-                combined_video_path="/tmp/unused-combined.mp4",
-                video_paths=[],
-                audio_file="/tmp/unused-audio.mp3",
-                video_transition_mode=None,
-            )
-            self.assertEqual(result, "/tmp/unused-combined.mp4")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            combined_video_path = os.path.join(temp_dir, "combined.mp4")
+            audio_file = os.path.join(temp_dir, "audio.mp3")
+
+            with patch.object(vd, "AudioFileClip", return_value=_FakeAudioClip()):
+                # Use empty video_paths to avoid heavy video processing while
+                # still exercising transition mode normalization logic.
+                result = vd.combine_videos(
+                    combined_video_path=combined_video_path,
+                    video_paths=[],
+                    audio_file=audio_file,
+                    video_transition_mode=None,
+                )
+                self.assertEqual(result, combined_video_path)
     
     def test_wrap_text(self):
         """test text wrapping function"""


### PR DESCRIPTION
Adds regression coverage for the historical `video_transition_mode=None` API path in `combine_videos()`.

The current implementation safely normalizes literal Python `None` values before transition handling, but existing tests did not directly exercise this successful execution path.

## This adds

* adds a focused regression test for `video_transition_mode=None`
* follows existing `test_video.py` mocking conventions
* avoids heavy video processing by using an empty video_paths input and temporary paths
* verifies the function safely handles API-style `null` transition values without raising errors

## Validation

```bash
pytest test/services/test_video.py::TestVideoService::test_combine_videos_handles_none_transition_mode -v
pytest test/services/test_video.py -v
```
