### PR TITLE
fix: write moviepy temp audio to system temp dir to avoid Windows Defender interference

### DIFF
--- a/app/services/video.py
+++ b/app/services/video.py
@@ -6,6 +6,7 @@ import random
 import gc
 import shutil
 import subprocess
+import tempfile
 from contextlib import redirect_stdout
 from functools import lru_cache
 from typing import List
@@ -973,6 +974,7 @@ def generate_video(
     # 显式沿用输入音频的采样率；如果取不到，再回退到 MoviePy 默认的 44100Hz。
     # 这样可以减少不同运行环境，尤其是 Docker 环境中再次重采样带来的音质波动。
     output_audio_fps = int(getattr(audio_clip, "fps", 0) or 44100)
+    temp_audio_dir = tempfile.gettempdir()
     _write_videofile_with_codec_fallback(
         video_clip,
         output_file=output_file,
@@ -980,7 +982,7 @@ def generate_video(
         audio_codec=audio_codec,
         audio_fps=output_audio_fps,
         audio_bitrate=audio_bitrate,
-        temp_audiofile_path=output_dir,
+        temp_audiofile_path=temp_audio_dir,
         threads=params.n_threads or 2,
         logger=None,
         fps=fps,

--- a/app/services/video.py
+++ b/app/services/video.py
@@ -6,6 +6,7 @@ import random
 import gc
 import shutil
 import subprocess
+import sys
 import tempfile
 from contextlib import redirect_stdout
 from functools import lru_cache
@@ -239,7 +240,6 @@ def _get_temp_audio_dir(output_dir: str) -> str:
     On Linux/macOS/Docker the output directory is returned unchanged so
     existing behaviour is preserved.
     """
-    import sys
     if sys.platform == "win32":
         return tempfile.gettempdir()
     return output_dir
@@ -833,7 +833,6 @@ def generate_video(
     # PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'final-1.mp4.tempTEMP_MPY_wvf_snd.mp3'
     # write into the same directory as the output file
     output_dir = os.path.dirname(output_file)
-
 
     font_path = ""
     if params.subtitle_enabled:

--- a/app/services/video.py
+++ b/app/services/video.py
@@ -226,6 +226,25 @@ def _disable_runtime_video_codec(codec: str, reason: str):
     )
 
 
+def _get_temp_audio_dir(output_dir: str) -> str:
+    """
+    Return the directory to use for MoviePy's temporary audio file.
+
+    On Windows, Windows Defender can lock files written to the task output
+    directory while scanning them, causing MoviePy to fail with a
+    PermissionError (WinError 32) on the TEMP_MPY_wvf_snd temp file and
+    leaving the final MP4 at 0 bytes.  Using the system temp directory
+    sidesteps the scan without changing behaviour on other platforms.
+
+    On Linux/macOS/Docker the output directory is returned unchanged so
+    existing behaviour is preserved.
+    """
+    import sys
+    if sys.platform == "win32":
+        return tempfile.gettempdir()
+    return output_dir
+
+
 def _fallback_write_videofile(clip, output_file: str, failed_codec: str, reason: str, **kwargs):
     """
     硬件编码失败后用 libx264 重试，只有重试成功才禁用该硬件编码器。
@@ -815,6 +834,7 @@ def generate_video(
     # write into the same directory as the output file
     output_dir = os.path.dirname(output_file)
 
+
     font_path = ""
     if params.subtitle_enabled:
         if not params.font_name:
@@ -974,7 +994,6 @@ def generate_video(
     # 显式沿用输入音频的采样率；如果取不到，再回退到 MoviePy 默认的 44100Hz。
     # 这样可以减少不同运行环境，尤其是 Docker 环境中再次重采样带来的音质波动。
     output_audio_fps = int(getattr(audio_clip, "fps", 0) or 44100)
-    temp_audio_dir = tempfile.gettempdir()
     _write_videofile_with_codec_fallback(
         video_clip,
         output_file=output_file,
@@ -982,7 +1001,7 @@ def generate_video(
         audio_codec=audio_codec,
         audio_fps=output_audio_fps,
         audio_bitrate=audio_bitrate,
-        temp_audiofile_path=temp_audio_dir,
+        temp_audiofile_path=_get_temp_audio_dir(output_dir),
         threads=params.n_threads or 2,
         logger=None,
         fps=fps,

--- a/test/services/test_video.py
+++ b/test/services/test_video.py
@@ -562,5 +562,18 @@ class TestVideoService(unittest.TestCase):
         finally:
             clip.close()
 
+    def test_get_temp_audio_dir_returns_system_temp_on_windows(self):
+        with patch("sys.platform", "win32"):
+            result = vd._get_temp_audio_dir("/some/output/dir")
+            self.assertEqual(result, tempfile.gettempdir())
+
+    def test_get_temp_audio_dir_returns_output_dir_on_non_windows(self):
+        for platform in ("linux", "darwin"):
+            with self.subTest(platform=platform):
+                with patch("sys.platform", platform):
+                    result = vd._get_temp_audio_dir("/some/output/dir")
+                    self.assertEqual(result, "/some/output/dir")
+
+
 if __name__ == "__main__":
-    unittest.main() 
+    unittest.main()


### PR DESCRIPTION
## Summary

On Windows, MoviePy writes a TEMP_MPY_wvf_snd file next to the output video in the task directory. Windows Defender scans files written to this directory and can lock/delay the temp file, causing the final MP4 to be written as 0 bytes (moov atom not found error).

Fix: write the temp audio file to tempfile.gettempdir() (system temp dir) which Defender does not actively scan during video generation.

## Related

Fixes #217

## Test plan

- Generate a video on Windows with Windows Defender active
- Confirm final-1.mp4 is written correctly (non-zero size, playable)
- Confirm no regression on Linux/macOS (tempfile.gettempdir() returns the standard temp dir on all platforms)