### PR TITLE
feat(minimax): upgrade default model to MiniMax-M3

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -134,10 +134,10 @@ qwen_model_name = "qwen-max"
 ########## MiniMax API Key
 # Visit https://platform.minimax.io to get your API key
 # MiniMax API is OpenAI-compatible
-# Available models: MiniMax-M2.7 (default), MiniMax-M2.7-highspeed
+# Available models: MiniMax-M3 (default), MiniMax-M2.7, MiniMax-M2.7-highspeed
 minimax_api_key = ""
 minimax_base_url = "https://api.minimax.io/v1"
-minimax_model_name = "MiniMax-M2.7"
+minimax_model_name = "MiniMax-M3"
 
 ########## Xiaomi MiMo API Key
 # Xiaomi MiMo API is OpenAI-compatible.


### PR DESCRIPTION
## Summary

Bump the minimax default model from `MiniMax-M2.7` to the newly released `MiniMax-M3` in `config.example.toml`. M2.7 and M2.7-highspeed remain selectable so existing users can pin the older model if they want to.

## Changes

- `config.example.toml`: change `minimax_model_name` default to `MiniMax-M3`, update the Available models comment.

No code changes in `app/services/llm.py` — the minimax branch already reads `minimax_model_name` from config and talks to the OpenAI-compatible endpoint at `https://api.minimax.io/v1`, so the new model works out of the box.

## Test plan

- [x] TOML still parses
- [x] No tests reference the model name
- [ ] Local smoke test: set `minimax_api_key` + run a video task with the new default