### PR TITLE
fix: handle non-enum video_contact_mode in download_videos

### DIFF
--- a/app/services/material.py
+++ b/app/services/material.py
@@ -266,7 +266,8 @@ def download_videos(
     elif material_directory and not os.path.isdir(material_directory):
         material_directory = ""
 
-    if video_contact_mode.value == VideoConcatMode.random.value:
+    concat_mode_value = getattr(video_contact_mode, "value", video_contact_mode)
+    if concat_mode_value == VideoConcatMode.random.value:
         random.shuffle(valid_video_items)
 
     total_duration = 0.0


### PR DESCRIPTION
## What

`download_videos` accessed `video_contact_mode.value` directly, which raises `AttributeError` when the argument is passed as a plain value instead of a `VideoConcatMode` enum.

## Fix

Use `getattr(video_contact_mode, "value", video_contact_mode)` so both the enum and a raw value are handled gracefully before comparing against `VideoConcatMode.random.value`.

## Impact

Prevents a crash in the video concatenation path when callers pass the mode as a string/value.