### PR TITLE
Fix video duration buffer without silent tail

### DIFF
--- a/app/services/video.py
+++ b/app/services/video.py
@@ -78,6 +78,11 @@ _SUPPORTED_VIDEO_CODECS = (
     "h264_videotoolbox",
 )
 _runtime_disabled_video_codecs = set()
+_VIDEO_DURATION_SAFETY_BUFFER_SECONDS = 0.1
+
+
+def _has_enough_video_duration(video_duration: float, audio_duration: float) -> bool:
+    return video_duration >= audio_duration + _VIDEO_DURATION_SAFETY_BUFFER_SECONDS
 
 
 def _prioritize_unique_source_clips(
@@ -279,7 +284,11 @@ def _format_ffmpeg_concat_path(file_path: str) -> str:
 
 
 def concat_video_clips_with_ffmpeg(
-    clip_files: List[str], output_file: str, threads: int, output_dir: str
+    clip_files: List[str],
+    output_file: str,
+    threads: int,
+    output_dir: str,
+    max_duration: float | None = None,
 ):
     concat_list_file = os.path.join(output_dir, "ffmpeg-concat-list.txt")
     with open(concat_list_file, "w", encoding="utf-8") as fp:
@@ -287,7 +296,7 @@ def concat_video_clips_with_ffmpeg(
             fp.write(f"file '{_format_ffmpeg_concat_path(clip_file)}'\n")
 
     def build_command(codec: str) -> list[str]:
-        return [
+        command = [
             utils.get_ffmpeg_binary(),
             "-y",
             "-f",
@@ -296,6 +305,10 @@ def concat_video_clips_with_ffmpeg(
             "0",
             "-i",
             concat_list_file,
+        ]
+        if max_duration is not None and max_duration > 0:
+            command.extend(["-t", f"{max_duration:.3f}"])
+        command.extend([
             "-c:v",
             codec,
             "-threads",
@@ -303,7 +316,8 @@ def concat_video_clips_with_ffmpeg(
             "-pix_fmt",
             "yuv420p",
             output_file,
-        ]
+        ])
+        return command
 
     def run_concat(codec: str):
         command = build_command(codec)
@@ -332,6 +346,52 @@ def concat_video_clips_with_ffmpeg(
             return result_codec
     finally:
         delete_files(concat_list_file)
+
+
+def trim_video_with_ffmpeg(
+    input_file: str,
+    output_file: str,
+    duration: float,
+    threads: int = 2,
+) -> str:
+    def build_command(codec: str) -> list[str]:
+        return [
+            utils.get_ffmpeg_binary(),
+            "-y",
+            "-i",
+            input_file,
+            "-t",
+            f"{duration:.3f}",
+            "-c:v",
+            codec,
+            "-threads",
+            str(threads or 2),
+            "-pix_fmt",
+            "yuv420p",
+            output_file,
+        ]
+
+    def run_trim(codec: str):
+        result = subprocess.run(
+            build_command(codec),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            error_message = (result.stderr or result.stdout or "").strip()
+            raise RuntimeError(error_message or "ffmpeg trim failed")
+        return codec
+
+    effective_codec = _get_effective_video_codec()
+    try:
+        run_trim(effective_codec)
+    except Exception as exc:
+        if effective_codec == _DEFAULT_VIDEO_CODEC:
+            raise
+        run_trim(_DEFAULT_VIDEO_CODEC)
+        _disable_runtime_video_codec(effective_codec, str(exc))
+    return output_file
 
 
 def _sanitize_image_file(image_path: str) -> str:
@@ -564,9 +624,10 @@ def combine_videos(
         
     logger.debug(f"total subclipped items: {len(subclipped_items)}")
     
-    # Add downloaded clips over and over until the duration of the audio (max_duration) has been reached
+    # Keep a tiny source buffer for frame rounding during ffmpeg concat, then
+    # trim the combined output back to the narration duration below.
     for i, subclipped_item in enumerate(subclipped_items):
-        if video_duration >= audio_duration:
+        if _has_enough_video_duration(video_duration, audio_duration):
             break
         
         logger.debug(
@@ -655,12 +716,13 @@ def combine_videos(
         except Exception as e:
             logger.error(f"failed to process clip: {str(e)}")
     
-    # loop processed clips until the video duration matches or exceeds the audio duration.
-    if video_duration < audio_duration:
-        logger.warning(f"video duration ({video_duration:.2f}s) is shorter than audio duration ({audio_duration:.2f}s), looping clips to match audio length.")
+    # Loop processed clips until the video has a small buffer. The final output
+    # is still trimmed to audio_duration, so this does not create a silent tail.
+    if not _has_enough_video_duration(video_duration, audio_duration):
+        logger.warning(f"video duration ({video_duration:.2f}s) is shorter than audio duration ({audio_duration:.2f}s) with buffer, looping clips to match audio length.")
         base_clips = processed_clips.copy()
         for clip in itertools.cycle(base_clips):
-            if video_duration >= audio_duration:
+            if _has_enough_video_duration(video_duration, audio_duration):
                 break
             processed_clips.append(clip)
             video_duration += clip.duration
@@ -675,7 +737,15 @@ def combine_videos(
     # if there is only one clip, use it directly
     if len(processed_clips) == 1:
         logger.info("using single clip directly")
-        shutil.copy(processed_clips[0].file_path, combined_video_path)
+        if processed_clips[0].duration > audio_duration:
+            trim_video_with_ffmpeg(
+                input_file=processed_clips[0].file_path,
+                output_file=combined_video_path,
+                duration=audio_duration,
+                threads=threads,
+            )
+        else:
+            shutil.copy(processed_clips[0].file_path, combined_video_path)
         delete_files([processed_clips[0].file_path])
         logger.info("video combining completed")
         return combined_video_path
@@ -687,6 +757,7 @@ def combine_videos(
         output_file=combined_video_path,
         threads=threads,
         output_dir=output_dir,
+        max_duration=audio_duration,
     )
     
     # clean temp files

--- a/test/services/test_video.py
+++ b/test/services/test_video.py
@@ -325,6 +325,36 @@ class TestVideoService(unittest.TestCase):
         self.assertEqual(used_codecs, ["h264_nvenc", "libx264"])
         self.assertIn("h264_nvenc", vd._runtime_disabled_video_codecs)
 
+    def test_concat_video_clips_trims_to_audio_duration(self):
+        """
+        拼接阶段需要保留一点素材缓冲，但输出文件必须裁到旁白时长，避免
+        追加整段素材后产生明显静音尾巴。
+        """
+        commands = []
+
+        def fake_run(command, capture_output, text, check):
+            commands.append(command)
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            clip_file = os.path.join(temp_dir, "clip.mp4")
+            output_file = os.path.join(temp_dir, "combined.mp4")
+            Path(clip_file).write_bytes(b"fake")
+
+            with patch.object(vd.subprocess, "run", side_effect=fake_run):
+                vd.concat_video_clips_with_ffmpeg(
+                    clip_files=[clip_file],
+                    output_file=output_file,
+                    threads=1,
+                    output_dir=temp_dir,
+                    max_duration=10.0,
+                )
+
+        command = commands[0]
+        self.assertIn("-t", command)
+        self.assertEqual(command[command.index("-t") + 1], "10.000")
+        self.assertLess(command.index("-t"), command.index("-c:v"))
+
     def test_concat_video_clips_does_not_disable_codec_when_fallback_also_fails(self):
         """
         concat 阶段如果 libx264 也失败，说明可能是输入 list、路径或输出权限
@@ -439,6 +469,12 @@ class TestVideoService(unittest.TestCase):
                     video_transition_mode=None,
                 )
                 self.assertEqual(result, combined_video_path)
+
+    def test_video_duration_requires_safety_buffer(self):
+        """视频素材时长刚好等于音频时长时仍应继续补充一点缓冲。"""
+        self.assertFalse(vd._has_enough_video_duration(10.0, 10.0))
+        self.assertFalse(vd._has_enough_video_duration(10.09, 10.0))
+        self.assertTrue(vd._has_enough_video_duration(10.1, 10.0))
 
     def test_prioritize_unique_source_clips_uses_each_source_before_reuse(self):
         """


### PR DESCRIPTION
## Summary
- keep a small 0.1s source-video buffer before stopping clip accumulation to avoid frame rounding making the final video slightly shorter than narration
- trim the combined video back to the narration duration during ffmpeg concat or the single-clip path, so the buffer does not create a long silent tail
- add regression coverage for the buffer helper and ffmpeg `-t` trimming command

Fixes #985

## Testing
- `.venv/bin/python -m pytest test/services/test_video.py -q`
- `.venv/bin/python -m compileall app test`
- `git diff --check`