### PR TITLE
refactor: remove verified dead code and unused imports

### DIFF
--- a/app/controllers/v1/video.py
+++ b/app/controllers/v1/video.py
@@ -167,7 +167,6 @@ from fastapi import Query
 
 @router.get("/tasks", response_model=TaskQueryResponse, summary="Get all tasks")
 def get_all_tasks(request: Request, page: int = Query(1, ge=1), page_size: int = Query(10, ge=1)):
-    request_id = base.get_task_id(request)
     tasks, total = sm.state.get_all_tasks(page, page_size)
 
     response = {

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -15,7 +15,7 @@ from xml.sax.saxutils import unescape
 
 import edge_tts
 import requests
-from edge_tts import SubMaker, submaker
+from edge_tts import SubMaker
 from loguru import logger
 from moviepy.video.tools import subtitles
 from moviepy.audio.io.AudioFileClip import AudioFileClip
@@ -1818,7 +1818,6 @@ def gemini_tts(
         SubMaker对象或None
     """
     import base64
-    import json
     import io
     from pydub import AudioSegment
     import google.generativeai as genai


### PR DESCRIPTION
Small self-contained cleanup (no feature/test changes). `app/services/voice.py`: drop unused `submaker` import and an unused local `import json`. `app/controllers/v1/video.py`: remove dead `request_id` assignment in `get_all_tasks` (`get_task_id` is pure). Verified with ruff (F401/F841) and py_compile.