### PR TITLE
fix: Docker Ollama detection, subtitle wrapping, BGM path validation, edge-tts rate, i18n & README

### DIFF
--- a/app/config/config.py
+++ b/app/config/config.py
@@ -5,6 +5,10 @@ import socket
 import toml
 from loguru import logger
 
+
+def in_docker() -> bool:
+    return os.path.isfile("/.dockerenv") or os.path.isfile("/proc/1/cgroup")
+
 root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 config_file = f"{root_dir}/config.toml"
 

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -99,7 +99,10 @@ def _generate_response(prompt: str) -> str:
                 model_name = config.app.get("ollama_model_name")
                 base_url = config.app.get("ollama_base_url", "")
                 if not base_url:
-                    base_url = "http://localhost:11434/v1"
+                    if config.in_docker():
+                        base_url = "http://host.docker.internal:11434/v1"
+                    else:
+                        base_url = "http://localhost:11434/v1"
             elif llm_provider == "openai":
                 api_key = config.app.get("openai_api_key")
                 model_name = config.app.get("openai_model_name")

--- a/config.example.toml
+++ b/config.example.toml
@@ -20,14 +20,14 @@ tls_verify = true
 # You can use multiple keys to avoid rate limits.
 # For example: pexels_api_keys = ["123adsf4567adf89","abd1321cd13efgfdfhi"]
 # 特别注意格式，Key 用英文双引号括起来，多个Key用逗号隔开
-pexels_api_keys = []
+pexels_api_keys = [hA0lomPo4h57sbjo51zWjjjGKqlWhl17KpPj31nJvHnXKtOgfm4HieI2]
 
 # Pixabay API Key
 # Register at https://pixabay.com/api/docs/ to get your API key.
 # You can use multiple keys to avoid rate limits.
 # For example: pixabay_api_keys = ["123adsf4567adf89","abd1321cd13efgfdfhi"]
 # 特别注意格式，Key 用英文双引号括起来，多个Key用逗号隔开
-pixabay_api_keys = []
+pixabay_api_keys = [56067304-ef39d6a9b77f7fdb5d44ab85f]
 
 # 支持的提供商 (Supported providers):
 #   openai

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -283,15 +283,21 @@ if not config.app.get("hide_config", False):
                 if not llm_model_name:
                     llm_model_name = "qwen:7b"
                 if not llm_base_url:
-                    llm_base_url = "http://localhost:11434/v1"
+                    if config.in_docker():
+                        llm_base_url = "http://host.docker.internal:11434/v1"
+                    else:
+                        llm_base_url = "http://localhost:11434/v1"
 
                 with llm_helper:
-                    tips = """
+                    docker_hint = ""
+                    if config.in_docker():
+                        docker_hint = "\n                            > 检测到 Docker 环境，已自动使用 `http://host.docker.internal:11434/v1`\n"
+                    tips = f"""
                             ##### Ollama配置说明
                             - **API Key**: 随便填写，比如 123
                             - **Base Url**: 一般为 http://localhost:11434/v1
                                 - 如果 `MoneyPrinterTurbo` 和 `Ollama` **不在同一台机器上**，需要填写 `Ollama` 机器的IP地址
-                                - 如果 `MoneyPrinterTurbo` 是 `Docker` 部署，建议填写 `http://host.docker.internal:11434/v1`
+                                - 如果 `MoneyPrinterTurbo` 是 `Docker` 部署，建议填写 `http://host.docker.internal:11434/v1`{docker_hint}
                             - **Model Name**: 使用 `ollama list` 查看，比如 `qwen:7b`
                             """
 


### PR DESCRIPTION
### Changes

- **Docker detection**: auto-detect Docker env, use \host.docker.internal\ for Ollama base URL
- **Subtitle wrapping**: rewrite \wrap_text\ with PIL measurement; token-level & char-level splitting for long text
- **BGM path**: accept project-relative paths (\./resource/songs/xxx.mp3\), block paths outside whitelist
- **edge-tts**: emit \+0%\ instead of bare \