### PR TITLE
[codex] fix qwen chat response parsing

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -295,8 +295,13 @@ def _generate_response(prompt: str) -> str:
                                 f'[{llm_provider}] returned an error response: "{response}"'
                             )
 
-                        content = response["output"]["text"]
-                        return content.replace("\n", "")
+                        output = response["output"]
+                        choices = output.get("choices", [])
+                        if choices:
+                            content = choices[0]["message"]["content"]
+                        else:
+                            content = output.get("text")
+                        return _normalize_text_response(content, llm_provider)
                     else:
                         raise Exception(
                             f'[{llm_provider}] returned an invalid response: "{response}"'

--- a/test/services/test_llm.py
+++ b/test/services/test_llm.py
@@ -473,6 +473,49 @@ class TestLiteLLMProvider(unittest.TestCase):
         self.assertIn("g4f package is not installed by default", result)
 
 
+class TestQwenProvider(unittest.TestCase):
+    def setUp(self):
+        self.original_app_config = dict(config.app)
+        config.app["llm_provider"] = "qwen"
+        config.app["qwen_api_key"] = "qwen-key"
+        config.app["qwen_model_name"] = "qwen-max"
+
+    def tearDown(self):
+        config.app.clear()
+        config.app.update(self.original_app_config)
+
+    def test_qwen_provider_reads_chat_message_content(self):
+        class FakeGenerationResponse(dict):
+            def __init__(self):
+                super().__init__(
+                    output={
+                        "choices": [
+                            {"message": {"role": "assistant", "content": "hello\nqwen"}}
+                        ]
+                    }
+                )
+                self.status_code = 200
+
+        fake_dashscope = types.SimpleNamespace(
+            api_key="",
+            Generation=types.SimpleNamespace(call=lambda **kwargs: FakeGenerationResponse()),
+        )
+        fake_response_module = types.SimpleNamespace(
+            GenerationResponse=FakeGenerationResponse
+        )
+
+        with patch.dict(
+            sys.modules,
+            {
+                "dashscope": fake_dashscope,
+                "dashscope.api_entities": types.SimpleNamespace(),
+                "dashscope.api_entities.dashscope_response": fake_response_module,
+            },
+        ):
+            result = llm._generate_response("Say hello")
+
+        self.assertEqual(result, "helloqwen")
+
 class TestRuntimeEnvironmentDetection(unittest.TestCase):
     def test_container_detection_ignores_plain_linux_cgroup_file(self):
         """


### PR DESCRIPTION
## Summary

Fix Qwen script and keyword generation when DashScope returns the chat response shape used by `Generation.call(..., messages=[...])`.

Closes #966

## Root cause

The Qwen provider sends a `messages` request but reads `response["output"]["text"]`. For chat responses, DashScope returns generated text in `output.choices[0].message.content`. `output.text` can be `None`, causing:

```text
Error: 'NoneType' object has no attribute 'replace'
```

## Changes

- Read `output.choices[0].message.content` when chat choices are present.
- Preserve `output.text` as a backward-compatible fallback.
- Route Qwen output through `_normalize_text_response()` for consistent empty-response validation.
- Add a regression test for the DashScope chat response shape.

## Validation

```text
docker compose exec -T webui python -m unittest test.services.test_llm -v
Ran 27 tests in 1.350s
OK (skipped=1)
```

The skipped test is the existing credential-gated `ANTHROPIC_FOUNDRY_API_KEY` live integration test.

## Evidence

Sanitized logs and screenshot are attached to #966:
https://github.com/harry0703/MoneyPrinterTurbo/issues/966#issuecomment-4593194192
