### PR TITLE
fix: handle empty Qwen choices

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -101,7 +101,11 @@ def _extract_qwen_generation_text(response) -> str:
     """
     output = _get_response_field(response, "output")
     choices = _get_response_field(output, "choices") if output else None
-    if choices:
+    if choices is not None:
+        if not choices:
+            logger.warning("Qwen returned an empty choices list")
+            raise ValueError("[qwen] returned empty choices")
+
         first_choice = choices[0]
         message = _get_response_field(first_choice, "message")
         content = _get_response_field(message, "content") if message else None

--- a/test/services/test_llm.py
+++ b/test/services/test_llm.py
@@ -277,6 +277,18 @@ class TestLiteLLMProvider(unittest.TestCase):
         self.assertIn("returned empty text content", result)
         self.assertNotIn("NoneType", result)
 
+    def test_qwen_provider_reports_empty_choices(self):
+        """Qwen chat 响应 choices 为空时应返回明确错误。"""
+        self._use_qwen_provider()
+        response = {"output": {"text": None, "choices": []}}
+
+        with self._patch_dashscope_generation(response):
+            result = llm._generate_response("Say hello")
+
+        self.assertIn("Error:", result)
+        self.assertIn("returned empty choices", result)
+        self.assertNotIn("NoneType", result)
+
     def test_aihubmix_provider_uses_openai_compatible_client(self):
         """
         AIHubMix 是 OpenAI-compatible 网关。这里用 fake OpenAI client


### PR DESCRIPTION
## Summary
- detect explicit empty Qwen choices lists before falling back to output.text
- return a clear Qwen empty choices error instead of an unclear empty text path
- add a regression test for empty choices responses

Fixes #984

## Testing
- uv run --with pytest python -m pytest test/services/test_llm.py