### PR TITLE
docs: fix README-en typo (#891)

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -405,7 +405,7 @@ To enablerepo look-ups and downloads online, pass 'local files only=False' as in
 
 or
 
-An error occured while synchronizing the model Systran/faster-whisper-large-v3 from the Hugging Face Hub:
+An error occurred while synchronizing the model Systran/faster-whisper-large-v3 from the Hugging Face Hub:
 An error happened while trying to locate the files on the Hub and we cannot find the appropriate snapshot folder for the
 specified revision on the local disk. Please check your internet connection and try again.
 Trying to load the model directly from the local cache, if it exists.


### PR DESCRIPTION
## Summary

PR #891 fixed `occured` → `occurred` in the Chinese `README.md` Whisper FAQ block, but the parallel English `README-en.md` section still had the same misspelling. This completes that one-line docs sweep.

## Problem

The English troubleshooting section quotes a Hugging Face Hub sync error with a typo:

```408:408:README-en.md
An error occured while synchronizing the model Systran/faster-whisper-large-v3 from the Hugging Face Hub:
```

`README.md` was corrected in #891; `README-en.md` was not.

## Solution

Apply the same spelling fix (`occurred`) in `README-en.md` only. No code or config changes.

## Out of scope

- Other garbled tokens in the quoted error lines (`LocalEntryNotfoundEror`, `trafic`, etc.) — those mirror the upstream error text in both READMEs and were left untouched in #891.
- Issue #899 (Colab dependency resolver warnings) — separate dependency-pinning work.

## Test plan

- [x] `grep -R occured README*.md` — only historical references remain in git history
- [ ] CI (docs-only diff)

## Related

- #891 — merged the same fix for `README.md`

Made with [Cursor](https://cursor.com)