### PR TITLE
Stabilize local TTS and video tests

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -4,6 +4,7 @@ import math
 import os
 import queue
 import re
+import shutil
 import threading
 import time
 from datetime import datetime
@@ -21,6 +22,20 @@ from app.config import config
 from app.utils import utils
 
 _DEFAULT_EDGE_TTS_TIMEOUT_SECONDS = 30.0
+
+
+def _configure_pydub_ffmpeg(audio_segment_cls):
+    configured_ffmpeg = os.environ.get("IMAGEIO_FFMPEG_EXE") or shutil.which("ffmpeg")
+    if not configured_ffmpeg:
+        try:
+            import imageio_ffmpeg
+
+            configured_ffmpeg = imageio_ffmpeg.get_ffmpeg_exe()
+        except Exception as exc:
+            logger.warning(f"failed to resolve bundled ffmpeg binary: {str(exc)}")
+
+    if configured_ffmpeg:
+        audio_segment_cls.converter = configured_ffmpeg
 
 
 def mktimestamp(time_unit: float) -> str:
@@ -1760,6 +1775,7 @@ def gemini_tts(
     import io
     from pydub import AudioSegment
     import google.generativeai as genai
+    _configure_pydub_ffmpeg(AudioSegment)
     
     try:
         # 配置Gemini API

--- a/test/services/test_video.py
+++ b/test/services/test_video.py
@@ -111,7 +111,10 @@ class TestVideoService(unittest.TestCase):
 
             # moviepy get video info
             clip = VideoFileClip(materials[0].url)
-            print(clip)
+            try:
+                print(clip)
+            finally:
+                clip.close()
 
             # clean generated test video file
             if os.path.exists(materials[0].url):

--- a/test/services/test_voice.py
+++ b/test/services/test_voice.py
@@ -46,6 +46,9 @@ class TestVoiceService(unittest.TestCase):
         self.loop.close()
     
     def test_siliconflow(self):
+        if not vs.config.app.get("siliconflow_api_key"):
+            self.skipTest("siliconflow_api_key is not configured")
+
         voice_name = "siliconflow:FunAudioLLM/CosyVoice2-0.5B:alex-Male"
         voice_name = vs.parse_voice_name(voice_name)
         
@@ -192,6 +195,9 @@ class TestVoiceService(unittest.TestCase):
         self.assertLess(elapsed, 2)
 
     def test_azure_tts_v2(self):
+        if not vs.config.azure.get("speech_key") or not vs.config.azure.get("speech_region"):
+            self.skipTest("Azure speech key or region is not configured")
+
         voice_name = "zh-CN-XiaoxiaoMultilingualNeural-V2-Female"
         voice_name = vs.parse_voice_name(voice_name)
         print(voice_name)


### PR DESCRIPTION
## Summary
- configure pydub to use the bundled imageio-ffmpeg binary when system ffmpeg is unavailable
- close VideoFileClip in the image preprocessing test so Windows can remove the generated file
- skip real SiliconFlow/Azure v2 tests when required API credentials are not configured

## Tests
- `python -m pytest -q` -> 34 passed, 3 skipped