### PR TITLE
fix(cli): validate --video-source local constraints at parse time

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -52,7 +52,18 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="enable subtitles (default: enabled, use --no-subtitle-enabled to disable)",
     )
     parser.add_argument("--task-id", default="", help="custom task id")
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+
+    if args.video_source == "local" and not (args.video_materials or "").strip():
+        parser.error("--video-materials is required when --video-source is local")
+
+    if args.video_source == "local" and args.stop_at == "terms":
+        parser.error(
+            "--stop-at terms has no effect with --video-source local "
+            "(search terms are not generated for local sources)"
+        )
+
+    return args
 
 
 def build_video_params(args: argparse.Namespace) -> VideoParams:

--- a/test/services/test_cli.py
+++ b/test/services/test_cli.py
@@ -105,5 +105,21 @@ class TestCli(unittest.TestCase):
                 os.remove(test_filepath)
 
 
+    def test_local_source_requires_video_materials(self):
+        with self.assertRaises(SystemExit) as cm:
+            cli.parse_args(["--video-subject", "test", "--video-source", "local"])
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_local_source_stop_at_terms_rejected(self):
+        with self.assertRaises(SystemExit) as cm:
+            cli.parse_args([
+                "--video-subject", "test",
+                "--video-source", "local",
+                "--video-materials", "a.mp4",
+                "--stop-at", "terms",
+            ])
+        self.assertNotEqual(cm.exception.code, 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #1032

## What

Two validation gaps in `cli.py` when `--video-source local` is used:

**Bug 1 — late failure when `--video-materials` is missing**

Without this fix, omitting `--video-materials` with `--video-source local` allows the pipeline to run through LLM script generation, TTS audio, and subtitle generation before failing at the materials step with a generic "no valid materials found" message. All that work is wasted.

**Bug 2 — `--stop-at terms` silently returns empty terms**

`"terms"` is listed as a valid `--stop-at` choice, but `generate_terms()` is intentionally skipped for local sources in `task.py`. This caused the pipeline to return `{"terms": ""}` with no error or warning.

## Fix

Both constraints are now checked in `parse_args()` via `parser.error()`, which exits immediately with a clear message before any work begins:

```
error: --video-materials is required when --video-source is local
error: --stop-at terms has no effect with --video-source local (search terms are not generated for local sources)
```

## Changes

- `cli.py` — two `parser.error()` guards added at the end of `parse_args()`
- `test/services/test_cli.py` — two tests covering the new validation paths