### PR TITLE
feat(subtitle): optional rounded/translucent subtitle background (opt-in, configurable) — supersedes #945

### DIFF
--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -100,6 +100,11 @@ class VideoParams(BaseModel):
     font_name: Optional[str] = "STHeitiMedium.ttc"
     text_fore_color: Optional[str] = "#FFFFFF"
     text_background_color: Union[bool, str] = True
+    # Opt-in subtitle background styling. Defaults preserve the original solid,
+    # fully opaque rectangle so existing output is unchanged.
+    subtitle_background_rounded: Optional[bool] = False
+    subtitle_background_opacity: Optional[int] = 100  # 0-100 (%); 100 = opaque
+    subtitle_background_radius: Optional[int] = 20  # px corner radius when rounded
 
     font_size: int = 60
     stroke_color: Optional[str] = "#000000"
@@ -123,6 +128,9 @@ class SubtitleRequest(BaseModel):
     font_name: Optional[str] = "STHeitiMedium.ttc"
     text_fore_color: Optional[str] = "#FFFFFF"
     text_background_color: Union[bool, str] = True
+    subtitle_background_rounded: Optional[bool] = False
+    subtitle_background_opacity: Optional[int] = 100
+    subtitle_background_radius: Optional[int] = 20
     font_size: int = 60
     stroke_color: Optional[str] = "#000000"
     stroke_width: float = 1.5

--- a/app/services/video.py
+++ b/app/services/video.py
@@ -20,7 +20,8 @@ from moviepy import (
     afx,
 )
 from moviepy.video.tools.subtitles import SubtitlesClip
-from PIL import Image, ImageFont
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
 
 from app.models import const
 from app.models.schema import (
@@ -32,6 +33,31 @@ from app.models.schema import (
 )
 from app.services.utils import video_effects
 from app.utils import file_security, utils
+
+
+def hex_to_rgb(color):
+    """Parse a #RRGGBB color to an (r, g, b) tuple; black on any invalid value."""
+    if isinstance(color, str) and color.startswith("#") and len(color) == 7:
+        try:
+            return (int(color[1:3], 16), int(color[3:5], 16), int(color[5:7], 16))
+        except ValueError:
+            return (0, 0, 0)
+    return (0, 0, 0)
+
+
+def build_subtitle_background_rgba(width, height, rgb, alpha, radius):
+    """Build an RGBA numpy array for a (optionally rounded) translucent subtitle
+    background. ``alpha`` is 0-255; ``radius`` is the corner radius in px
+    (0 = square). Pure function — used by the renderer and covered by tests."""
+    img = Image.new("RGBA", (int(width), int(height)), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    draw.rounded_rectangle(
+        [0, 0, int(width) - 1, int(height) - 1],
+        radius=int(radius),
+        fill=(rgb[0], rgb[1], rgb[2], int(alpha)),
+    )
+    return np.array(img)
+
 
 class SubClippedVideoClip:
     def __init__(self, file_path, start_time=None, end_time=None, width=None, height=None, duration=None):
@@ -573,6 +599,16 @@ def generate_video(
             return "#000000" if params.text_background_color else None
         return params.text_background_color
 
+    def _hex_to_rgb(color):
+        return hex_to_rgb(color)
+
+    def _rounded_bg_clip(width, height, rgb, alpha, radius):
+        # Transparent (optionally rounded) subtitle background as an ImageClip.
+        return ImageClip(
+            build_subtitle_background_rgba(width, height, rgb, alpha, radius),
+            transparent=True,
+        )
+
     def create_text_clip(subtitle_item):
         params.font_size = int(params.font_size)
         params.stroke_width = int(params.stroke_width)
@@ -588,23 +624,82 @@ def generate_video(
         # 描边或背景色时，容易把最后一行的下半部分裁掉。这里显式传入
         # 一个更保守的高度，把行间距和额外上下留白一并算进去，保证字幕
         # 背景框与文字本身都能完整渲染出来。
-        size = (
-            int(max_width),
-            int(txt_height + vertical_padding + (interline * line_count)),
-        )
+        clip_h = int(txt_height + vertical_padding + (interline * line_count))
+        bg_color = resolve_subtitle_background_color()
 
-        _clip = TextClip(
-            text=wrapped_txt,
-            font=font_path,
-            font_size=params.font_size,
-            color=params.text_fore_color,
-            bg_color=resolve_subtitle_background_color(),
-            stroke_color=params.stroke_color,
-            stroke_width=params.stroke_width,
-            interline=interline,
-            size=size,
-            text_align="center",
-        )
+        if bg_color is None:
+            # بلا خلفية: نُبقي السلوك الأصلي (نص بعرض الإطار الأقصى).
+            _clip = TextClip(
+                text=wrapped_txt,
+                font=font_path,
+                font_size=params.font_size,
+                color=params.text_fore_color,
+                bg_color=None,
+                stroke_color=params.stroke_color,
+                stroke_width=params.stroke_width,
+                interline=interline,
+                size=(int(max_width), clip_h),
+                text_align="center",
+            )
+        else:
+            # Opt-in flags. Defaults (rounded=False, opacity=100) reproduce the
+            # original solid, fully opaque rectangle so existing output is unchanged.
+            rounded = bool(getattr(params, "subtitle_background_rounded", False))
+            opacity_pct = int(getattr(params, "subtitle_background_opacity", 100) or 100)
+            opacity_pct = max(0, min(100, opacity_pct))
+
+            if not rounded and opacity_pct >= 100:
+                # DEFAULT (unchanged): solid opaque rectangle spanning the box.
+                _clip = TextClip(
+                    text=wrapped_txt,
+                    font=font_path,
+                    font_size=params.font_size,
+                    color=params.text_fore_color,
+                    bg_color=bg_color,
+                    stroke_color=params.stroke_color,
+                    stroke_width=params.stroke_width,
+                    interline=interline,
+                    size=(int(max_width), clip_h),
+                    text_align="center",
+                )
+            else:
+                # OPT-IN: translucent and/or rounded background hugging the text.
+                # 1) measure the actual text width so the box hugs it.
+                try:
+                    _font = ImageFont.truetype(font_path, params.font_size)
+                    text_w = max(
+                        int(_font.getbbox(line)[2] - _font.getbbox(line)[0])
+                        for line in wrapped_txt.split("\n")
+                    )
+                except Exception:
+                    text_w = int(max_width)
+                pad_x = int(params.font_size * 0.6)
+                box_w = min(int(max_width), text_w + 2 * pad_x)
+                alpha = int(round(opacity_pct / 100 * 255))
+                radius = (
+                    max(0, int(getattr(params, "subtitle_background_radius", 20) or 0))
+                    if rounded
+                    else 0
+                )
+                # 2) transparent text over a (rounded) translucent background.
+                _txt = TextClip(
+                    text=wrapped_txt,
+                    font=font_path,
+                    font_size=params.font_size,
+                    color=params.text_fore_color,
+                    bg_color=None,
+                    stroke_color=params.stroke_color,
+                    stroke_width=params.stroke_width,
+                    interline=interline,
+                    size=(box_w, clip_h),
+                    text_align="center",
+                )
+                _bg = _rounded_bg_clip(
+                    box_w, clip_h, _hex_to_rgb(bg_color), alpha=alpha, radius=radius
+                )
+                _clip = CompositeVideoClip(
+                    [_bg, _txt.with_position("center")], size=(box_w, clip_h)
+                )
         duration = subtitle_item[0][1] - subtitle_item[0][0]
         _clip = _clip.with_start(subtitle_item[0][0])
         _clip = _clip.with_end(subtitle_item[0][1])

--- a/test/services/test_subtitle_background.py
+++ b/test/services/test_subtitle_background.py
@@ -1,0 +1,61 @@
+"""Focused tests for the opt-in subtitle background styling.
+
+Guarantees the default stays the original solid, fully opaque rectangle and
+that the opt-in path produces a configurable translucent / rounded background.
+"""
+
+import unittest
+
+import numpy as np
+
+from app.models.schema import VideoParams
+from app.services.video import build_subtitle_background_rgba, hex_to_rgb
+
+
+class SubtitleBackgroundDefaultsTest(unittest.TestCase):
+    def test_defaults_preserve_original_behavior(self):
+        # New fields must default to the original solid, opaque rectangle.
+        p = VideoParams(video_subject="x")
+        self.assertFalse(p.subtitle_background_rounded)
+        self.assertEqual(p.subtitle_background_opacity, 100)
+
+
+class HexToRgbTest(unittest.TestCase):
+    def test_valid_and_invalid(self):
+        self.assertEqual(hex_to_rgb("#000000"), (0, 0, 0))
+        self.assertEqual(hex_to_rgb("#FF8040"), (255, 128, 64))
+        self.assertEqual(hex_to_rgb("nonsense"), (0, 0, 0))
+        self.assertEqual(hex_to_rgb("#GGGGGG"), (0, 0, 0))
+
+
+class SubtitleBackgroundRenderTest(unittest.TestCase):
+    W, H = 200, 80
+
+    def _arr(self, alpha, radius):
+        return build_subtitle_background_rgba(self.W, self.H, (0, 0, 0), alpha, radius)
+
+    def test_shape_is_rgba(self):
+        arr = self._arr(255, 0)
+        self.assertEqual(arr.shape, (self.H, self.W, 4))
+
+    def test_opaque_square_default(self):
+        # opacity=255, radius=0 -> fully opaque everywhere (the default look).
+        arr = self._arr(255, 0)
+        self.assertEqual(int(arr[0, 0, 3]), 255)  # corner opaque
+        self.assertEqual(int(arr[self.H // 2, self.W // 2, 3]), 255)  # centre opaque
+
+    def test_translucent_center(self):
+        # opacity ~55% -> centre alpha 140, still opaque corners when square.
+        arr = self._arr(140, 0)
+        self.assertEqual(int(arr[self.H // 2, self.W // 2, 3]), 140)
+        self.assertEqual(int(arr[0, 0, 3]), 140)
+
+    def test_rounded_corners_are_transparent(self):
+        # With a radius the extreme corner pixel is outside the rounded shape.
+        arr = self._arr(255, 24)
+        self.assertEqual(int(arr[0, 0, 3]), 0)  # corner cut away -> transparent
+        self.assertEqual(int(arr[self.H // 2, self.W // 2, 3]), 255)  # centre filled
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -1084,6 +1084,29 @@ with right_panel:
             params.stroke_color = st.color_picker(tr("Stroke Color"), "#000000")
         with stroke_cols[1]:
             params.stroke_width = st.slider(tr("Stroke Width"), 0.0, 10.0, 1.5)
+
+        # Subtitle background styling (opt-in). Defaults keep the original
+        # solid, fully opaque rectangle so existing output is unchanged.
+        params.subtitle_background_rounded = st.checkbox(
+            tr("Rounded Subtitle Background"),
+            value=config.ui.get("subtitle_background_rounded", False),
+        )
+        config.ui["subtitle_background_rounded"] = params.subtitle_background_rounded
+        bg_cols = st.columns(2)
+        with bg_cols[0]:
+            params.subtitle_background_opacity = st.slider(
+                tr("Subtitle Background Opacity"), 0, 100,
+                int(config.ui.get("subtitle_background_opacity", 100)),
+                help=tr("100% keeps the original opaque background"),
+            )
+            config.ui["subtitle_background_opacity"] = params.subtitle_background_opacity
+        with bg_cols[1]:
+            params.subtitle_background_radius = st.slider(
+                tr("Subtitle Background Corner Radius"), 0, 60,
+                int(config.ui.get("subtitle_background_radius", 20)),
+                disabled=not params.subtitle_background_rounded,
+            )
+            config.ui["subtitle_background_radius"] = params.subtitle_background_radius
     with st.expander(tr("Click to show API Key management"), expanded=False):
         st.subheader(tr("Manage Pexels and Pixabay API Keys"))
 

--- a/webui/i18n/de.json
+++ b/webui/i18n/de.json
@@ -117,6 +117,10 @@
     "Pixabay API Key added successfully": "Pixabay-API-Schlüssel erfolgreich hinzugefügt",
     "Select Pixabay API Key to delete": "Wählen Sie den zu löschenden Pixabay-API-Schlüssel aus",
     "Delete Selected Pixabay API Key": "Ausgewählten Pixabay-API-Schlüssel löschen",
-    "Pixabay API Key deleted successfully": "Pixabay-API-Schlüssel erfolgreich gelöscht"
+    "Pixabay API Key deleted successfully": "Pixabay-API-Schlüssel erfolgreich gelöscht",
+    "Rounded Subtitle Background": "Abgerundeter Untertitelhintergrund",
+    "Subtitle Background Opacity": "Deckkraft des Untertitelhintergrunds",
+    "Subtitle Background Corner Radius": "Eckenradius des Untertitelhintergrunds",
+    "100% keeps the original opaque background": "100 % behält den ursprünglichen undurchsichtigen Hintergrund"
   }
 }

--- a/webui/i18n/en.json
+++ b/webui/i18n/en.json
@@ -130,6 +130,10 @@
     "Pixabay API Key added successfully": "Pixabay API Key added successfully",
     "Select Pixabay API Key to delete": "Select Pixabay API Key to delete",
     "Delete Selected Pixabay API Key": "Delete Selected Pixabay API Key",
-    "Pixabay API Key deleted successfully": "Pixabay API Key deleted successfully"
+    "Pixabay API Key deleted successfully": "Pixabay API Key deleted successfully",
+    "Rounded Subtitle Background": "Rounded Subtitle Background",
+    "Subtitle Background Opacity": "Subtitle Background Opacity",
+    "Subtitle Background Corner Radius": "Subtitle Background Corner Radius",
+    "100% keeps the original opaque background": "100% keeps the original opaque background"
   }
 }

--- a/webui/i18n/pt.json
+++ b/webui/i18n/pt.json
@@ -117,6 +117,10 @@
     "Pixabay API Key added successfully": "Chave de API do Pixabay adicionada com sucesso",
     "Select Pixabay API Key to delete": "Selecione a chave de API do Pixabay para excluir",
     "Delete Selected Pixabay API Key": "Excluir chave de API do Pixabay selecionada",
-    "Pixabay API Key deleted successfully": "Chave de API do Pixabay excluída com sucesso"
+    "Pixabay API Key deleted successfully": "Chave de API do Pixabay excluída com sucesso",
+    "Rounded Subtitle Background": "Fundo de legenda arredondado",
+    "Subtitle Background Opacity": "Opacidade do fundo da legenda",
+    "Subtitle Background Corner Radius": "Raio do canto do fundo",
+    "100% keeps the original opaque background": "100% mantém o fundo opaco original"
   }
 }

--- a/webui/i18n/ru.json
+++ b/webui/i18n/ru.json
@@ -100,6 +100,10 @@
     "Hide Log": "Скрыть журнал",
     "Hide Basic Settings": "Скрыть основные настройки\n\nПри скрытии панель основных настроек не будет отображаться на странице.\n\nДля повторного отображения установите `hide_config = false` в `config.toml`",
     "LLM Settings": "**Настройки LLM**",
-    "Video Source Settings": "**Настройки источника видео**"
+    "Video Source Settings": "**Настройки источника видео**",
+    "Rounded Subtitle Background": "Скруглённый фон субтитров",
+    "Subtitle Background Opacity": "Непрозрачность фона субтитров",
+    "Subtitle Background Corner Radius": "Радиус скругления фона",
+    "100% keeps the original opaque background": "100% сохраняет исходный непрозрачный фон"
   }
 }

--- a/webui/i18n/tr.json
+++ b/webui/i18n/tr.json
@@ -119,6 +119,10 @@
     "Pixabay API Key added successfully": "Pixabay API Anahtarı başarıyla eklendi",
     "Select Pixabay API Key to delete": "Silinecek Pixabay API Anahtarını seçin",
     "Delete Selected Pixabay API Key": "Seçili Pixabay API Anahtarını Sil",
-    "Pixabay API Key deleted successfully": "Pixabay API Anahtarı başarıyla silindi"
+    "Pixabay API Key deleted successfully": "Pixabay API Anahtarı başarıyla silindi",
+    "Rounded Subtitle Background": "Yuvarlatılmış altyazı arka planı",
+    "Subtitle Background Opacity": "Altyazı arka plan opaklığı",
+    "Subtitle Background Corner Radius": "Altyazı arka plan köşe yarıçapı",
+    "100% keeps the original opaque background": "%100 orijinal opak arka planı korur"
   }
 }

--- a/webui/i18n/vi.json
+++ b/webui/i18n/vi.json
@@ -117,6 +117,10 @@
     "Pixabay API Key added successfully": "Thêm API Key Pixabay thành công",
     "Select Pixabay API Key to delete": "Chọn API Key Pixabay để xóa",
     "Delete Selected Pixabay API Key": "Xóa API Key Pixabay đã chọn",
-    "Pixabay API Key deleted successfully": "Xóa API Key Pixabay thành công"
+    "Pixabay API Key deleted successfully": "Xóa API Key Pixabay thành công",
+    "Rounded Subtitle Background": "Nền phụ đề bo góc",
+    "Subtitle Background Opacity": "Độ mờ nền phụ đề",
+    "Subtitle Background Corner Radius": "Bán kính góc nền phụ đề",
+    "100% keeps the original opaque background": "100% giữ nền mờ đục ban đầu"
   }
 }

--- a/webui/i18n/zh.json
+++ b/webui/i18n/zh.json
@@ -130,6 +130,10 @@
     "Pixabay API Key added successfully": "Pixabay API Key 添加成功",
     "Select Pixabay API Key to delete": "选择要删除的 Pixabay API Key",
     "Delete Selected Pixabay API Key": "删除选定的 Pixabay API Key",
-    "Pixabay API Key deleted successfully": "Pixabay API Key 删除成功"
+    "Pixabay API Key deleted successfully": "Pixabay API Key 删除成功",
+    "Rounded Subtitle Background": "圆角字幕背景",
+    "Subtitle Background Opacity": "字幕背景不透明度",
+    "Subtitle Background Corner Radius": "字幕背景圆角半径",
+    "100% keeps the original opaque background": "100% 保持原始不透明背景"
   }
 }


### PR DESCRIPTION
This reworks #945 to be fully compatibility-preserving, per the review feedback there. Thanks again for the clear direction.

**Default behavior is unchanged** — subtitles still render a solid, fully opaque rectangle. The rounded/translucent background is strictly opt-in and configurable.

### What changed
- **API** (`app/models/schema.py`): `subtitle_background_rounded` (default `False`), `subtitle_background_opacity` (default `100`), `subtitle_background_radius` (default `20`) on `VideoParams` + `SubtitleRequest`. Defaults reproduce the original output exactly.
- **Rendering** (`app/services/video.py`): the default path keeps the original solid opaque `TextClip`; only when opted in is the text composited over a PIL rounded-rectangle RGBA background with configurable alpha/radius. Pure helpers `hex_to_rgb()` and `build_subtitle_background_rgba()` extracted for testing.
- **WebUI** (`webui/Main.py`): checkbox + opacity slider + corner-radius slider in the subtitle settings.
- **i18n**: 4 new keys across the existing locales.
- **Tests** (`test/services/test_subtitle_background.py`): verify defaults stay opaque and that the opt-in path yields transparent rounded corners + configurable translucency. (6 tests, all passing.)

Maps to the checklist from #945:
- [x] keep the current default rendering unchanged
- [x] explicit WebUI/API option for rounded / translucent background
- [x] configurable opacity / radius with documented defaults
- [x] focused rendering test (alpha/corner frame checks)

Closes #945 conceptually (that PR can't be reopened after a force-push).