### PR TITLE
fix: use Optional[list] type annotation in upload_post.py

### DIFF
--- a/app/services/upload_post.py
+++ b/app/services/upload_post.py
@@ -4,6 +4,8 @@ Upload-Post API integration for cross-posting videos to TikTok and Instagram.
 Docs: https://docs.upload-post.com
 """
 import os
+from typing import Optional
+
 import requests
 from loguru import logger
 from app.config import config
@@ -31,7 +33,7 @@ class UploadPostService:
         self,
         video_path: str,
         title: str,
-        platforms: list = None,
+        platforms: Optional[list] = None,
         privacy_level: str = "PUBLIC_TO_EVERYONE"
     ) -> dict:
         """
@@ -132,7 +134,7 @@ class UploadPostService:
 upload_post_service = UploadPostService()
 
 
-def cross_post_video(video_path: str, title: str, platforms: list = None) -> dict:
+def cross_post_video(video_path: str, title: str, platforms: Optional[list] = None) -> dict:
     """
     Convenience function to cross-post a video.
     


### PR DESCRIPTION
## Description

Fix incorrect type annotations in `app/services/upload_post.py` where `platforms: list = None` should be `platforms: Optional[list] = None`.

### Changes

1. Added `from typing import Optional` import
2. Changed `platforms: list = None` to `platforms: Optional[list] = None` in:
   - `UploadPostService.upload_video()` method (line 34)
   - `cross_post_video()` convenience function (line 135)

### Why

When a parameter has a default value of `None`, the type annotation should use `Optional[T]` (or `T | None` in Python 3.10+) to correctly indicate that the value can be `None`. Using just `list` suggests the parameter only accepts list values, which is misleading.

Closes #959