### PR TITLE
fix(llm): sanitize embedded credentials from LLM error messages

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -547,7 +547,12 @@ def _generate_response(prompt: str) -> str:
 
         return _normalize_text_response(content, llm_provider)
     except Exception as e:
-        return f"Error: {str(e)}"
+        return f"Error: {_sanitize_error_message(e)}"
+
+
+def _sanitize_error_message(msg) -> str:
+    """Strip embedded credentials from any URLs that appear in exception messages."""
+    return re.sub(r"(https?://)([^:@/\s]+:[^@/\s]+@)", r"\1***:***@", str(msg))
 
 
 def _limit_script_text(text: str | None, max_length: int, field_name: str) -> str:


### PR DESCRIPTION
## Summary

Closes / references #1049 (as requested in the discussion on #986).

When a provider is configured with a `*_base_url` that contains embedded credentials (`https://user:pass@host/...`), the OpenAI SDK may raise an exception whose `str()` representation includes the raw URL. The outer `except Exception as e: return f"Error: {str(e)}"` block in `_generate_response` was surfacing that string verbatim, leaking credentials into:

- API responses returned to callers
- Any logging layer that records return values

## Fix

Added `_sanitize_error_message()` — a one-liner regex that strips the `userinfo@` component from any `http://` or `https://` URL found in the exception message — and routed the except block through it:

```python
def _sanitize_error_message(msg) -> str:
    """Strip embedded credentials from any URLs that appear in exception messages."""
    return re.sub(r"(https?://)([^:@/\s]+:[^@/\s]+@)", r"\1***:***@", str(msg))

# before:
except Exception as e:
    return f"Error: {str(e)}"

# after:
except Exception as e:
    return f"Error: {_sanitize_error_message(e)}"
```

`re` is already imported in the module so no new dependency is introduced.

## Test plan

- [ ] Configure any provider with `base_url = "https://myuser:mysecret@proxy.example.com/v1"` and trigger an exception (e.g. bad API key, network timeout)
- [ ] Confirm the returned error string shows `https://***:***@proxy.example.com/v1` instead of the raw credentials
- [ ] Confirm normal error messages (no URL) are returned unchanged