### PR TITLE
Add AIML API provider

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -51,7 +51,7 @@ materials, video subtitles, and video background music before synthesizing a hig
 - [x] Supports **background music**, either random or specified music files, with adjustable `background music volume`
 - [x] Video material sources are **high-definition** and **royalty-free**, and you can also use your own **local materials**
 - [x] Supports multiple stock video providers: **Pexels**, **Pixabay**, and **Coverr** (free HD/4K stock videos, subject to [Coverr license terms](https://coverr.co/license); mostly 16:9 landscape; register at [coverr.co/developers](https://coverr.co/developers?ctx=header_navigation), Demo tier 50 requests/hour)
-- [x] Supports integration with various models such as **OpenAI**, **AIHubMix**, **Moonshot**, **Azure**, **gpt4free**, **one-api**, **Qwen**, **Google Gemini**, **Ollama**, **DeepSeek**, **MiniMax**, **ERNIE**, **Pollinations**, **ModelScope** and more
+- [x] Supports integration with various models such as **OpenAI**, **AIHubMix**, **AIML API**, **Moonshot**, **Azure**, **gpt4free**, **one-api**, **Qwen**, **Google Gemini**, **Ollama**, **DeepSeek**, **MiniMax**, **ERNIE**, **Pollinations**, **ModelScope** and more
 
 ## Video Demos 📺
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 - [x] 支持 **背景音乐**，随机或者指定音乐文件，可设置`背景音乐音量`
 - [x] 视频素材来源 **高清**，而且 **无版权**，也可以使用自己的 **本地素材**
 - [x] 支持多种素材源:**Pexels**、**Pixabay**、**Coverr**(免费高清/4K 素材库,使用须遵守 [Coverr 许可条款](https://coverr.co/license),以 16:9 横屏为主;在 [coverr.co/developers](https://coverr.co/developers?ctx=header_navigation) 注册即可,Demo 套餐 50 次/小时)
-- [x] 支持 **OpenAI**、**AIHubMix**、**Moonshot**、**Azure**、**gpt4free**、**one-api**、**通义千问**、**Google Gemini**、**Ollama**、**DeepSeek**、**MiniMax**、 **文心一言**, **Pollinations**、**ModelScope** 等多种模型接入
+- [x] 支持 **OpenAI**、**AIHubMix**、**AIML API**、**Moonshot**、**Azure**、**gpt4free**、**one-api**、**通义千问**、**Google Gemini**、**Ollama**、**DeepSeek**、**MiniMax**、 **文心一言**, **Pollinations**、**ModelScope** 等多种模型接入
 
 ## 视频演示 📺
 

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -181,6 +181,14 @@ def _generate_response(prompt: str) -> str:
                     base_url = "https://aihubmix.com/v1"
                 if not model_name:
                     model_name = "gpt-5.4-mini"
+            elif llm_provider == "aimlapi":
+                api_key = config.app.get("aimlapi_api_key")
+                model_name = config.app.get("aimlapi_model_name")
+                base_url = config.app.get("aimlapi_base_url", "")
+                if not base_url:
+                    base_url = "https://api.aimlapi.com/v1"
+                if not model_name:
+                    model_name = "openai/gpt-4o-mini"
             elif llm_provider == "oneapi":
                 api_key = config.app.get("oneapi_api_key")
                 model_name = config.app.get("oneapi_model_name")

--- a/config.example.toml
+++ b/config.example.toml
@@ -45,6 +45,7 @@ coverr_api_keys = []
 # 支持的提供商 (Supported providers):
 #   openai
 #   aihubmix   (OpenAI-compatible AI model gateway)
+#   aimlapi     (OpenAI-compatible multi-model AI API)
 #   moonshot    (月之暗面)
 #   azure
 #   qwen        (通义千问)
@@ -94,6 +95,13 @@ openai_model_name = "gpt-4o-mini"
 aihubmix_api_key = ""
 aihubmix_base_url = "https://aihubmix.com/v1"
 aihubmix_model_name = "gpt-5.4-mini"
+
+########## AIML API Key
+# AIML API is OpenAI-compatible and can use one API key to access multiple model families.
+# Visit https://aimlapi.com/app/keys to create your API key.
+aimlapi_api_key = ""
+aimlapi_base_url = "https://api.aimlapi.com/v1"
+aimlapi_model_name = "openai/gpt-4o-mini"
 
 ########## Moonshot API Key
 # Visit https://platform.moonshot.cn/console/api-keys to get your API key.

--- a/test/services/test_llm.py
+++ b/test/services/test_llm.py
@@ -331,6 +331,43 @@ class TestLiteLLMProvider(unittest.TestCase):
         )
         self.assertEqual(result, "helloaihubmix")
 
+    def test_aimlapi_provider_uses_openai_compatible_client(self):
+        config.app["llm_provider"] = "aimlapi"
+        config.app["aimlapi_api_key"] = "aimlapi-key"
+        config.app["aimlapi_base_url"] = ""
+        config.app["aimlapi_model_name"] = ""
+
+        class FakeCompletions:
+            def create(self, **kwargs):
+                self.kwargs = kwargs
+                message = types.SimpleNamespace(content="hello\naimlapi")
+                choice = types.SimpleNamespace(message=message)
+                return types.SimpleNamespace(choices=[choice])
+
+        fake_completions = FakeCompletions()
+        fake_client = types.SimpleNamespace(
+            chat=types.SimpleNamespace(completions=fake_completions)
+        )
+
+        with (
+            patch.object(llm, "OpenAI", return_value=fake_client) as openai_client,
+            patch.object(llm, "ChatCompletion", types.SimpleNamespace),
+        ):
+            result = llm._generate_response("Say hello")
+
+        openai_client.assert_called_once_with(
+            api_key="aimlapi-key",
+            base_url="https://api.aimlapi.com/v1",
+        )
+        self.assertEqual(
+            fake_completions.kwargs,
+            {
+                "model": "openai/gpt-4o-mini",
+                "messages": [{"role": "user", "content": "Say hello"}],
+            },
+        )
+        self.assertEqual(result, "helloaimlapi")
+
     def test_grok_provider_still_uses_existing_path(self):
         config.app["llm_provider"] = "grok"
         config.app["grok_api_key"] = ""

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -284,6 +284,7 @@ if not config.app.get("hide_config", False):
             llm_provider_options = [
                 ("OpenAI", "openai"),
                 (aihubmix_label, "aihubmix"),
+                ("AIML API", "aimlapi"),
                 ("Moonshot", "moonshot"),
                 ("Azure", "azure"),
                 ("Qwen", "qwen"),
@@ -379,6 +380,19 @@ if not config.app.get("hide_config", False):
                             - **稳定**: 无限并发，永远在线，集群部署于谷歌云，长期为众多知名应用提供高并发服务
                             - **能力完整**: 文本、图片生成、视频生成、TTS、STT、向量嵌入、Rerank，多模态场景全搞定
                             - **计费透明**: 按量付费，无会员无包月，免费模型可使用
+                            """
+
+            if llm_provider == "aimlapi":
+                if not llm_model_name:
+                    llm_model_name = "openai/gpt-4o-mini"
+                if not llm_base_url:
+                    llm_base_url = "https://api.aimlapi.com/v1"
+                with llm_helper:
+                    tips = """
+                            ##### AIML API Configuration
+                            - **API Key**: create one at https://aimlapi.com/app/keys
+                            - **Base Url**: https://api.aimlapi.com/v1
+                            - **Model Name**: for example `openai/gpt-4o-mini`, `openai/gpt-4o`, `anthropic/claude-sonnet-4.5`, or `google/gemini-3-flash-preview`
                             """
 
             if llm_provider == "moonshot":


### PR DESCRIPTION
## Summary
- add AIML API as an OpenAI-compatible LLM provider
- expose AIML API settings in config.example.toml and WebUI provider setup
- document AIML API in the provider list and add a unit test for the OpenAI-compatible client path

Closes #1017

## Test plan
- `uv run python -m unittest test.services.test_llm -v` passed: 49 tests, 1 skipped
- `uv run python -m unittest discover -s test -v` currently fails locally on Windows cp1251 console encoding in `services.test_video.TestVideoService.test_wrap_text` while printing Chinese text; the AIML API provider test passes before that unrelated failure