### PR TITLE
fix: default pollinations_base_url points to a dead endpoint (405)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -65,8 +65,12 @@ llm_provider = "openai"
 # Visit https://pollinations.ai/ to learn more
 # API Key is optional - leave empty for public access
 pollinations_api_key = ""
-# Default base URL for Pollinations API
-pollinations_base_url = "https://pollinations.ai/api/v1"
+# Base URL for Pollinations API.
+# Leave empty to use the default endpoint (https://text.pollinations.ai/openai).
+# Note: the old "https://pollinations.ai/api/v1" endpoint no longer accepts
+# requests (returns 405 Method Not Allowed), so only set this if you have a
+# working custom endpoint.
+pollinations_base_url = ""
 # Default model for text generation
 pollinations_model_name = "openai-fast"
 


### PR DESCRIPTION
## What changed

Changed the default `pollinations_base_url` in `config.example.toml` from `"https://pollinations.ai/api/v1"` to `""` (empty), and updated the comment to document the fallback behavior.

## Why

The endpoint shipped in the example config no longer accepts requests:

```
failed to generate video script: Error: request failed:
405 Client Error: Method Not Allowed for url: https://pollinations.ai/api/v1
```

Anyone who selects `llm_provider = "pollinations"` with the default config gets this failure on their first video task.

The provider implementation in `app/services/llm.py` already handles an empty `pollinations_base_url` correctly by falling back to the working endpoint:

```python
base_url = config.app.get("pollinations_base_url", "")
if not base_url:
    base_url = "https://text.pollinations.ai/openai"
```

So shipping an empty default makes the pollinations provider work out of the box.

## How it was verified

Reproduced on Windows 11 / v1.3.0:
1. Set `llm_provider = "pollinations"` with the shipped default URL → task fails with the 405 above.
2. Set `pollinations_base_url = ""` → request reaches `https://text.pollinations.ai/openai` and script generation works (modulo anonymous-tier rate limits, which are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)