### PR TITLE
feat: add pluggable render backend

### DIFF
--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -79,6 +79,7 @@ class VideoParams(BaseModel):
     video_clip_duration: Optional[int] = 5
     video_count: Optional[int] = 1
 
+    render_backend: Optional[str] = "local"
     video_source: Optional[str] = "pexels"
     video_materials: Optional[List[MaterialInfo]] = (
         None  # Materials used to generate the video

--- a/app/services/material.py
+++ b/app/services/material.py
@@ -225,6 +225,23 @@ def save_video(video_url: str, save_dir: str = "") -> str:
     return ""
 
 
+class SourcedPath(str):
+    """A clip path that also remembers the URL it came from.
+
+    It IS a str, so it behaves like the path everywhere downstream. An optional
+    render backend can read `.source_url` to fetch the clip from its origin
+    instead of re-uploading it.
+    """
+
+    source_url: str = ""
+
+
+def _sourced(path: str, url: str) -> "SourcedPath":
+    sp = SourcedPath(path)
+    sp.source_url = url
+    return sp
+
+
 def download_videos(
     task_id: str,
     search_terms: List[str],
@@ -271,22 +288,30 @@ def download_videos(
         random.shuffle(valid_video_items)
 
     total_duration = 0.0
+    # A render backend can fetch the clips by URL directly, so there is no need to
+    # download (and later re-upload) them. We still select enough clips to cover
+    # the audio, using the duration the provider already reported.
+    skip_local_download = config.app.get("render_backend") == "rendobar"
     for item in valid_video_items:
         try:
-            logger.info(f"downloading video: {item.url}")
-            saved_video_path = save_video(
-                video_url=item.url, save_dir=material_directory
-            )
-            if saved_video_path:
+            if skip_local_download:
+                video_paths.append(_sourced(item.url, item.url))
+            else:
+                logger.info(f"downloading video: {item.url}")
+                saved_video_path = save_video(
+                    video_url=item.url, save_dir=material_directory
+                )
+                if not saved_video_path:
+                    continue
                 logger.info(f"video saved: {saved_video_path}")
-                video_paths.append(saved_video_path)
-                seconds = min(max_clip_duration, item.duration)
-                total_duration += seconds
-                if total_duration > audio_duration:
-                    logger.info(
-                        f"total duration of downloaded videos: {total_duration} seconds, skip downloading more"
-                    )
-                    break
+                video_paths.append(_sourced(saved_video_path, item.url))
+            seconds = min(max_clip_duration, item.duration or max_clip_duration)
+            total_duration += seconds
+            if total_duration > audio_duration:
+                logger.info(
+                    f"selected videos cover {total_duration} seconds, enough for the audio"
+                )
+                break
         except Exception as e:
             logger.error(f"failed to download video: {utils.to_json(item)} => {str(e)}")
     logger.success(f"downloaded {len(video_paths)} videos")

--- a/app/services/render/__init__.py
+++ b/app/services/render/__init__.py
@@ -1,0 +1,55 @@
+"""Render backends.
+
+`local` is the default and unchanged. `rendobar` is an opt-in cloud backend. The
+dispatcher below picks the selected backend, checks it can serve the job, and
+always falls back to Local on ineligibility or error so a render never fails just
+because an optional backend had a problem.
+
+Add your own backend: implement RenderBackend (see base.py) and register it in
+BACKENDS.
+"""
+
+from loguru import logger
+
+from app.services.render.base import RenderBackend, RenderContext
+from app.services.render.local import LocalRenderBackend
+from app.services.render.rendobar import RendobarRenderBackend, rendobar_eligible
+
+BACKENDS = {
+    "local": LocalRenderBackend,
+    "rendobar": RendobarRenderBackend,
+}
+
+__all__ = [
+    "RenderBackend",
+    "RenderContext",
+    "BACKENDS",
+    "get_render_backend",
+    "render_with_fallback",
+]
+
+
+def get_render_backend(name: str) -> RenderBackend:
+    return BACKENDS.get(name or "local", LocalRenderBackend)()
+
+
+def render_with_fallback(ctx: RenderContext) -> None:
+    """Render with the selected backend, falling back to Local when needed."""
+    name = (getattr(ctx.params, "render_backend", "local") or "local").lower()
+
+    if name == "rendobar" and not rendobar_eligible(ctx.params):
+        logger.warning(
+            "Rendobar backend not eligible (no API key set). Using local render."
+        )
+        name = "local"
+
+    if name == "local":
+        LocalRenderBackend().render(ctx)
+        return
+
+    try:
+        get_render_backend(name).render(ctx)
+    except Exception as e:
+        # Any backend failure must not break the run, fall back to local.
+        logger.error(f"{name} render failed ({e}), falling back to local render")
+        LocalRenderBackend().render(ctx)

--- a/app/services/render/base.py
+++ b/app/services/render/base.py
@@ -1,0 +1,42 @@
+"""Render backend interface.
+
+Lets the render step (combine clips, mix audio, burn captions, encode) run in
+different places without changing the rest of the app. Local keeps today's
+behavior; another backend can run it elsewhere, such as a remote service.
+
+To add one: subclass RenderBackend, implement render(), and register it in
+app/services/render/__init__.py.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, List
+
+from app.models.schema import VideoParams
+
+
+@dataclass
+class RenderContext:
+    """Everything a backend needs to render one final video, all already computed
+    by the pipeline: the clips, the voiceover, the subtitle file, output paths and
+    the user's params."""
+
+    params: VideoParams
+    video_paths: List[str]          # downloaded clip files, in order
+    audio_file: str                 # voiceover audio
+    subtitle_path: str              # SRT produced earlier in the pipeline
+    combined_video_path: str        # intermediate, silent, normalized resolution
+    final_video_path: str           # the finished video to produce
+    video_concat_mode: Any
+    video_transition_mode: Any
+
+
+class RenderBackend(ABC):
+    """A render backend. Implementations must produce ctx.final_video_path."""
+
+    name: str = "base"
+
+    @abstractmethod
+    def render(self, ctx: RenderContext) -> None:
+        """Produce ctx.final_video_path. Raise on failure so the caller can react."""
+        raise NotImplementedError

--- a/app/services/render/caption_ass.py
+++ b/app/services/render/caption_ass.py
@@ -1,0 +1,296 @@
+"""Build an ASS subtitle file matching the local MoviePy caption layout.
+
+Captions are burned with libass (ffmpeg), which sizes glyphs and spaces lines
+differently from PIL. So we measure the text with PIL, the same library video.py
+uses, and write an ASS that positions every line and draws the box explicitly,
+loading the font via fontsdir. Standard library plus Pillow only.
+"""
+
+import re
+import struct
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from PIL import ImageFont
+
+
+def _read_win_metrics(font_path: str) -> Tuple[Optional[int], Optional[int], Optional[int]]:
+    """Read (unitsPerEm, usWinAscent, usWinDescent) from the font's sfnt tables.
+
+    libass maps the ASS font size onto the win-metric height, not the em square,
+    so we need these to scale the size and correct the vertical anchor. Handles
+    TTF/OTF and TTC (font 0); returns Nones if the tables are missing.
+    """
+    try:
+        data = Path(font_path).read_bytes()
+    except OSError:
+        return None, None, None
+    if len(data) < 12:
+        return None, None, None
+
+    def u16(o: int) -> int:
+        return struct.unpack(">H", data[o:o + 2])[0]
+
+    def u32(o: int) -> int:
+        return struct.unpack(">I", data[o:o + 4])[0]
+
+    try:
+        dir_off = u32(12) if data[0:4] == b"ttcf" else 0  # TTC: first font's table dir
+        num_tables = u16(dir_off + 4)
+        tables = {}
+        rec = dir_off + 12
+        for _ in range(num_tables):
+            tables[data[rec:rec + 4]] = u32(rec + 8)
+            rec += 16
+        if b"head" not in tables or b"OS/2" not in tables:
+            return None, None, None
+        upm = u16(tables[b"head"] + 18)
+        os2 = tables[b"OS/2"]
+        return upm, u16(os2 + 74), u16(os2 + 76)
+    except (struct.error, IndexError):
+        return None, None, None
+
+
+def _ts_to_seconds(ts: str) -> float:
+    parts = ts.strip().replace(",", ".").split(":")
+    try:
+        if len(parts) == 3:
+            h, m, s = parts
+            return int(h) * 3600 + int(m) * 60 + float(s)
+        if len(parts) == 2:
+            m, s = parts
+            return int(m) * 60 + float(s)
+        return float(parts[0])
+    except ValueError:
+        return 0.0
+
+
+def _parse_srt(path: str) -> List[Tuple[float, float, str]]:
+    content = Path(path).read_text(encoding="utf-8-sig", errors="replace")
+    cues = []
+    for block in re.split(r"\n\s*\n", content.strip()):
+        lines = [ln for ln in block.splitlines() if ln.strip()]
+        if len(lines) < 2:
+            continue
+        i = 1 if re.match(r"^\d+$", lines[0].strip()) else 0
+        m = re.match(r"(\S+)\s*-->\s*(\S+)", lines[i])
+        if not m:
+            continue
+        text = " ".join(lines[i + 1:]).strip()
+        if text:
+            cues.append((_ts_to_seconds(m.group(1)), _ts_to_seconds(m.group(2)), text))
+    return cues
+
+
+def _ass_time(t: float) -> str:
+    t = max(0.0, t)
+    h = int(t // 3600)
+    m = int((t % 3600) // 60)
+    s = int(t % 60)
+    cs = int(round((t - int(t)) * 100))
+    if cs == 100:  # rounding spill carries up through the units
+        cs, s = 0, s + 1
+    if s == 60:
+        s, m = 0, m + 1
+    if m == 60:
+        m, h = 0, h + 1
+    return f"{h}:{m:02d}:{s:02d}.{cs:02d}"
+
+
+def _hex_to_ass(hex_color: str, alpha: int = 0) -> str:
+    # ASS colors are &HAABBGGRR: bytes reversed from web, alpha 00=opaque..FF=clear.
+    h = hex_color.lstrip("#")
+    if len(h) >= 6:
+        r, g, b = h[0:2], h[2:4], h[4:6]
+        return f"&H{alpha:02X}{b}{g}{r}".upper()
+    return "&H00FFFFFF"
+
+
+def _wrap(text: str, font: ImageFont.FreeTypeFont, max_width: int) -> List[str]:
+    # Greedy word wrap by pixel width, like video.py's wrap_text. Words wider than
+    # the line (CJK runs) fall back to wrapping by character.
+    def width(s: str) -> int:
+        box = font.getbbox(s)
+        return box[2] - box[0]
+
+    if width(text) <= max_width:
+        return [text]
+    lines = []
+    cur = ""
+    for word in text.split(" "):
+        if width(word) > max_width:
+            if cur:
+                lines.append(cur)
+                cur = ""
+            piece = ""
+            for ch in word:
+                if piece and width(piece + ch) > max_width:
+                    lines.append(piece)
+                    piece = ch
+                else:
+                    piece += ch
+            cur = piece
+            continue
+        candidate = (cur + " " + word).strip()
+        if not cur or width(candidate) <= max_width:
+            cur = candidate
+        else:
+            lines.append(cur)
+            cur = word
+    if cur:
+        lines.append(cur)
+    return lines
+
+
+def _sanitize(text: str) -> str:
+    # Drop ASS override braces so subtitle text can't inject tags.
+    return text.replace("{", "(").replace("}", ")").replace("\n", " ").strip()
+
+
+def _rect_path(w: int, h: int) -> str:
+    return f"m 0 0 l {w} 0 l {w} {h} l 0 {h}"
+
+
+def _rounded_rect_path(w: int, h: int, r: int) -> str:
+    # Corners are quarter-circle beziers; 0.5523 is the circle approximation.
+    r = max(0, min(r, w // 2, h // 2))
+    if r == 0:
+        return _rect_path(w, h)
+    c = round(r * 0.5523)
+    return (
+        f"m {r} 0 l {w - r} 0 "
+        f"b {w - r + c} 0 {w} {r - c} {w} {r} "
+        f"l {w} {h - r} "
+        f"b {w} {h - r + c} {w - r + c} {h} {w - r} {h} "
+        f"l {r} {h} "
+        f"b {r - c} {h} 0 {h - r + c} 0 {h - r} "
+        f"l 0 {r} "
+        f"b 0 {r - c} {r - c} 0 {r} 0"
+    )
+
+
+def _font_family(font_path: str) -> str:
+    # The ASS Fontname must match the font's family so libass resolves it from
+    # fontsdir. PIL reads it from the file.
+    try:
+        name, _ = ImageFont.truetype(font_path, 32).getname()
+        return name or "Arial"
+    except Exception:
+        return "Arial"
+
+
+def build_caption_ass(subtitle_path: str, params, width: int, height: int,
+                      font_path: str) -> str:
+    """Render the SRT into an ASS string matching the local caption layout."""
+    fs = int(getattr(params, "font_size", 48) or 48)
+    font = ImageFont.truetype(font_path, fs)
+    upm, win_asc, win_desc = _read_win_metrics(font_path)
+    have_metrics = bool(upm and win_asc is not None and win_desc is not None)
+    win_h = (win_asc + win_desc) if have_metrics else 0
+    # Scale the ASS size so libass renders glyphs at fs pixels (PIL's em size).
+    ass_fs = round(fs * win_h / upm) if have_metrics else fs
+    # \an5 centers a line on its tall win box, dropping the baseline below the
+    # \pos point. We undo that per cue, since the ink offset depends on the
+    # glyphs the first and last line carry.
+    baseline_off = ((win_asc - win_desc) / 2.0 / upm * fs) if have_metrics else 0.0
+    metric_ascent = font.getmetrics()[0]
+
+    interline = int(fs * 0.25)
+    vertical_padding = int(fs * 0.35)
+    max_width = int(width * 0.9)        # wrap and box width, like video.py
+    box_pad_x = int(fs * 0.6)           # rounded-box horizontal padding
+    box_radius = max(8, int(fs * 0.4))  # rounded-box corner radius
+
+    fore = getattr(params, "text_fore_color", "#FFFFFF") or "#FFFFFF"
+    stroke_color = getattr(params, "stroke_color", "#000000") or "#000000"
+    stroke_w = int(float(getattr(params, "stroke_width", 0) or 0))  # video.py also int()s this
+
+    bg_raw = getattr(params, "text_background_color", True)
+    box_on = bool(bg_raw)
+    box_color = bg_raw if isinstance(bg_raw, str) and bg_raw.startswith("#") else "#000000"
+    rounded = bool(getattr(params, "rounded_subtitle_background", False))
+    box_alpha = (255 - 140) if rounded else 0  # video.py uses alpha 140 when rounded
+
+    pos = getattr(params, "subtitle_position", "bottom")
+    custom_pos = float(getattr(params, "custom_position", 70.0) or 70.0)
+
+    def clip_top(clip_h: int) -> float:
+        if pos == "top":
+            return height * 0.05
+        if pos == "center":
+            return (height - clip_h) / 2
+        if pos == "custom":
+            y = (height - clip_h) * (custom_pos / 100.0)
+            return max(10.0, min(y, height - clip_h - 10.0))
+        return height * 0.95 - clip_h
+
+    primary = _hex_to_ass(fore)
+    outline = _hex_to_ass(stroke_color)
+    # A \p fill takes color (\c, BGR) and alpha separately.
+    box_hex = box_color.lstrip("#")
+    box_c = f"&H{box_hex[4:6]}{box_hex[2:4]}{box_hex[0:2]}".upper() if len(box_hex) >= 6 else "&H000000"
+    box_a = f"&H{box_alpha:02X}"
+
+    header = [
+        "[Script Info]",
+        "ScriptType: v4.00+",
+        f"PlayResX: {width}",
+        f"PlayResY: {height}",
+        "ScaledBorderAndShadow: yes",
+        "WrapStyle: 2",  # we wrap ourselves, libass must not re-wrap
+        "",
+        "[V4+ Styles]",
+        "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, "
+        "BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, "
+        "BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding",
+        "Style: Box,Arial,1,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,"
+        "100,100,0,0,1,0,0,7,0,0,0,1",
+        # Outline only; the box is a separate layer. Weight comes from the font file.
+        f"Style: Txt,{_font_family(font_path)},{ass_fs},{primary},&H000000FF,{outline},"
+        f"&H00000000,0,0,0,0,100,100,0,0,1,{stroke_w},0,5,0,0,0,1",
+        "",
+        "[Events]",
+        "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text",
+    ]
+
+    events = []
+    for start, end, text in _parse_srt(subtitle_path):
+        lines = _wrap(text, font, max_width)
+        n = len(lines)
+        bbox = font.getbbox(text)  # single-line height, as video.py measures it
+        single_h = bbox[3] - bbox[1]
+        clip_h = int(n * single_h + vertical_padding + interline * n)
+        ct = clip_top(clip_h)
+        st, et = _ass_time(start), _ass_time(end)
+
+        if box_on:
+            # Solid: opaque bar at 90% width. Rounded: ~55% translucent, fits the
+            # widest line plus padding, rounded corners (video.py's two styles).
+            if rounded:
+                widest = max(font.getbbox(ln)[2] - font.getbbox(ln)[0] for ln in lines)
+                box_w = min(max_width, widest + 2 * box_pad_x)
+                path = _rounded_rect_path(box_w, clip_h, box_radius)
+            else:
+                box_w = max_width
+                path = _rect_path(box_w, clip_h)
+            box_x = (width - box_w) // 2
+            events.append(
+                f"Dialogue: 0,{st},{et},Box,,0,0,0,,"
+                f"{{\\pos({box_x},{round(ct)})\\an7\\p1\\c{box_c}\\alpha{box_a}}}"
+                f"{path}{{\\p0}}"
+            )
+        # PIL stacks lines by getbbox("A")[3] + spacing; center the block in the
+        # clip, then shift up so the ink (not the win box) is centered.
+        line_pitch = font.getbbox("A")[3] + interline
+        center_y = ct + clip_h / 2.0
+        ink_asc_top = metric_ascent - font.getbbox(lines[0])[1]
+        ink_desc_bot = font.getbbox(lines[-1])[3] - metric_ascent
+        anchor_dy = baseline_off + (ink_desc_bot - ink_asc_top) / 2.0
+        for i, ln in enumerate(lines):
+            cy = center_y + (i - (n - 1) / 2.0) * line_pitch - anchor_dy
+            events.append(
+                f"Dialogue: 1,{st},{et},Txt,,0,0,0,,"
+                f"{{\\pos({round(width / 2)},{round(cy)})}}{_sanitize(ln)}"
+            )
+
+    return "\n".join(header + events) + "\n"

--- a/app/services/render/local.py
+++ b/app/services/render/local.py
@@ -1,0 +1,54 @@
+"""Local render backend: the default.
+
+This wraps the existing render path (video.combine_videos + video.generate_video)
+behind the RenderBackend interface. The behavior is unchanged. This is what runs
+unless the user explicitly selects a different backend.
+"""
+
+import os
+
+from loguru import logger
+
+from app.services import video
+from app.services.render.base import RenderBackend, RenderContext
+
+
+def _ensure_local(path):
+    # Local rendering needs the clip on disk. The Rendobar backend skips the
+    # download and keeps the source URL, so fetch it here when falling back to
+    # local. Plain local paths pass through.
+    source_url = getattr(path, "source_url", "")
+    if source_url and not os.path.isfile(str(path)):
+        try:
+            from app.services.material import save_video
+            local = save_video(video_url=source_url, save_dir="")
+            if local:
+                return local
+            logger.warning(f"could not download {source_url}")
+        except Exception as e:
+            logger.warning(f"download error for {source_url}: {e}")
+    return path
+
+
+class LocalRenderBackend(RenderBackend):
+    name = "local"
+
+    def render(self, ctx: RenderContext) -> None:
+        video_paths = [_ensure_local(p) for p in ctx.video_paths]
+        video.combine_videos(
+            combined_video_path=ctx.combined_video_path,
+            video_paths=video_paths,
+            audio_file=ctx.audio_file,
+            video_aspect=ctx.params.video_aspect,
+            video_concat_mode=ctx.video_concat_mode,
+            video_transition_mode=ctx.video_transition_mode,
+            max_clip_duration=ctx.params.video_clip_duration,
+            threads=ctx.params.n_threads,
+        )
+        video.generate_video(
+            video_path=ctx.combined_video_path,
+            audio_path=ctx.audio_file,
+            subtitle_path=ctx.subtitle_path,
+            output_file=ctx.final_video_path,
+            params=ctx.params,
+        )

--- a/app/services/render/rendobar.py
+++ b/app/services/render/rendobar.py
@@ -1,0 +1,463 @@
+"""Optional cloud render backend.
+
+Renders the reel on Rendobar's API instead of locally, so the heavy MoviePy and
+ffmpeg work does not run on (or crash) the user's machine. The local backend
+stays the default; this runs only when the user selects it and sets an API key.
+
+Stock clips (Pexels, Pixabay) are passed to the cloud by URL, so only true local
+files (voiceover, music, custom clips) are uploaded. Those uploads go to a
+third-party service and each render spends credits. The cloud output is visually
+equivalent to the local render, not a pixel clone. Uses the standard library plus
+requests, which the project already depends on.
+"""
+
+import os
+import random
+import shutil
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import requests
+from loguru import logger
+
+from app.config import config
+from app.models.schema import VideoAspect
+from app.services.render.base import RenderBackend, RenderContext
+
+BASE_URL = os.environ.get("RENDOBAR_API_BASE", "https://api.rendobar.com")
+POLL_INTERVAL_SEC = 5
+POLL_TIMEOUT_SEC = 900
+UPLOAD_CONCURRENCY = 4
+MAX_RETRIES = 4
+TRANSIENT_STATUS = {429, 500, 502, 503, 504}  # worth retrying, not a real failure
+
+
+class RendobarError(RuntimeError):
+    pass
+
+
+def _api_key() -> str:
+    return (
+        config.app.get("rendobar_api_key")
+        or os.environ.get("RENDOBAR_API_KEY")
+        or ""
+    ).strip()
+
+
+def rendobar_eligible(params) -> bool:
+    """True when the backend can serve the job, i.e. an API key is set."""
+    return bool(_api_key())
+
+
+def _headers() -> dict:
+    return {"Authorization": f"Bearer {_api_key()}"}
+
+
+def _check(resp: requests.Response, ctx: str) -> dict:
+    try:
+        body = resp.json()
+    except ValueError:
+        body = {}
+    if not resp.ok or (isinstance(body, dict) and "error" in body):
+        err = body.get("error", {}) if isinstance(body, dict) else {}
+        code = err.get("code", f"HTTP {resp.status_code}")
+        # Fall back to the status reason, not resp.text, so an HTML error page
+        # (e.g. a 503 from the edge) doesn't end up dumped into the log.
+        message = err.get("message") or resp.reason or f"HTTP {resp.status_code}"
+        raise RendobarError(f"{ctx} failed [{code}]: {message}")
+    return body
+
+
+def _send(make_request, ctx: str) -> requests.Response:
+    """Send a request, retrying transient HTTP and network errors with backoff.
+
+    `make_request` is a callable that performs the request and returns the
+    response, so it can reopen a file stream on each retry.
+    """
+    last = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = make_request()
+            if resp.status_code not in TRANSIENT_STATUS:
+                return resp
+            last = f"HTTP {resp.status_code} {resp.reason}"
+        except requests.exceptions.RequestException as e:
+            last = str(e)
+        wait = min(2 ** attempt, 30)
+        logger.warning(f"{ctx}: {last}, retrying in {wait}s")
+        time.sleep(wait)
+    raise RendobarError(f"{ctx} failed after {MAX_RETRIES} tries: {last}")
+
+
+_progress_lock = threading.Lock()
+
+
+def _upload_one(path: str) -> str:
+    file_path = Path(path)
+    if not file_path.is_file():
+        raise RendobarError(f"input not found: {path}")
+
+    def post():
+        with file_path.open("rb") as stream:
+            return requests.post(
+                f"{BASE_URL}/uploads",
+                headers=_headers(),
+                params={"filename": file_path.name},
+                data=stream,
+                timeout=300,
+            )
+
+    resp = _send(post, f"upload of {file_path.name}")
+    url = _check(resp, f"upload of {file_path.name}").get("data", {}).get("downloadUrl")
+    if not url:
+        raise RendobarError(f"upload of {file_path.name} returned no downloadUrl")
+    return url
+
+
+def _upload_all(paths: List[str]) -> List[str]:
+    """Upload many files concurrently (bounded), keeping input order."""
+    total = len(paths)
+    if total == 0:
+        return []
+    done = {"n": 0}
+
+    def _job(idx_path):
+        idx, p = idx_path
+        url = _upload_one(p)
+        with _progress_lock:
+            done["n"] += 1
+            logger.info(f"uploaded {done['n']}/{total}")
+        return idx, url
+
+    results = [""] * total
+    with ThreadPoolExecutor(max_workers=min(UPLOAD_CONCURRENCY, total)) as ex:
+        for idx, url in ex.map(_job, list(enumerate(paths))):
+            results[idx] = url
+    return results
+
+
+def _create_job(job_type: str, inputs: dict, params: dict) -> str:
+    def post():
+        return requests.post(
+            f"{BASE_URL}/jobs",
+            headers=_headers(),
+            json={"type": job_type, "inputs": inputs, "params": params},
+            timeout=60,
+        )
+
+    job_id = _check(_send(post, f"create {job_type} job"), f"create {job_type} job").get("data", {}).get("id")
+    if not job_id:
+        raise RendobarError(f"create {job_type} job returned no job id")
+    return job_id
+
+
+def _poll(job_id: str) -> str:
+    deadline = time.monotonic() + POLL_TIMEOUT_SEC
+    while time.monotonic() < deadline:
+        # The job is running server-side, so a transient blip (network, 5xx)
+        # should not end it. Keep polling until it reports a terminal status or
+        # the overall timeout is reached.
+        try:
+            resp = requests.get(f"{BASE_URL}/jobs/{job_id}", headers=_headers(), timeout=60)
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"poll job {job_id}: {e}, retrying")
+            time.sleep(POLL_INTERVAL_SEC)
+            continue
+        if resp.status_code in TRANSIENT_STATUS:
+            logger.warning(f"poll job {job_id}: HTTP {resp.status_code}, retrying")
+            time.sleep(POLL_INTERVAL_SEC)
+            continue
+        data = _check(resp, f"poll job {job_id}").get("data", {})
+        status = data.get("status")
+        if status == "complete":
+            url = data.get("outputUrl")
+            if not url:
+                raise RendobarError(f"job {job_id} completed but returned no outputUrl")
+            return url
+        if status in ("failed", "cancelled"):
+            code = data.get("errorCode") or status
+            message = data.get("errorMessage") or f"job {status}"
+            raise RendobarError(f"job {job_id} {status} [{code}]: {message}")
+        time.sleep(POLL_INTERVAL_SEC)
+    raise RendobarError(f"job {job_id} did not finish within {POLL_TIMEOUT_SEC}s")
+
+
+def _download(url: str, output: str) -> None:
+    out = Path(output)
+    if out.parent and not out.parent.exists():
+        out.parent.mkdir(parents=True, exist_ok=True)
+    last = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            with requests.get(url, stream=True, timeout=300) as resp:
+                if resp.status_code in TRANSIENT_STATUS:
+                    last = f"HTTP {resp.status_code} {resp.reason}"
+                elif not resp.ok:
+                    raise RendobarError(f"download failed: HTTP {resp.status_code}")
+                else:
+                    with out.open("wb") as handle:
+                        for chunk in resp.iter_content(chunk_size=1 << 16):
+                            if chunk:
+                                handle.write(chunk)
+                    return
+        except requests.exceptions.RequestException as e:
+            last = str(e)
+        wait = min(2 ** attempt, 30)
+        logger.warning(f"download: {last}, retrying in {wait}s")
+        time.sleep(wait)
+    raise RendobarError(f"download failed after {MAX_RETRIES} tries: {last}")
+
+
+def _slide_offset(mode: str, side: str, w: int, h: int, t: float, s: float):
+    # Linear position over t seconds, matching video_effects.py's slide. Returns
+    # the ffmpeg overlay (x, y) expressions, where t is the frame time.
+    if mode == "SlideIn":
+        table = {
+            "left": (f"if(lt(t,{t}),-{w}+{w}*t/{t},0)", "0"),
+            "right": (f"if(lt(t,{t}),{w}-{w}*t/{t},0)", "0"),
+            "top": ("0", f"if(lt(t,{t}),-{h}+{h}*t/{t},0)"),
+            "bottom": ("0", f"if(lt(t,{t}),{h}-{h}*t/{t},0)"),
+        }
+    else:  # SlideOut
+        table = {
+            "left": (f"if(gt(t,{s}),-{w}*(t-{s})/{t},0)", "0"),
+            "right": (f"if(gt(t,{s}),{w}*(t-{s})/{t},0)", "0"),
+            "top": ("0", f"if(gt(t,{s}),-{h}*(t-{s})/{t},0)"),
+            "bottom": ("0", f"if(gt(t,{s}),{h}*(t-{s})/{t},0)"),
+        }
+    return table[side]
+
+
+def _clip_chain(idx, cover, mode, clip_duration, width, height, rng):
+    # Filter statements for one clip, ending at label [v{idx}], reproducing
+    # MoviePy's per-clip transition: a 1s fade or slide, then plain concat.
+    label = f"v{idx}"
+    if mode == "Shuffle":
+        mode = rng.choice(["FadeIn", "FadeOut", "SlideIn", "SlideOut"])
+    t = min(1.0, clip_duration)
+    s = clip_duration - t
+    if mode == "FadeIn":
+        return [f"[{idx}:v]{cover},fade=t=in:st=0:d={t}[{label}]"]
+    if mode == "FadeOut":
+        return [f"[{idx}:v]{cover},fade=t=out:st={s}:d={t}[{label}]"]
+    if mode in ("SlideIn", "SlideOut"):
+        side = rng.choice(["left", "right", "top", "bottom"])
+        x, y = _slide_offset(mode, side, width, height, t, s)
+        return [
+            f"[{idx}:v]{cover}[c{idx}]",
+            f"color=black:s={width}x{height}:d={clip_duration}[bg{idx}]",
+            f"[bg{idx}][c{idx}]overlay=x='{x}':y='{y}'[{label}]",
+        ]
+    return [f"[{idx}:v]{cover}[{label}]"]  # None or unknown
+
+
+def _build_command(clip_urls, voiceover_url, music_url, width, height,
+                   clip_duration, voice_volume, bgm_volume, transition=None) -> str:
+    """Build the raw.ffmpeg command. Each clip is trimmed to clip_duration, its
+    timestamps reset, then scaled and center-cropped to fill the frame, with the
+    transition applied per clip, before all clips are concatenated. The voiceover
+    drives length; music is ducked under it.
+    """
+    inputs = [f'-i "{u}"' for u in clip_urls]
+    inputs.append(f'-i "{voiceover_url}"')
+    voice_idx = len(clip_urls)
+    if music_url:
+        inputs.append(f'-i "{music_url}"')
+        music_idx = voice_idx + 1
+
+    cover = (
+        f"trim=duration={clip_duration},setpts=PTS-STARTPTS,"
+        f"scale={width}:{height}:force_original_aspect_ratio=increase,"
+        f"crop={width}:{height},setsar=1"
+    )
+    mode = getattr(transition, "value", transition)
+    rng = random.Random()
+    parts = []
+    for i in range(len(clip_urls)):
+        parts.extend(_clip_chain(i, cover, mode, clip_duration, width, height, rng))
+    concat_in = "".join(f"[v{i}]" for i in range(len(clip_urls)))
+    parts.append(f"{concat_in}concat=n={len(clip_urls)}:v=1:a=0[vout]")
+
+    if music_url:
+        parts.append(f"[{voice_idx}:a]volume={voice_volume}[vo]")
+        parts.append(f"[{music_idx}:a]volume={bgm_volume}[bg]")
+        parts.append("[vo][bg]amix=inputs=2:duration=first:dropout_transition=2[aout]")
+    else:
+        parts.append(f"[{voice_idx}:a]volume={voice_volume}[aout]")
+
+    filtergraph = ";".join(parts)
+    return (
+        "ffmpeg " + " ".join(inputs)
+        + f' -filter_complex "{filtergraph}"'
+        + ' -map "[vout]" -map "[aout]"'
+        + " -c:v libx264 -preset veryfast -pix_fmt yuv420p"
+        + " -c:a aac -b:a 192k -shortest output.mp4"
+    )
+
+
+def _is_remote(path) -> bool:
+    url = getattr(path, "source_url", "")
+    return isinstance(url, str) and url.startswith(("http://", "https://"))
+
+
+def _local_font_path(font_name: str) -> Optional[str]:
+    # Path to the bundled font file, uploaded so the cloud renders the exact face.
+    # Returns None for a blank or missing font.
+    if not font_name:
+        return None
+    try:
+        from app.utils import utils
+        path = os.path.join(utils.font_dir(), font_name)
+    except Exception:
+        return None
+    return path if os.path.isfile(path) else None
+
+
+def _map_subtitle_settings(params, height: int) -> dict:
+    """Translate the Subtitle Settings into caption.burn params.
+
+    Used only on the fallback path when no font file is available; the font, size,
+    color, outline, position and box carry over. Rounded corners aren't represented
+    here, the box is square.
+    """
+    pos_raw = getattr(params, "subtitle_position", "bottom")
+    if pos_raw == "top":
+        position, margin_v = "top", round(height * 0.05)
+    elif pos_raw == "center":
+        position, margin_v = "center", 0
+    elif pos_raw == "custom":
+        # custom_position is a top-down percentage; convert to a bottom margin.
+        cp = float(getattr(params, "custom_position", 70.0) or 70.0)
+        position, margin_v = "bottom", max(10, round((1.0 - cp / 100.0) * height))
+    else:
+        position, margin_v = "bottom", round(height * 0.05)
+
+    box_enabled = bool(getattr(params, "text_background_color", False))
+    burn = {
+        "fontSize": int(getattr(params, "font_size", 48) or 48),
+        "fontColor": getattr(params, "text_fore_color", "#FFFFFF") or "#FFFFFF",
+        "outlineColor": getattr(params, "stroke_color", "#000000") or "#000000",
+        "outlineWidth": float(getattr(params, "stroke_width", 2) or 2),
+        "position": position,
+        "alignment": "center",
+        "marginV": margin_v,
+        "boxEnabled": box_enabled,
+        "shadow": 0,  # MoviePy draws no drop shadow
+    }
+    # Family name (extension stripped); ignored when a font file is uploaded.
+    font = getattr(params, "font_name", "") or ""
+    if font:
+        burn["fontFamily"] = font.rsplit(".", 1)[0]
+    if box_enabled:
+        bg = getattr(params, "text_background_color", True)
+        burn["boxColor"] = bg if isinstance(bg, str) and bg.startswith("#") else "#000000"
+        rounded = bool(getattr(params, "rounded_subtitle_background", False))
+        burn["boxOpacity"] = 0.55 if rounded else 1.0
+    return burn
+
+
+class RendobarRenderBackend(RenderBackend):
+    name = "rendobar"
+
+    def render(self, ctx: RenderContext) -> None:
+        params = ctx.params
+        width, height = VideoAspect(params.video_aspect).to_resolution()
+        clip_duration = int(getattr(params, "video_clip_duration", 5) or 5)
+
+        # Stock clips go by URL; only true local files are uploaded.
+        clip_refs: List[Optional[str]] = []
+        local_clips: List[Tuple[int, str]] = []
+        for i, clip in enumerate(ctx.video_paths):
+            if _is_remote(clip):
+                clip_refs.append(clip.source_url)
+            else:
+                clip_refs.append(None)
+                local_clips.append((i, str(clip)))
+
+        music_path = None
+        if getattr(params, "bgm_volume", 0):
+            try:
+                from app.services.video import get_bgm_file
+                music_path = get_bgm_file(bgm_type=params.bgm_type, bgm_file=params.bgm_file)
+            except Exception as e:
+                logger.warning(f"skipping background music: {e}")
+                music_path = None
+
+        to_upload = [p for _, p in local_clips] + [ctx.audio_file]
+        if music_path:
+            to_upload.append(music_path)
+        logger.info(
+            f"{len(clip_refs) - len(local_clips)} clips by url, "
+            f"uploading {len(to_upload)} local files"
+        )
+        uploaded = _upload_all(to_upload)
+        for (i, _), url in zip(local_clips, uploaded[: len(local_clips)]):
+            clip_refs[i] = url
+        voiceover_url = uploaded[len(local_clips)]
+        music_url = uploaded[len(local_clips) + 1] if music_path else None
+
+        # random concat = shuffle the clip order (and subset, when there are more
+        # than needed); sequential keeps the download order.
+        concat_mode = getattr(params, "video_concat_mode", "random")
+        if getattr(concat_mode, "value", concat_mode) == "random":
+            random.shuffle(clip_refs)
+
+        command = _build_command(
+            clip_refs, voiceover_url, music_url, width, height, clip_duration,
+            getattr(params, "voice_volume", 1.0),
+            getattr(params, "bgm_volume", 0.2),
+            getattr(params, "video_transition_mode", None),
+        )
+        logger.info("rendering reel on cloud ffmpeg")
+        reel_url = _poll(_create_job("raw.ffmpeg", {}, {"command": command, "timeout": 900}))
+
+        if getattr(params, "subtitle_enabled", False):
+            reel_url = self._add_captions(ctx, reel_url)
+
+        _download(reel_url, ctx.final_video_path)
+        try:
+            shutil.copyfile(ctx.final_video_path, ctx.combined_video_path)
+        except OSError:
+            pass
+        logger.success(f"cloud render wrote {ctx.final_video_path}")
+
+    def _add_captions(self, ctx: RenderContext, reel_url: str) -> str:
+        """Burn the subtitles onto the reel with caption.burn, honoring the
+        Subtitle Settings. The user's font is uploaded so the exact face is used.
+        """
+        if not (ctx.subtitle_path and os.path.isfile(ctx.subtitle_path)):
+            return reel_url
+        params = ctx.params
+        logger.info("burning subtitles via caption.burn")
+        width, height = VideoAspect(params.video_aspect).to_resolution()
+        font_path = _local_font_path(getattr(params, "font_name", "") or "")
+
+        # With the font available, build an ASS that reproduces the local MoviePy
+        # layout and burn it as-is, so the cloud output matches the local render.
+        if font_path:
+            try:
+                from app.services.render.caption_ass import build_caption_ass
+                ass_text = build_caption_ass(ctx.subtitle_path, params, width, height, font_path)
+                ass_path = os.path.join(os.path.dirname(ctx.subtitle_path), "caption.ass")
+                with open(ass_path, "w", encoding="utf-8") as handle:
+                    handle.write(ass_text)
+                sub_url = _upload_one(ass_path)
+                font_url = _upload_one(font_path)
+                return _poll(_create_job(
+                    "caption.burn",
+                    {"source": reel_url, "subtitles": sub_url, "font": font_url},
+                    {},
+                ))
+            except Exception as e:
+                logger.warning(f"caption ass build failed, using srt: {e}")
+
+        # Fallback: send the SRT and let caption.burn style it from the params.
+        srt_url = _upload_one(ctx.subtitle_path)
+        return _poll(_create_job(
+            "caption.burn",
+            {"source": reel_url, "subtitles": srt_url},
+            _map_subtitle_settings(params, height),
+        ))

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -10,6 +10,7 @@ from app.models import const
 from app.models.schema import VideoConcatMode, VideoParams
 from app.services import llm, material, subtitle, video, voice, upload_post
 from app.services import state as sm
+from app.services.render import RenderContext, render_with_fallback
 from app.utils import utils
 
 
@@ -212,33 +213,26 @@ def generate_final_videos(
         combined_video_path = path.join(
             utils.task_dir(task_id), f"combined-{index}.mp4"
         )
-        logger.info(f"\n\n## combining video: {index} => {combined_video_path}")
-        video.combine_videos(
-            combined_video_path=combined_video_path,
-            video_paths=downloaded_videos,
-            audio_file=audio_file,
-            video_aspect=params.video_aspect,
-            video_concat_mode=video_concat_mode,
-            video_transition_mode=video_transition_mode,
-            max_clip_duration=params.video_clip_duration,
-            threads=params.n_threads,
-        )
-
-        _progress += 50 / params.video_count / 2
-        sm.state.update_task(task_id, progress=_progress)
-
         final_video_path = path.join(utils.task_dir(task_id), f"final-{index}.mp4")
 
-        logger.info(f"\n\n## generating video: {index} => {final_video_path}")
-        video.generate_video(
-            video_path=combined_video_path,
-            audio_path=audio_file,
-            subtitle_path=subtitle_path,
-            output_file=final_video_path,
-            params=params,
+        logger.info(
+            f"\n\n## rendering video: {index} "
+            f"(backend: {params.render_backend or 'local'}) => {final_video_path}"
+        )
+        render_with_fallback(
+            RenderContext(
+                params=params,
+                video_paths=downloaded_videos,
+                audio_file=audio_file,
+                subtitle_path=subtitle_path,
+                combined_video_path=combined_video_path,
+                final_video_path=final_video_path,
+                video_concat_mode=video_concat_mode,
+                video_transition_mode=video_transition_mode,
+            )
         )
 
-        _progress += 50 / params.video_count / 2
+        _progress += 50 / params.video_count
         sm.state.update_task(task_id, progress=_progress)
 
         final_video_paths.append(final_video_path)

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -796,6 +796,36 @@ with middle_panel:
                 help=tr("Video Encoder Help"),
             )
             config.app["video_codec"] = video_codec_options[selected_codec_index][1]
+
+        render_backends = [
+            (tr("Local (default)"), "local"),
+            ("Rendobar (cloud)", "rendobar"),
+        ]
+        saved_backend = config.app.get("render_backend", "local")
+        backend_index = next(
+            (i for i, b in enumerate(render_backends) if b[1] == saved_backend), 0
+        )
+        selected_backend_index = st.selectbox(
+            tr("Render Backend"),
+            options=range(len(render_backends)),
+            format_func=lambda x: render_backends[x][0],
+            index=backend_index,
+        )
+        params.render_backend = render_backends[selected_backend_index][1]
+        config.app["render_backend"] = params.render_backend
+
+        if params.render_backend == "rendobar":
+            rendobar_api_key = st.text_input(
+                "Rendobar API Key",
+                value=config.app.get("rendobar_api_key", ""),
+                type="password",
+            )
+            config.app["rendobar_api_key"] = rendobar_api_key
+            st.caption(
+                "Renders on Rendobar's cloud instead of locally. "
+                "Get an API key at https://rendobar.com/ffmpeg/"
+            )
+
     with st.container(border=True):
         st.write(tr("Audio Settings"))
 


### PR DESCRIPTION
Hello,

Thanks for this cool project, it's been really helpful.

One thing I noticed is that the render step and caption burning can get heavy, especially for folks on older PCs or slower internet connections. So this PR adds an optional the option to run the render on a cloud backend instead of locally.

<img width="807" height="180" alt="image" src="https://github.com/user-attachments/assets/68842b38-d60e-4e0c-848a-39f5c9523b0d" />


It adds a dropdown to choose the render method, Local by default, and the cloud backend as an option. The two are interchangeable, and the output of either should look almost the same. If the cloud render ever fails it just falls back to Local, so it can't get in the way of a run.


Happy to discuss anything and keep contributing to the project. (For transparency, [Rendobar](https://rendobar.com/ffmpeg/) is one of the projects I work on, so I'm happy to keep the integration generic for other backends or adjust whatever you'd prefer.)

I also think the cloud render idea could open the door to some fun directions later on, like a mobile app or an automation pipeline.

Thanks!!