### PR TITLE
fix: keep last subtitle when SRT has no trailing blank line

### DIFF
--- a/app/services/subtitle.py
+++ b/app/services/subtitle.py
@@ -161,6 +161,13 @@ def file_to_subtitles(filename):
                 current_times, current_text = None, ""
             elif current_times:
                 current_text += line
+
+    # Flush the final block. SRT files whose last subtitle is not followed by a
+    # trailing blank line never hit the blank-line branch above, so without this
+    # the last subtitle would be silently dropped.
+    if current_times:
+        index += 1
+        times_texts.append((index, current_times.strip(), current_text.strip()))
     return times_texts
 
 

--- a/test/services/test_subtitle.py
+++ b/test/services/test_subtitle.py
@@ -43,6 +43,50 @@ class TestSubtitleService(unittest.TestCase):
         self.assertNotIn("---", corrected_srt)
         self.assertNotIn("00:00:00,000 --> 00:00:00,000", corrected_srt)
 
+    def test_file_to_subtitles_keeps_last_block_without_trailing_newline(self):
+        """
+        The final subtitle must be parsed even when the SRT file does not end
+        with a trailing blank line. Many tools omit it, and previously the last
+        block was silently dropped because only a blank line flushed a block.
+        """
+        srt_without_trailing_blank = (
+            "1\n"
+            "00:00:00,000 --> 00:00:01,000\n"
+            "Hello\n\n"
+            "2\n"
+            "00:00:01,000 --> 00:00:02,000\n"
+            "World"
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            subtitle_file = Path(tmp_dir) / "subtitle.srt"
+            subtitle_file.write_text(srt_without_trailing_blank, encoding="utf-8")
+
+            items = subtitle.file_to_subtitles(str(subtitle_file))
+
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0][2], "Hello")
+        self.assertEqual(items[1][2], "World")
+
+    def test_file_to_subtitles_parses_blocks_with_trailing_newline(self):
+        """A normal SRT ending in a blank line still parses all blocks."""
+        srt_with_trailing_blank = (
+            "1\n"
+            "00:00:00,000 --> 00:00:01,000\n"
+            "Hello\n\n"
+            "2\n"
+            "00:00:01,000 --> 00:00:02,000\n"
+            "World\n\n"
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            subtitle_file = Path(tmp_dir) / "subtitle.srt"
+            subtitle_file.write_text(srt_with_trailing_blank, encoding="utf-8")
+
+            items = subtitle.file_to_subtitles(str(subtitle_file))
+
+        self.assertEqual([item[2] for item in items], ["Hello", "World"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`app/services/subtitle.py::file_to_subtitles` only records a subtitle block when it encounters a **following blank line**:

```python
elif line.strip() == "" and current_times:
    index += 1
    times_texts.append((index, current_times.strip(), current_text.strip()))
    current_times, current_text = None, ""
```

If the SRT file's **last block is not terminated by a trailing blank line** (very common — many tools and hand-written files omit it), that branch never fires for the final block, so the last subtitle is **silently dropped**.

```python
# SRT ending in "...World" with no trailing newline:
file_to_subtitles(path)   # -> only ["Hello"], "World" is lost
```

This feeds `correct()`, `task.py` subtitle handling, so a dropped last line propagates into the rendered video / corrected SRT.

## Fix

Flush the pending block after the read loop:

```python
if current_times:
    index += 1
    times_texts.append((index, current_times.strip(), current_text.strip()))
```

Files that *do* end with a blank line are unaffected (the block is already flushed inside the loop, and `current_times` is reset to `None`).

## Tests

Added two cases to `test/services/test_subtitle.py`:
- `..._keeps_last_block_without_trailing_newline` — **fails on `main`** (1 subtitle instead of 2) and passes with the fix.
- `..._parses_blocks_with_trailing_newline` — guards against regressing the normal case.

All subtitle tests pass.
