### PR TITLE
Harden API auth, network binding, uploads, and Docker defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ FROM python:3.11-slim-bullseye
 # Set the working directory in the container
 WORKDIR /MoneyPrinterTurbo
 
-# 设置/MoneyPrinterTurbo目录权限为777
-RUN chmod 777 /MoneyPrinterTurbo
+# Create a non-root user to run the app (defense in depth). UID/GID 1000 makes
+# bind-mounted volumes easy to share with the typical host user.
+RUN groupadd --gid 1000 appuser && \
+    useradd --uid 1000 --gid 1000 --create-home appuser
 
 ENV PYTHONPATH="/MoneyPrinterTurbo"
 
@@ -55,8 +57,13 @@ RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple/ --trus
     pip install --no-cache-dir -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/ --trusted-host mirrors.tuna.tsinghua.edu.cn --retries 3 --timeout 60 -r requirements.txt || \
     pip install --no-cache-dir --retries 3 --timeout 60 -r requirements.txt
 
-# Now copy the rest of the codebase into the image
-COPY . .
+# Now copy the rest of the codebase into the image, owned by the non-root user
+COPY --chown=appuser:appuser . .
+
+# Drop root privileges for the running container.
+# NOTE: bind-mounted volumes (./storage, ./config.toml) must be writable by
+# UID 1000. If you hit permission errors, run:  chown -R 1000:1000 ./storage
+USER appuser
 
 # Expose the port the app runs on
 EXPOSE 8501

--- a/SECURITY_REVIEW.md
+++ b/SECURITY_REVIEW.md
@@ -1,0 +1,147 @@
+# Security Review — MoneyPrinterTurbo
+
+**Date:** 2026-05-31
+**Scope:** Static review of the local repo (branch `main`, HEAD `8b2e530`). Source-level analysis; no dynamic testing or dependency CVE scan was run.
+
+> **Remediation status (2026-05-31):** Findings #1–#7 have been fixed in the working tree (see "Remediation applied" at the end). The findings below are kept as the original audit record.
+
+## Summary
+
+The codebase shows real, recent security hardening: path-traversal protection (`app/utils/file_security.py`), upload filename sanitization, TLS verification on by default, and the risky `g4f` provider disabled by default. Those are good.
+
+The dominant remaining problem is that **the FastAPI API ships with all authentication disabled**, while the server defaults to binding every network interface. That single gap turns several otherwise-acceptable endpoints (file upload, file download/stream, task deletion, paid LLM calls) into things any host on the network can drive. Most of what follows flows from that.
+
+| # | Severity | Issue |
+|---|----------|-------|
+| 1 | High | API authentication disabled on all routes |
+| 2 | Medium | Server binds `0.0.0.0` by default |
+| 3 | Medium | `/tasks` static mount uses `follow_symlink=True`, bypassing path checks |
+| 4 | Medium | CORS allows all origins with credentials |
+| 5 | Low/Med | Dockerfile: `chmod 777` on app dir, runs as root |
+| 6 | Low | Unbounded in-memory file uploads (DoS) |
+| 7 | Low | Unhandled `Range` header parsing in stream endpoint |
+| 8 | Info | `tls_verify=false` escape hatch; g4f supply-chain risk |
+
+---
+
+## Findings
+
+### 1. API authentication is disabled on every route — High
+
+`app/controllers/v1/video.py:37` and `app/controllers/v1/llm.py:14` both have the auth dependency commented out:
+
+```python
+# router = new_router(dependencies=[Depends(base.verify_token)])
+router = new_router()
+```
+
+A complete `verify_token` implementation exists in `app/controllers/base.py` but is never wired in. As shipped, **every** endpoint is unauthenticated, including:
+
+- `POST /api/v1/videos`, `/subtitle`, `/audio` and `POST /api/v1/scripts`, `/terms` — trigger work that spends the operator's **paid Pexels/Pixabay and LLM API keys**.
+- `POST /api/v1/musics`, `/video_materials` — upload files to the server.
+- `GET /api/v1/download/{path}`, `/stream/{path}` — read generated files.
+- `DELETE /api/v1/tasks/{task_id}` — delete tasks and their output directories (`shutil.rmtree`).
+
+Anyone who can reach the port can run up API bills, fill disk, and delete data.
+
+Also note that even when enabled, `verify_token` compares tokens with `!=` (`base.py`), which is not constant-time, and an empty configured `api_key` would accept an empty token. Use `secrets.compare_digest` and reject empty keys.
+
+**Fix:** uncomment the dependency on both routers, require a non-empty `api_key`, and use a constant-time comparison.
+
+### 2. Server binds `0.0.0.0` by default — Medium
+
+`app/config/config.py:175`:
+
+```python
+listen_host = _cfg.get("listen_host", "0.0.0.0")
+```
+
+Combined with finding #1, the unauthenticated API is exposed on all interfaces — the LAN, and the public internet if the host is reachable. Default to `127.0.0.1` and require an explicit opt-in to bind externally.
+
+### 3. `/tasks` static mount follows symlinks — Medium
+
+`app/asgi.py`:
+
+```python
+app.mount("/tasks", StaticFiles(directory=task_dir, html=True, follow_symlink=True), name="")
+```
+
+The careful `file_security.resolve_path_within_directory` checks guard the `/download` and `/stream` handlers, but this static mount serves the task directory directly and **bypasses them**. `follow_symlink=True` means any symlink that ends up inside `storage/tasks` resolves outside the directory, exposing arbitrary host files over the (unauthenticated) HTTP server. Drop `follow_symlink=True` unless there's a concrete need, and keep file serving behind the validated handlers.
+
+### 4. CORS allows all origins with credentials — Medium
+
+`app/asgi.py`:
+
+```python
+origins = cors_allowed_origins_str.split(",") if cors_allowed_origins_str else ["*"]
+app.add_middleware(CORSMiddleware, allow_origins=origins, allow_credentials=True,
+                   allow_methods=["*"], allow_headers=["*"])
+```
+
+`allow_origins=["*"]` with `allow_credentials=True` is an invalid/permissive combination (browsers reject the wildcard when credentials are sent, but the intent is wrong and breaks the moment a specific origin is configured). Set a concrete allow-list via `CORS_ALLOWED_ORIGINS` and don't default to `*`.
+
+### 5. Dockerfile runs as root with a world-writable app directory — Low/Medium
+
+`Dockerfile`:
+
+```dockerfile
+RUN chmod 777 /MoneyPrinterTurbo
+```
+
+No `USER` directive, so the container runs as root, and the entire app directory is world-writable (`777`) — any process in the container can overwrite application code. It also relaxes the ImageMagick policy (`sed -i '/<policy domain="path".../d'`), widening what ImageMagick will process. Add a non-root `USER`, use tighter permissions (`755`), and keep the ImageMagick path policy unless a specific feature needs it.
+
+### 6. Unbounded in-memory uploads — Low
+
+`upload_bgm_file` / `upload_video_material_file` (`video.py`) do `buffer.write(file.file.read())` — the whole upload is read into memory with no size cap. Unauthenticated (see #1), this is an easy memory/disk exhaustion vector. Enforce a max content length and stream to disk in chunks. (Extension is validated and the filename is sanitized — those parts are fine.)
+
+### 7. Unhandled `Range` parsing in `/stream` — Low
+
+`stream_video` parses the client `Range` header with `int(part)` and no try/except. A malformed header (`Range: bytes=abc-`) raises and returns a 500; crafted values can produce odd seeks/lengths. Validate and clamp `start`/`end` against `video_size` and return `416` on invalid ranges.
+
+### 8. Informational
+
+- `material.py` supports `tls_verify=false`, which disables certificate validation for API calls and downloads. It defaults to `true` and logs a warning — acceptable, but document that it must stay on outside trusted proxies.
+- The `g4f` provider relies on reverse-engineered third-party endpoints (supply-chain/legal risk). It's correctly disabled by default and gated behind `enable_g4f=true` — good.
+- No secrets are committed; `config.toml` is git-ignored and `config.example.toml` ships empty keys. Good.
+- `state.py` uses `ast.literal_eval` (safe), and the ffmpeg call in `video.py` uses an argument list (no `shell=True`) on server-controlled paths — both fine.
+
+---
+
+## Recommended priority
+
+1. Re-enable `verify_token` on both routers; require a non-empty key and constant-time compare (#1).
+2. Default `listen_host` to `127.0.0.1` (#2).
+3. Remove `follow_symlink=True` from the `/tasks` mount (#3).
+4. Tighten CORS defaults (#4).
+5. Harden the Dockerfile and add upload size limits (#5, #6).
+
+Items 1–2 together close the largest exposure and are small changes.
+
+---
+
+## Remediation applied (2026-05-31)
+
+All findings except #8 (informational) were fixed:
+
+- **#1 — Auth enabled.** `app/controllers/base.py:verify_token` now fails closed (rejects all requests when no `api_key` is configured) and uses `secrets.compare_digest` for a constant-time comparison. The dependency is wired into both routers (`app/controllers/v1/video.py`, `app/controllers/v1/llm.py`). Verified with a functional test covering no-key/correct/wrong/missing-header cases.
+- **#2 — Binding.** `listen_host` now defaults to `127.0.0.1` (`app/config/config.py`).
+- **#3 — Symlinks.** `follow_symlink=True` removed from the `/tasks` static mount (`app/asgi.py`).
+- **#4 — CORS.** No longer defaults to `*`; uses concrete localhost origins unless `CORS_ALLOWED_ORIGINS` is set (`app/asgi.py`).
+- **#5 — Docker.** `chmod 777` removed; image now creates and runs as non-root `appuser` (UID 1000) with `COPY --chown` (`Dockerfile`).
+- **#6 — Uploads.** Both upload endpoints stream to disk with a configurable cap (`max_upload_size_mb`, default 512) and return 413 on oversize (`app/controllers/v1/video.py`).
+- **#7 — Range.** `/stream` parses the `Range` header defensively, clamps bounds, and returns 416 on malformed input. Verified with 10 parsing test cases.
+
+### Action required by you
+
+To use the **HTTP API** (port 8080), set a strong key in `config.toml` and send it as the `x-api-key` header:
+
+```toml
+[app]
+api_key = "<paste output of: python -c 'import secrets; print(secrets.token_urlsafe(32))'>"
+```
+
+```bash
+curl -H "x-api-key: YOUR_KEY" http://127.0.0.1:8080/api/v1/musics
+```
+
+The **Streamlit WebUI** (port 8501) is unaffected — it calls the services directly, not the HTTP API. To deliberately expose the API beyond localhost, set `listen_host = "0.0.0.0"` *and* keep `api_key` set, ideally behind a reverse proxy with TLS.

--- a/app/asgi.py
+++ b/app/asgi.py
@@ -52,9 +52,20 @@ def get_application() -> FastAPI:
 
 app = get_application()
 
-# Configures the CORS middleware for the FastAPI app
+# Configures the CORS middleware for the FastAPI app.
+# Never pair a wildcard origin with allow_credentials=True. By default we only
+# trust same-host browser origins; widen via the CORS_ALLOWED_ORIGINS env var
+# (comma-separated list of full origins, e.g. "https://app.example.com").
 cors_allowed_origins_str = os.getenv("CORS_ALLOWED_ORIGINS", "")
-origins = cors_allowed_origins_str.split(",") if cors_allowed_origins_str else ["*"]
+if cors_allowed_origins_str:
+    origins = [o.strip() for o in cors_allowed_origins_str.split(",") if o.strip()]
+else:
+    origins = [
+        "http://localhost:8501",
+        "http://127.0.0.1:8501",
+        f"http://localhost:{config.listen_port}",
+        f"http://127.0.0.1:{config.listen_port}",
+    ]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
@@ -64,8 +75,10 @@ app.add_middleware(
 )
 
 task_dir = utils.task_dir()
+# follow_symlink is intentionally disabled: a symlink placed inside the task
+# directory must not be able to expose files elsewhere on the host.
 app.mount(
-    "/tasks", StaticFiles(directory=task_dir, html=True, follow_symlink=True), name=""
+    "/tasks", StaticFiles(directory=task_dir, html=True), name=""
 )
 
 public_dir = utils.public_dir()

--- a/app/config/config.py
+++ b/app/config/config.py
@@ -172,7 +172,10 @@ ui = _cfg.get(
 hostname = socket.gethostname()
 
 log_level = _cfg.get("log_level", "DEBUG")
-listen_host = _cfg.get("listen_host", "0.0.0.0")
+# Bind to loopback by default so the API is not exposed to the LAN/internet.
+# Only set listen_host = "0.0.0.0" in config.toml after enabling api_key auth
+# and putting the service behind a trusted network or reverse proxy.
+listen_host = _cfg.get("listen_host", "127.0.0.1")
 listen_port = _cfg.get("listen_port", 8080)
 project_name = _cfg.get("project_name", "MoneyPrinterTurbo")
 project_description = _cfg.get(

--- a/app/controllers/base.py
+++ b/app/controllers/base.py
@@ -1,3 +1,4 @@
+import secrets
 from uuid import uuid4
 
 from fastapi import Request
@@ -19,9 +20,25 @@ def get_api_key(request: Request):
 
 
 def verify_token(request: Request):
-    token = get_api_key(request)
-    if token != config.app.get("api_key", ""):
-        request_id = get_task_id(request)
+    # Fail closed: if no api_key is configured, reject all API requests rather
+    # than silently allowing access. Set a non-empty api_key in config.toml
+    # [app] section to enable the HTTP API.
+    configured_key = config.app.get("api_key", "") or ""
+    token = get_api_key(request) or ""
+    request_id = get_task_id(request)
+
+    if not configured_key:
+        raise HttpException(
+            task_id=request_id,
+            status_code=401,
+            message=(
+                "API access is disabled: set a non-empty 'api_key' in the [app] "
+                "section of config.toml and send it in the 'x-api-key' header."
+            ),
+        )
+
+    # Constant-time comparison avoids leaking the key length/contents via timing.
+    if not secrets.compare_digest(token, configured_key):
         request_url = request.url
         user_agent = request.headers.get("user-agent")
         raise HttpException(

--- a/app/controllers/v1/llm.py
+++ b/app/controllers/v1/llm.py
@@ -1,5 +1,6 @@
-from fastapi import Request
+from fastapi import Depends, Request
 
+from app.controllers import base
 from app.controllers.v1.base import new_router
 from app.models.schema import (
     VideoScriptRequest,
@@ -10,9 +11,8 @@ from app.models.schema import (
 from app.services import llm
 from app.utils import utils
 
-# authentication dependency
-# router = new_router(dependencies=[Depends(base.verify_token)])
-router = new_router()
+# authentication dependency: LLM endpoints spend paid API quota, so require auth.
+router = new_router(dependencies=[Depends(base.verify_token)])
 
 
 @router.post(

--- a/app/controllers/v1/video.py
+++ b/app/controllers/v1/video.py
@@ -6,7 +6,7 @@ from typing import Union
 
 from fastapi import BackgroundTasks, Depends, Path, Query, Request, UploadFile
 from fastapi.params import File
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from loguru import logger
 
 from app.config import config
@@ -33,9 +33,8 @@ from app.services import state as sm
 from app.services import task as tm
 from app.utils import file_security, utils
 
-# 认证依赖项
-# router = new_router(dependencies=[Depends(base.verify_token)])
-router = new_router()
+# 认证依赖项：所有 /api/v1 路由都要求通过 x-api-key 校验。
+router = new_router(dependencies=[Depends(base.verify_token)])
 
 _enable_redis = config.app.get("enable_redis", False)
 _redis_host = config.app.get("redis_host", "localhost")
@@ -71,6 +70,37 @@ def _sanitize_upload_filename(filename: str, request_id: str) -> str:
             message=f"{request_id}: invalid filename",
         )
     return normalized_name
+
+
+def _save_upload_within_limit(file: UploadFile, save_path: str, request_id: str) -> None:
+    # Stream the upload to disk in chunks and abort if it exceeds the limit, so
+    # a single (or many) large uploads cannot exhaust memory or fill the disk.
+    max_bytes = int(config.app.get("max_upload_size_mb", 512)) * 1024 * 1024
+    written = 0
+    file.file.seek(0)
+    try:
+        with open(save_path, "wb+") as buffer:
+            while True:
+                chunk = file.file.read(1024 * 1024)
+                if not chunk:
+                    break
+                written += len(chunk)
+                if written > max_bytes:
+                    raise HttpException(
+                        task_id=request_id,
+                        status_code=413,
+                        message=f"{request_id}: uploaded file exceeds the "
+                        f"{max_bytes // (1024 * 1024)} MB limit",
+                    )
+                buffer.write(chunk)
+    except HttpException:
+        # Remove the partially written file before re-raising.
+        if os.path.exists(save_path):
+            try:
+                os.remove(save_path)
+            except OSError:
+                pass
+        raise
 
 
 def _resolve_path_within_directory(base_dir: str, unsafe_path: str, request_id: str) -> str:
@@ -267,11 +297,8 @@ def upload_bgm_file(request: Request, file: UploadFile = File(...)):
     if safe_filename.lower().endswith("mp3"):
         song_dir = utils.song_dir()
         save_path = os.path.join(song_dir, safe_filename)
-        # save file
-        with open(save_path, "wb+") as buffer:
-            # If the file already exists, it will be overwritten
-            file.file.seek(0)
-            buffer.write(file.file.read())
+        # save file (size-limited, streamed to disk; existing file is overwritten)
+        _save_upload_within_limit(file, save_path, request_id)
         response = {"file": safe_filename}
         return utils.get_response(200, response)
 
@@ -322,11 +349,8 @@ def upload_video_material_file(request: Request, file: UploadFile = File(...)):
     if normalized_filename.endswith(allowed_suffixes):
         local_videos_dir = utils.storage_dir("local_videos", create=True)
         save_path = os.path.join(local_videos_dir, safe_filename)
-        # save file
-        with open(save_path, "wb+") as buffer:
-            # If the file already exists, it will be overwritten
-            file.file.seek(0)
-            buffer.write(file.file.read())
+        # save file (size-limited, streamed to disk; existing file is overwritten)
+        _save_upload_within_limit(file, save_path, request_id)
         response = {"file": safe_filename}
         return utils.get_response(200, response)
 
@@ -345,14 +369,36 @@ async def stream_video(request: Request, file_path: str):
 
     length = video_size
     if range_header:
-        range_ = range_header.split("bytes=")[1]
-        start, end = [int(part) if part else None for part in range_.split("-")]
-        if start is None:
-            start = video_size - end
-            end = video_size - 1
-        if end is None:
-            end = video_size - 1
-        length = end - start + 1
+        # The Range header is attacker-controlled; parse defensively and reject
+        # malformed/out-of-bounds ranges with 416 instead of raising a 500.
+        try:
+            if "bytes=" not in range_header:
+                raise ValueError("unsupported range unit")
+            range_ = range_header.split("bytes=")[1].split(",")[0]
+            raw_start, raw_end = range_.split("-")
+            start = int(raw_start) if raw_start else None
+            end = int(raw_end) if raw_end else None
+
+            if start is None:
+                # suffix range: last `end` bytes
+                if end is None or end <= 0:
+                    raise ValueError("invalid suffix range")
+                start = max(0, video_size - end)
+                end = video_size - 1
+            else:
+                if end is None:
+                    end = video_size - 1
+
+            if start < 0 or end < start or start >= video_size:
+                raise ValueError("range out of bounds")
+            end = min(end, video_size - 1)
+            length = end - start + 1
+        except (ValueError, IndexError):
+            return JSONResponse(
+                status_code=416,
+                content=utils.get_response(416, message="invalid Range header"),
+                headers={"Content-Range": f"bytes */{video_size}"},
+            )
 
     def file_iterator(file_path, offset=0, bytes_to_read=None):
         with open(file_path, "rb") as f:

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,6 +1,15 @@
 [app]
 video_source = "pexels" # "pexels" or "pixabay"
 
+# HTTP API authentication key (REQUIRED to use the FastAPI endpoints).
+# All /api/v1 routes require this value to be sent in the "x-api-key" header.
+# If left empty, the API rejects every request (fail closed). Generate a long
+# random value, e.g.  python -c "import secrets; print(secrets.token_urlsafe(32))"
+api_key = ""
+
+# Maximum size (in MB) accepted by the BGM / video material upload endpoints.
+max_upload_size_mb = 512
+
 # 是否隐藏配置面板
 hide_config = false
 


### PR DESCRIPTION
- Enable verify_token on /api/v1/video and /api/v1/llm routers; fail-closed when api_key is unset, constant-time compare via secrets.compare_digest.
- Default listen_host to 127.0.0.1 so the API is not exposed on all interfaces by default.
- Drop follow_symlink=True from the /tasks static mount; rely on resolve_path_within_directory in /download and /stream.
- Tighten CORS: no wildcard default; opt in via CORS_ALLOWED_ORIGINS.
- Dockerfile: drop chmod 777, run as non-root appuser (UID 1000), COPY --chown.
- Uploads: stream to disk in chunks with max_upload_size_mb cap (default 512), return 413 on oversize.
- /stream: parse Range header defensively, clamp bounds, return 416 on malformed input.

See SECURITY_REVIEW.md for the original audit and per-finding details.