### PR TITLE
[codex] Run full unit test suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Compile Python sources
         run: uv run python -m compileall app cli.py main.py webui test
 
-      - name: Run deterministic unit tests
-        run: uv run python -X utf8 -m unittest test.services.test_state test.services.test_task test.services.test_schema test.services.test_webui_i18n
+      - name: Run unit tests
+        run: uv run python -X utf8 -m unittest discover -s test

--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1019,7 +1019,10 @@ def gemini_tts(
             return None
         
         # 导出为MP3格式
-        audio_segment.export(voice_file, format="mp3")
+        ensure_file_path_exists(voice_file)
+        export_handle = audio_segment.export(voice_file, format="mp3")
+        if hasattr(export_handle, "close"):
+            export_handle.close()
         
         logger.info(f"completed, output file: {voice_file}")
         


### PR DESCRIPTION
## Summary

- Run the full unittest discovery suite in CI instead of a fixed subset of four test modules.
- Ensure Gemini TTS creates the output directory before exporting MP3 audio and closes the export handle.

## Why

`python -m unittest discover -s test` currently exercises the existing deterministic tests, but the CI workflow only ran a small subset. Enabling discovery keeps future `test_*.py` files covered automatically. While validating the full suite, the Gemini TTS test exposed that its MP3 export path did not create the target directory first.

## Validation

- `.venv/bin/python -m compileall app cli.py main.py webui test`
- `.venv/bin/python -X utf8 -m unittest discover -s test`