### PR TITLE
feat: Vietnamese social caption & hashtag generator for short-video platforms

### DIFF
--- a/app/controllers/v1/llm.py
+++ b/app/controllers/v1/llm.py
@@ -4,6 +4,8 @@ from app.controllers.v1.base import new_router
 from app.models.schema import (
     VideoScriptRequest,
     VideoScriptResponse,
+    VideoSocialMetadataRequest,
+    VideoSocialMetadataResponse,
     VideoTermsRequest,
     VideoTermsResponse,
 )
@@ -45,3 +47,20 @@ def generate_video_terms(request: Request, body: VideoTermsRequest):
     )
     response = {"video_terms": video_terms}
     return utils.get_response(200, response)
+
+
+@router.post(
+    "/social-metadata",
+    response_model=VideoSocialMetadataResponse,
+    summary="Generate social publishing metadata (title, caption, hashtags)",
+)
+def generate_video_social_metadata(
+    request: Request, body: VideoSocialMetadataRequest
+):
+    metadata = llm.generate_social_metadata(
+        video_subject=body.video_subject,
+        video_script=body.video_script,
+        language=body.language,
+        platform=body.platform,
+    )
+    return utils.get_response(200, metadata)

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -178,6 +178,24 @@ class VideoTermsParams:
     amount: Optional[int] = 5
 
 
+
+class VideoSocialMetadataParams:
+    """
+    Parameters for generating social-publishing metadata (title, caption,
+    hashtags) for short-video platforms popular in Vietnam.
+    {
+      "video_subject": "",
+      "video_script": "",
+      "language": "vi",
+      "platform": "tiktok"
+    }
+    """
+
+    video_subject: Optional[str] = "Khám phá Việt Nam"
+    video_script: Optional[str] = ""
+    language: Optional[str] = "vi"
+    platform: Optional[str] = "tiktok"
+
 class BaseResponse(BaseModel):
     status: int = 200
     message: Optional[str] = "success"
@@ -197,6 +215,10 @@ class VideoScriptRequest(VideoScriptParams, BaseModel):
 
 
 class VideoTermsRequest(VideoTermsParams, BaseModel):
+    pass
+
+
+class VideoSocialMetadataRequest(VideoSocialMetadataParams, BaseModel):
     pass
 
 
@@ -280,6 +302,21 @@ class VideoTermsResponse(BaseResponse):
                 "status": 200,
                 "message": "success",
                 "data": {"video_terms": ["sky", "tree"]},
+            },
+        }
+
+
+class VideoSocialMetadataResponse(BaseResponse):
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "status": 200,
+                "message": "success",
+                "data": {
+                    "title": "5 mẹo du lịch Việt Nam bạn nhất định phải biết!",
+                    "caption": "Bỏ túi ngay 5 mẹo này trước chuyến đi nhé! Lưu lại và theo dõi để xem thêm.",
+                    "hashtags": ["#dulich", "#vietnam", "#xuhuong", "#fyp", "#review"],
+                },
             },
         }
 

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -710,6 +710,222 @@ Please note that you must use English for generating video search terms; Chinese
     return search_terms
 
 
+# =============================================================================
+# Social publishing metadata (Vietnamese-first)
+#
+# Turns a generated script into ready-to-publish metadata (title, caption,
+# hashtags) tuned for the short-video platforms popular in Vietnam such as
+# TikTok, YouTube Shorts, Instagram Reels and Facebook Reels. Defaults to
+# Vietnamese so VN creators get natural, platform-appropriate copy out of the
+# box, but any language can be requested.
+# =============================================================================
+
+# Per-platform limits. `title_max`/`caption_max` are conservative character
+# budgets; `hashtag_count` is how many tags to request.
+SOCIAL_PLATFORMS = {
+    "tiktok": {"title_max": 100, "caption_max": 2200, "hashtag_count": 5},
+    "youtube_shorts": {"title_max": 100, "caption_max": 5000, "hashtag_count": 3},
+    "instagram_reels": {"title_max": 125, "caption_max": 2200, "hashtag_count": 8},
+    "facebook_reels": {"title_max": 125, "caption_max": 2200, "hashtag_count": 5},
+}
+DEFAULT_SOCIAL_PLATFORM = "tiktok"
+DEFAULT_SOCIAL_LANGUAGE = "vi"
+
+SOCIAL_PLATFORM_LABELS = {
+    "tiktok": "TikTok",
+    "youtube_shorts": "YouTube Shorts",
+    "instagram_reels": "Instagram Reels",
+    "facebook_reels": "Facebook Reels",
+}
+
+# Sensible Vietnamese defaults used only when the LLM is unavailable so the
+# feature still returns something usable instead of failing the whole task.
+_DEFAULT_VI_HASHTAGS = [
+    "#xuhuong",
+    "#fyp",
+    "#viral",
+    "#trending",
+    "#vietnam",
+    "#reels",
+    "#tiktok",
+    "#viralvideo",
+]
+
+
+def _resolve_social_platform(platform: str | None) -> str:
+    value = (platform or "").strip().lower()
+    return value if value in SOCIAL_PLATFORMS else DEFAULT_SOCIAL_PLATFORM
+
+
+def _clamp_text(text, max_length: int) -> str:
+    value = ("" if text is None else str(text)).strip()
+    if max_length and len(value) > max_length:
+        return value[:max_length].rstrip()
+    return value
+
+
+def _normalize_hashtags(raw, count: int) -> List[str]:
+    """Normalize arbitrary LLM hashtag output into clean ``#tag`` strings.
+
+    Accepts either a list or a free-form string, removes spaces/punctuation
+    inside a tag (Vietnamese letters are preserved), de-duplicates
+    case-insensitively, and clamps the result to ``count`` tags.
+    """
+    if isinstance(raw, str):
+        # A free-form string may contain several space/comma separated tags.
+        candidates = re.split(r"[\s,]+", raw)
+    elif isinstance(raw, (list, tuple)):
+        # A JSON array already delimits tags: treat each entry as one tag so a
+        # multi-word entry like "du lich" becomes "#dulich" rather than two tags.
+        candidates = [str(entry) for entry in raw]
+    else:
+        candidates = []
+
+    seen = set()
+    result: List[str] = []
+    for item in candidates:
+        # Keep unicode word characters (Vietnamese letters included); this also
+        # strips a leading '#', spaces, and punctuation.
+        tag = re.sub(r"[^\w]", "", item, flags=re.UNICODE)
+        if not tag:
+            continue
+        key = tag.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(f"#{tag}")
+        if count and len(result) >= count:
+            break
+    return result
+
+
+def build_social_metadata_prompt(
+    video_subject: str,
+    video_script: str = "",
+    language: str = DEFAULT_SOCIAL_LANGUAGE,
+    platform: str = DEFAULT_SOCIAL_PLATFORM,
+) -> str:
+    platform = _resolve_social_platform(platform)
+    spec = SOCIAL_PLATFORMS[platform]
+    label = SOCIAL_PLATFORM_LABELS.get(platform, platform)
+    language = (language or DEFAULT_SOCIAL_LANGUAGE).strip() or DEFAULT_SOCIAL_LANGUAGE
+
+    prompt = f"""
+# Role: Short-Video Social Media Copywriter
+
+## Goal
+Write engaging publishing metadata for a short video that will be posted on {label}.
+
+## Constraints
+1. Respond ONLY with a single valid minified JSON object. No markdown, no code fences, no commentary.
+2. The JSON must contain exactly these keys: "title", "caption", "hashtags".
+3. "title": a catchy hook, at most {spec['title_max']} characters.
+4. "caption": an engaging description that ends with a call to action, at most {spec['caption_max']} characters. Do not put hashtags inside the caption.
+5. "hashtags": a JSON array of exactly {spec['hashtag_count']} strings. Each must start with '#', contain no spaces, and be relevant to the topic and to {label}.
+6. Write "title" and "caption" in this language: {language}. For Vietnamese, use natural, modern, social-media style wording (it is fine to use diacritic-free hashtags, which are common on Vietnamese social media).
+
+## Output Example
+{{"title": "...", "caption": "...", "hashtags": ["#example", "#video"]}}
+
+## Context
+### Video Subject
+{video_subject}
+
+### Video Script
+{video_script}
+""".strip()
+    return prompt
+
+
+def _parse_social_metadata(response: str, platform: str) -> dict:
+    spec = SOCIAL_PLATFORMS[_resolve_social_platform(platform)]
+
+    data = None
+    try:
+        data = json.loads(response)
+    except Exception:
+        # LLMs sometimes wrap JSON in prose or code fences; recover the object.
+        match = re.search(r"\{.*\}", response or "", re.DOTALL)
+        if match:
+            data = json.loads(match.group())
+
+    if not isinstance(data, dict):
+        raise ValueError("social metadata response is not a JSON object")
+
+    title = _clamp_text(data.get("title", ""), spec["title_max"])
+    caption = _clamp_text(data.get("caption", ""), spec["caption_max"])
+    hashtags = _normalize_hashtags(data.get("hashtags", []), spec["hashtag_count"])
+
+    if not title and not caption:
+        raise ValueError("social metadata response is missing both title and caption")
+
+    return {"title": title, "caption": caption, "hashtags": hashtags}
+
+
+def _fallback_social_metadata(
+    video_subject: str, video_script: str, platform: str
+) -> dict:
+    spec = SOCIAL_PLATFORMS[_resolve_social_platform(platform)]
+    subject = (video_subject or "").strip()
+    script = (video_script or "").strip()
+
+    title = subject
+    if not title and script:
+        # Use the first sentence of the script as a last-resort title.
+        title = re.split(r"(?<=[.!?。！？])\s+", script)[0]
+
+    return {
+        "title": _clamp_text(title, spec["title_max"]),
+        "caption": _clamp_text(script or subject, spec["caption_max"]),
+        "hashtags": _normalize_hashtags(_DEFAULT_VI_HASHTAGS, spec["hashtag_count"]),
+    }
+
+
+def generate_social_metadata(
+    video_subject: str,
+    video_script: str = "",
+    language: str = DEFAULT_SOCIAL_LANGUAGE,
+    platform: str = DEFAULT_SOCIAL_PLATFORM,
+) -> dict:
+    """Generate social publishing metadata (title, caption, hashtags).
+
+    Returns a dict ``{"title": str, "caption": str, "hashtags": List[str]}``.
+    Falls back to a Vietnamese heuristic if the LLM is unavailable so callers
+    always receive a usable result.
+    """
+    platform = _resolve_social_platform(platform)
+    prompt = build_social_metadata_prompt(
+        video_subject=video_subject,
+        video_script=video_script,
+        language=language,
+        platform=platform,
+    )
+    logger.info(
+        f"generating social metadata: platform={platform}, language={language}"
+    )
+
+    response = ""
+    for i in range(_max_retries):
+        try:
+            response = _generate_response(prompt)
+            if isinstance(response, str) and "Error: " in response:
+                logger.error(f"failed to generate social metadata: {response}")
+                break
+            metadata = _parse_social_metadata(response, platform)
+            logger.success(f"completed: \n{metadata}")
+            return metadata
+        except Exception as e:
+            logger.warning(f"failed to parse social metadata: {str(e)}")
+
+        if i < _max_retries:
+            logger.warning(
+                f"failed to generate social metadata, trying again... {i + 1}"
+            )
+
+    logger.warning("falling back to heuristic Vietnamese social metadata")
+    return _fallback_social_metadata(video_subject, video_script, platform)
+
+
 if __name__ == "__main__":
     video_subject = "生命的意义是什么"
     script = generate_script(

--- a/test/services/test_llm.py
+++ b/test/services/test_llm.py
@@ -11,7 +11,7 @@ from pydantic import ValidationError
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from app.config import config
-from app.models.schema import VideoScriptRequest
+from app.models.schema import VideoScriptRequest, VideoSocialMetadataRequest
 from app.services import llm
 
 
@@ -516,6 +516,118 @@ class TestRuntimeEnvironmentDetection(unittest.TestCase):
             )
 
             self.assertEqual(config.get_container_default_gateway_ip(str(route_path)), "")
+
+
+
+class TestSocialMetadata(unittest.TestCase):
+    """Vietnamese-first social publishing metadata (title/caption/hashtags)."""
+
+    def test_build_prompt_includes_platform_language_and_limits(self):
+        prompt = llm.build_social_metadata_prompt(
+            video_subject="Du lịch Đà Nẵng",
+            video_script="Đà Nẵng có biển đẹp và đồ ăn ngon.",
+            language="vi",
+            platform="tiktok",
+        )
+        self.assertIn("TikTok", prompt)
+        self.assertIn("language: vi", prompt)
+        self.assertIn("Du lịch Đà Nẵng", prompt)
+        self.assertIn("Đà Nẵng có biển đẹp", prompt)
+        # tiktok requests 5 hashtags
+        self.assertIn("array of exactly 5 strings", prompt)
+
+    def test_unknown_platform_falls_back_to_default(self):
+        prompt = llm.build_social_metadata_prompt(
+            video_subject="x", platform="zalo-unsupported"
+        )
+        # Default platform is TikTok
+        self.assertIn("TikTok", prompt)
+
+    def test_normalize_hashtags_from_string_dedupes_and_clamps(self):
+        tags = llm._normalize_hashtags("#fyp fyp, xuhuong #Xuhuong viral", count=2)
+        self.assertEqual(tags, ["#fyp", "#xuhuong"])
+
+    def test_normalize_hashtags_from_list_keeps_vietnamese_and_strips_spaces(self):
+        tags = llm._normalize_hashtags(
+            ["du lich", "#việt nam", "  ", "@bad!chars"], count=5
+        )
+        # internal spaces removed, leading # stripped/re-added, punctuation dropped
+        self.assertEqual(tags, ["#dulich", "#việtnam", "#badchars"])
+
+    def test_clamp_text_truncates(self):
+        self.assertEqual(llm._clamp_text("abcdefgh", 4), "abcd")
+        self.assertEqual(llm._clamp_text("  hi  ", 100), "hi")
+        self.assertEqual(llm._clamp_text(None, 10), "")
+
+    def test_parse_social_metadata_parses_clean_json(self):
+        raw = (
+            '{"title": "Tiêu đề", "caption": "Mô tả hấp dẫn", '
+            '"hashtags": ["#fyp", "#xuhuong", "#viral", "#a", "#b", "#c"]}'
+        )
+        result = llm._parse_social_metadata(raw, "tiktok")
+        self.assertEqual(result["title"], "Tiêu đề")
+        self.assertEqual(result["caption"], "Mô tả hấp dẫn")
+        # clamped to tiktok's 5 hashtags
+        self.assertEqual(len(result["hashtags"]), 5)
+
+    def test_parse_social_metadata_recovers_embedded_json(self):
+        raw = 'Sure! Here you go: {"title": "T", "caption": "C", "hashtags": ["#x"]} thanks'
+        result = llm._parse_social_metadata(raw, "tiktok")
+        self.assertEqual(result["title"], "T")
+        self.assertEqual(result["hashtags"], ["#x"])
+
+    def test_parse_social_metadata_rejects_non_object(self):
+        with self.assertRaises(ValueError):
+            llm._parse_social_metadata("[1, 2, 3]", "tiktok")
+
+    def test_parse_social_metadata_requires_title_or_caption(self):
+        with self.assertRaises(ValueError):
+            llm._parse_social_metadata('{"hashtags": ["#x"]}', "tiktok")
+
+    def test_generate_social_metadata_uses_llm_response(self):
+        payload = (
+            '{"title": "5 mẹo hay", "caption": "Lưu lại ngay nhé!", '
+            '"hashtags": ["#meovat", "#xuhuong", "#fyp"]}'
+        )
+        with patch.object(llm, "_generate_response", return_value=payload):
+            result = llm.generate_social_metadata(
+                video_subject="Mẹo vặt", video_script="...", platform="tiktok"
+            )
+        self.assertEqual(result["title"], "5 mẹo hay")
+        self.assertEqual(result["caption"], "Lưu lại ngay nhé!")
+        self.assertEqual(result["hashtags"], ["#meovat", "#xuhuong", "#fyp"])
+
+    def test_generate_social_metadata_falls_back_on_llm_error(self):
+        with patch.object(
+            llm, "_generate_response", return_value="Error: api_key is not set"
+        ):
+            result = llm.generate_social_metadata(
+                video_subject="Phở Hà Nội",
+                video_script="Phở là món ăn nổi tiếng.",
+                platform="tiktok",
+            )
+        # Fallback derives a usable title and Vietnamese default hashtags.
+        self.assertEqual(result["title"], "Phở Hà Nội")
+        self.assertIn("Phở", result["caption"])
+        self.assertEqual(len(result["hashtags"]), 5)
+        self.assertTrue(all(t.startswith("#") for t in result["hashtags"]))
+
+    def test_generate_social_metadata_falls_back_on_invalid_json(self):
+        with patch.object(
+            llm, "_generate_response", return_value="not json at all"
+        ):
+            result = llm.generate_social_metadata(
+                video_subject="Cà phê sữa đá", platform="instagram_reels"
+            )
+        self.assertEqual(result["title"], "Cà phê sữa đá")
+        # instagram_reels requests 8 hashtags
+        self.assertEqual(len(result["hashtags"]), 8)
+
+    def test_request_model_defaults_to_vietnamese_tiktok(self):
+        body = VideoSocialMetadataRequest(video_subject="Test")
+        self.assertEqual(body.language, "vi")
+        self.assertEqual(body.platform, "tiktok")
+
 
 
 FOUNDRY_KEY = os.environ.get("ANTHROPIC_FOUNDRY_API_KEY", "")


### PR DESCRIPTION
## Summary
Adds a Vietnamese-first **social publishing metadata generator**: given a video subject/script, it produces a platform-tuned **title, caption, and hashtags** for the short-video platforms popular in Vietnam (TikTok, YouTube Shorts, Instagram Reels, Facebook Reels). This complements the existing `Upload-Post` cross-posting by giving creators ready-to-publish copy, defaulting to Vietnamese so VN creators get natural wording out of the box.

## What's included
- `app/services/llm.py`: `generate_social_metadata(video_subject, video_script, language="vi", platform="tiktok")` plus helpers — per-platform limits (`SOCIAL_PLATFORMS`), prompt builder, robust JSON parsing (recovers JSON embedded in prose), hashtag normalization (de-dupes, strips spaces/punctuation, preserves Vietnamese letters, clamps per platform), and a graceful Vietnamese heuristic fallback when no LLM is configured.
- `app/models/schema.py`: `VideoSocialMetadataParams` / `Request` / `Response` (defaults: `language="vi"`, `platform="tiktok"`).
- `app/controllers/v1/llm.py`: new `POST /social-metadata` endpoint, mirroring the existing `/scripts` and `/terms` endpoints.
- `test/services/test_llm.py`: 13 unit tests covering prompt building, hashtag normalization, JSON parsing/recovery, validation errors, fallback behavior, and request-model defaults.

## Behavior notes
- Reuses the existing `_generate_response` LLM plumbing, so it works with every configured provider.
- Returns `{"title": str, "caption": str, "hashtags": [str, ...]}`.
- Never hard-fails: on LLM error or unparseable output it falls back to a usable Vietnamese result (title from the subject, sensible default VN hashtags).
- No changes to existing behavior; purely additive.

## Example request
```json
POST /api/v1/social-metadata
{"video_subject": "Du lịch Đà Nẵng", "video_script": "...", "language": "vi", "platform": "tiktok"}
```

## Testing
`python -m unittest test.services.test_llm` — all tests pass locally (the one skipped test is the pre-existing live-LLM integration that requires an API key).

This is a follow-up to the Vietnamese UI translation work; happy to adjust platform limits, default hashtags, or wire it into the WebUI if you'd like.