### PR TITLE
fix(groq): add default model name + clarify unvalidated manual entry warning

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -212,6 +212,8 @@ def _generate_response(prompt: str) -> str:
             elif llm_provider == "groq":
                 api_key = config.app.get("groq_api_key")
                 model_name = config.app.get("groq_model_name")
+                if not model_name:
+                    model_name = "llama-3.3-70b-versatile"
                 base_url = config.app.get("groq_base_url", "")
                 if not base_url:
                     base_url = "https://api.groq.com/openai/v1"

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -590,7 +590,7 @@ if not config.app.get("hide_config", False):
                         )
                         if effective_api_key:
                             st.caption(
-                                "Unable to load Groq model list right now. You can still enter a model name manually."
+                                "Unable to load Groq model list right now. You can still enter a model name manually — note it won't be validated until generation."
                             )
                         else:
                             st.caption(


### PR DESCRIPTION
Fixes #1013

## Changes

**`app/services/llm.py`**
- Added default `model_name = "llama-3.3-70b-versatile"` when `groq_model_name` is not set in config — consistent with how other providers handle missing model names (`g4f`, `gemini`, `mimo`, `aihubmix` all set defaults here rather than relying solely on the WebUI default)

**`webui/Main.py`**
- Updated caption shown when model list fails to load — now explicitly says the manually entered name won't be validated until generation, so users understand a wrong model name will fail at request time rather than immediately

## Why

When `get_groq_model_ids()` fails (network issue, outage, bad API key), the UI falls back to a text input. The previous caption said "you can still enter a model name manually" but didn't warn that the name would go unvalidated. Combined with `@st.cache_data(ttl=300)`, a user could spend 5 minutes trying a wrong model name before realising the issue.

The `llm.py` default also helps users who configure Groq via `config.toml` directly without the WebUI — they get a working default instead of a validation error if they forget to set `groq_model_name`.