### PR TITLE
docs: fix unbalanced code fence in README-en MacOS section

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -203,7 +203,7 @@ Notes:
 
 ```shell
 brew install imagemagick
-````
+```
 
 ###### Ubuntu
 


### PR DESCRIPTION
## What

Fixes an unbalanced Markdown code fence in `README-en.md`. The MacOS ImageMagick install block opens with three backticks (```` ```shell ````) but closes with four (```` ```` ````).

## Why

The stray fourth backtick leaves the fence unterminated, so on GitHub the MacOS section renders merged into the following Ubuntu section instead of as a clean closed code block. Every other one of the file's ~18 fences uses three backticks; this is the lone outlier.

## Change

Documentation only, single character removed:

```diff
 ```shell
 brew install imagemagick
-````
+```
```

No content or behavior change.
