### PR TITLE
fix: rename misspelled video_contact_mode parameter to video_concat_mode

### DIFF
--- a/app/services/material.py
+++ b/app/services/material.py
@@ -306,7 +306,7 @@ def download_videos(
     search_terms: List[str],
     source: str = "pexels",
     video_aspect: VideoAspect = VideoAspect.portrait,
-    video_contact_mode: VideoConcatMode = VideoConcatMode.random,
+    video_concat_mode: VideoConcatMode = VideoConcatMode.random,
     audio_duration: float = 0.0,
     max_clip_duration: int = 5,
 ) -> List[str]:
@@ -344,7 +344,7 @@ def download_videos(
     elif material_directory and not os.path.isdir(material_directory):
         material_directory = ""
 
-    concat_mode_value = getattr(video_contact_mode, "value", video_contact_mode)
+    concat_mode_value = getattr(video_concat_mode, "value", video_concat_mode)
     if concat_mode_value == VideoConcatMode.random.value:
         random.shuffle(valid_video_items)
 

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -183,7 +183,7 @@ def get_video_materials(task_id, params, video_terms, audio_duration):
             search_terms=video_terms,
             source=params.video_source,
             video_aspect=params.video_aspect,
-            video_contact_mode=params.video_concat_mode,
+            video_concat_mode=params.video_concat_mode,
             audio_duration=audio_duration * params.video_count,
             max_clip_duration=params.video_clip_duration,
         )

--- a/test/services/test_material.py
+++ b/test/services/test_material.py
@@ -124,7 +124,7 @@ class TestMaterialTlsVerification(unittest.TestCase):
         result = material.download_videos(
             task_id="string-concat-mode",
             search_terms=[],
-            video_contact_mode="random",
+            video_concat_mode="random",
         )
 
         self.assertEqual(result, [])


### PR DESCRIPTION
## What

Renames the `download_videos()` parameter `video_contact_mode` to `video_concat_mode` ("contact" was a misspelling of "concat").

## Why

The parameter definition in `app/services/material.py`, its call site in `app/services/task.py`, and the test in `test/services/test_material.py` were all consistently misspelled, so the code worked — but the name was inconsistent with `video_concat_mode` used everywhere else in the codebase (`VideoParams` schema, video service, webui). This makes the API consistent and less confusing.

## Changes

- `app/services/material.py`: parameter definition + internal usage
- `app/services/task.py`: keyword argument at the call site
- `test/services/test_material.py`: keyword argument in test

## Testing

All 11 tests in `test/services/test_material.py` pass:

```
Ran 11 tests in 0.003s
OK
```

No functional change — pure rename, no external API or config key involved.