### PR TITLE
fix(voice): emit signed +0% for rates that round to zero (edge-tts ValueError)

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1193,13 +1193,14 @@ def tts(
 
 
 def convert_rate_to_percent(rate: float) -> str:
-    if rate == 1.0:
-        return "+0%"
+    # edge-tts requires a sign-prefixed percentage (e.g. "+0%", "-20%").
+    # Rounding can yield 0 for rates near but not equal to 1.0 (e.g. 1.004,
+    # 0.997); those must still be returned as "+0%", not the unsigned "0%"
+    # which edge-tts rejects with ValueError: Invalid rate '0%'.
     percent = round((rate - 1.0) * 100)
-    if percent > 0:
+    if percent >= 0:
         return f"+{percent}%"
-    else:
-        return f"{percent}%"
+    return f"{percent}%"
 
 
 def ensure_file_path_exists(file_path: str) -> None:

--- a/test/services/test_voice.py
+++ b/test/services/test_voice.py
@@ -378,6 +378,17 @@ class TestVoiceService(unittest.TestCase):
         self.assertEqual(len(sub_items), len(script_lines))
         self.assertIn("1,000 years", sub_items[-1])
 
+    def test_convert_rate_to_percent_signs_zero_rate(self):
+        # Rates near but not exactly 1.0 round to 0 percent. edge-tts rejects
+        # an unsigned "0%" (ValueError: Invalid rate '0%'), so the helper must
+        # emit a sign-prefixed "+0%". Regression test for that crash.
+        self.assertEqual(vs.convert_rate_to_percent(1.0), "+0%")
+        self.assertEqual(vs.convert_rate_to_percent(1.004), "+0%")
+        self.assertEqual(vs.convert_rate_to_percent(0.997), "+0%")
+        self.assertEqual(vs.convert_rate_to_percent(1.5), "+50%")
+        self.assertEqual(vs.convert_rate_to_percent(0.8), "-20%")
+
+
 if __name__ == "__main__":
     # python -m unittest test.services.test_voice.TestVoiceService.test_azure_tts_v1
     # python -m unittest test.services.test_voice.TestVoiceService.test_azure_tts_v2


### PR DESCRIPTION
## Problem

`convert_rate_to_percent()` in `app/services/voice.py` only returns the edge-tts-valid `"+0%"` when `rate == 1.0` **exactly**. Any other rate that rounds to 0 percent falls through to the `else` branch and returns an **unsigned** `"0%"`.

edge-tts requires a sign-prefixed rate string. `"0%"` is rejected:

```
ValueError: Invalid rate '0%'.
```

This aborts TTS generation. It's reachable from the WebUI speed slider whenever the chosen rate is close to but not exactly 1.0 (e.g. `1.004`, `0.997`).

### Reproduction

```python
import edge_tts
from app.services.voice import convert_rate_to_percent

rate_str = convert_rate_to_percent(1.004)   # -> '0%'
edge_tts.Communicate("hello", "zh-CN-YunxiNeural", rate=rate_str)
# ValueError: Invalid rate '0%'.
```

Verified against `edge-tts==7.2.7` (pinned) / `7.2.8`.

## Fix

Compute the rounded percent first, then sign-prefix any value `>= 0` so near-1.0 rates yield `"+0%"`:

```diff
-def convert_rate_to_percent(rate: float) -> str:
-    if rate == 1.0:
-        return "+0%"
-    percent = round((rate - 1.0) * 100)
-    if percent > 0:
-        return f"+{percent}%"
-    else:
-        return f"{percent}%"
+def convert_rate_to_percent(rate: float) -> str:
+    # edge-tts requires a sign-prefixed percentage (e.g. "+0%", "-20%").
+    # Rounding can yield 0 for rates near but not equal to 1.0 (e.g. 1.004,
+    # 0.997); those must still be returned as "+0%", not the unsigned "0%"
+    # which edge-tts rejects with ValueError: Invalid rate '0%'.
+    percent = round((rate - 1.0) * 100)
+    if percent >= 0:
+        return f"+{percent}%"
+    return f"{percent}%"
```

Negative rates are unaffected (they already carry the `-` sign).

## Tests

Adds `test_convert_rate_to_percent_signs_zero_rate` to `test/services/test_voice.py` covering `1.0`, `1.004`, `0.997` (all `"+0%"`), `1.5` (`"+50%"`) and `0.8` (`"-20%"`).

```
python -m unittest test.services.test_voice.TestVoiceService.test_convert_rate_to_percent_signs_zero_rate
```
