### PR TITLE
fix(api): expose match_materials_to_script in /terms endpoint

### DIFF
--- a/app/controllers/v1/llm.py
+++ b/app/controllers/v1/llm.py
@@ -44,6 +44,7 @@ def generate_video_terms(request: Request, body: VideoTermsRequest):
         video_subject=body.video_subject,
         video_script=body.video_script,
         amount=body.amount,
+        match_script_order=body.match_materials_to_script,
     )
     response = {"video_terms": video_terms}
     return utils.get_response(200, response)

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -168,7 +168,8 @@ class VideoTermsParams:
     {
       "video_subject": "",
       "video_script": "",
-      "amount": 5
+      "amount": 5,
+      "match_materials_to_script": false
     }
     """
 
@@ -177,6 +178,7 @@ class VideoTermsParams:
         "春天的花海，如诗如画般展现在眼前。万物复苏的季节里，大地披上了一袭绚丽多彩的盛装。金黄的迎春、粉嫩的樱花、洁白的梨花、艳丽的郁金香……"
     )
     amount: Optional[int] = 5
+    match_materials_to_script: bool = False
 
 
 class VideoSocialMetadataParams:


### PR DESCRIPTION
## What's the bug

Commit 552f056 added `match_materials_to_script` to `VideoParams` and correctly wired it through `task.py` → `material.py`. But `VideoTermsParams` was not updated, and the `/terms` controller still calls `generate_terms()` without `match_script_order`.

**Result:** calling `POST /api/v1/llm/terms` with `"match_materials_to_script": true` silently ignores the flag — `generate_terms()` always uses the relevance-ordered prompt, never the chronological one.

## Root cause

```python
# app/controllers/v1/llm.py — match_script_order never passed
video_terms = llm.generate_terms(
    video_subject=body.video_subject,
    video_script=body.video_script,
    amount=body.amount,
    # match_script_order missing ← always defaults to False
)
```

`VideoTermsParams` also has no `match_materials_to_script` field, so the body field is dropped at parse time even if a caller sends it.

## Fix

Two changes:

1. **`app/models/schema.py`** — add `match_materials_to_script: bool = False` to `VideoTermsParams`
2. **`app/controllers/v1/llm.py`** — pass `match_script_order=body.match_materials_to_script` to `generate_terms()`

Default is `False`, so existing callers are completely unaffected.

## How I found it

I was doing a commit-by-commit review of recent changes using a static analysis tool I built for catching inter-module gaps like this — where a new field added to one schema doesn't get propagated to sibling schemas. The tool flagged that `VideoTermsParams` was not updated alongside `VideoParams` in 552f056. I then manually traced the call path (`VideoTermsRequest` → controller → `generate_terms()`) to confirm the flag was silently dropped end-to-end.

(Happy to share more about the tool if you're curious.)

## Test

```bash
# Before fix: flag ignored, relevance-ordered terms always returned
curl -X POST /api/v1/llm/terms \
  -d '{"video_subject":"春天","video_script":"...","amount":5,"match_materials_to_script":true}'

# After fix: generate_terms() receives match_script_order=True,
# uses the chronological prompt and returns script-ordered terms
```