### PR TITLE
Prevent Streamlit first-run prompt from blocking WebUI startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ COPY . .
 EXPOSE 8501
 
 # Command to run the application
-CMD ["streamlit", "run", "./webui/Main.py","--browser.serverAddress=127.0.0.1","--server.enableCORS=True","--browser.gatherUsageStats=False"]
+CMD ["streamlit", "run", "./webui/Main.py","--browser.serverAddress=127.0.0.1","--server.enableCORS=True","--browser.gatherUsageStats=False","--server.showEmailPrompt=False"]
 
 # 1. Build the Docker image using the following command
 # docker build -t moneyprinterturbo .

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -52,4 +52,4 @@ COPY . .
 EXPOSE 8501
 
 # Command to run the application
-CMD ["streamlit", "run", "./webui/Main.py","--browser.serverAddress=127.0.0.1","--server.enableCORS=True","--browser.gatherUsageStats=False"]
+CMD ["streamlit", "run", "./webui/Main.py","--browser.serverAddress=127.0.0.1","--server.enableCORS=True","--browser.gatherUsageStats=False","--server.showEmailPrompt=False"]

--- a/README-ar.md
+++ b/README-ar.md
@@ -220,7 +220,7 @@ sudo yum install ImageMagick
 ###### Windows
 
 ```shell
-uv run streamlit run ./webui/Main.py --browser.gatherUsageStats=False
+uv run streamlit run ./webui/Main.py --browser.gatherUsageStats=False --server.showEmailPrompt=False
 ```
 
 إذا كنت قد فعّلت البيئة الافتراضية يدوياً، فما زال بإمكانك تشغيل:
@@ -232,7 +232,7 @@ webui.bat
 ###### MacOS أو Linux
 
 ```shell
-uv run streamlit run ./webui/Main.py --browser.gatherUsageStats=False
+uv run streamlit run ./webui/Main.py --browser.gatherUsageStats=False --server.showEmailPrompt=False
 ```
 
 إذا كنت قد فعّلت البيئة الافتراضية يدوياً، فما زال بإمكانك تشغيل:

--- a/README-en.md
+++ b/README-en.md
@@ -251,7 +251,7 @@ To allow other devices on your LAN to access the WebUI, run `set MPT_WEBUI_HOST=
 ###### MacOS or Linux
 
 ```shell
-uv run streamlit run ./webui/Main.py --browser.gatherUsageStats=False
+uv run streamlit run ./webui/Main.py --browser.gatherUsageStats=False --server.showEmailPrompt=False
 ```
 
 If you have already activated the virtual environment manually, you can still run:

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ pip install -r requirements.txt
 ###### MacOS or Linux
 
 ```shell
-uv run streamlit run ./webui/Main.py --browser.gatherUsageStats=False
+uv run streamlit run ./webui/Main.py --browser.gatherUsageStats=False --server.showEmailPrompt=False
 ```
 
 如果你已经手动激活了虚拟环境，也可以直接执行：

--- a/config.example.toml
+++ b/config.example.toml
@@ -19,6 +19,8 @@ tls_verify = true
 # Register at https://www.pexels.com/api/ to get your API key.
 # You can use multiple keys to avoid rate limits.
 # For example: pexels_api_keys = ["123adsf4567adf89","abd1321cd13efgfdfhi"]
+# Use straight ASCII double quotes around each key. Smart quotes copied from rich text will break TOML parsing.
+# 请使用英文半角双引号包裹每个 Key；从富文本复制来的弯引号会导致 TOML 解析失败。
 # 特别注意格式，Key 用英文双引号括起来，多个Key用逗号隔开
 pexels_api_keys = []
 
@@ -26,6 +28,8 @@ pexels_api_keys = []
 # Register at https://pixabay.com/api/docs/ to get your API key.
 # You can use multiple keys to avoid rate limits.
 # For example: pixabay_api_keys = ["123adsf4567adf89","abd1321cd13efgfdfhi"]
+# Use straight ASCII double quotes around each key. Smart quotes copied from rich text will break TOML parsing.
+# 请使用英文半角双引号包裹每个 Key；从富文本复制来的弯引号会导致 TOML 解析失败。
 # 特别注意格式，Key 用英文双引号括起来，多个Key用逗号隔开
 pixabay_api_keys = []
 
@@ -39,6 +43,8 @@ pixabay_api_keys = []
 # and use Coverr to widen the catalog for landscape/cinematic content.
 # You can use multiple keys to avoid rate limits.
 # For example: coverr_api_keys = ["123adsf4567adf89","abd1321cd13efgfdfhi"]
+# Use straight ASCII double quotes around each key. Smart quotes copied from rich text will break TOML parsing.
+# 请使用英文半角双引号包裹每个 Key；从富文本复制来的弯引号会导致 TOML 解析失败。
 # 特别注意格式，Key 用英文双引号括起来，多个Key用逗号隔开
 coverr_api_keys = []
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     container_name: "moneyprinterturbo-webui"
     ports:
       - "127.0.0.1:8501:8501"
-    command: [ "streamlit", "run", "./webui/Main.py","--browser.serverAddress=127.0.0.1","--server.enableCORS=True","--browser.gatherUsageStats=False" ]
+    command: [ "streamlit", "run", "./webui/Main.py","--browser.serverAddress=127.0.0.1","--server.enableCORS=True","--browser.gatherUsageStats=False","--server.showEmailPrompt=False" ]
     volumes: *common-volumes
     restart: always
   api:

--- a/webui.bat
+++ b/webui.bat
@@ -49,4 +49,4 @@ if not "%SELECTED_WEBUI_PORT%"=="%MPT_WEBUI_PORT%" (
 set "MPT_WEBUI_PORT=%SELECTED_WEBUI_PORT%"
 
 echo ***** WebUI address: http://%MPT_WEBUI_HOST%:%MPT_WEBUI_PORT% *****
-%STREAMLIT_CMD% run .\webui\Main.py --server.address=%MPT_WEBUI_HOST% --server.port=%MPT_WEBUI_PORT% --browser.serverAddress=%MPT_WEBUI_HOST% --browser.gatherUsageStats=False --server.enableCORS=True
+%STREAMLIT_CMD% run .\webui\Main.py --server.address=%MPT_WEBUI_HOST% --server.port=%MPT_WEBUI_PORT% --browser.serverAddress=%MPT_WEBUI_HOST% --browser.gatherUsageStats=False --server.showEmailPrompt=False --server.enableCORS=True

--- a/webui.sh
+++ b/webui.sh
@@ -75,4 +75,5 @@ echo "***** WebUI address: http://$MPT_WEBUI_HOST:$MPT_WEBUI_PORT *****"
   --server.port="$MPT_WEBUI_PORT" \
   --browser.serverAddress="$MPT_WEBUI_HOST" \
   --browser.gatherUsageStats=False \
+  --server.showEmailPrompt=False \
   --server.enableCORS=True


### PR DESCRIPTION
## Summary
- Disable Streamlit's first-run email prompt across WebUI launch paths so startup does not block before the dashboard is available.
- Update README launch examples to include the same Streamlit flag.
- Clarify API key quote formatting in `config.example.toml` in English and Chinese to avoid TOML parse errors from smart quotes.

## Validation
- `python -c "import tomllib; tomllib.load(open('config.example.toml','rb')); print('config.example.toml parsed OK')"`
- `git diff --cached --check`
