### PR TITLE
feat: import .txt/.md file into the WebUI video script field

### DIFF
--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -243,6 +243,45 @@ def split_string_by_punctuations(s):
     return result
 
 
+def strip_markdown(text: str) -> str:
+    text = text or ""
+    cleaned_lines = []
+    removed_separator = False
+
+    for line in text.splitlines():
+        line = re.sub(r"!\[[^\]]*\]\([^)]+\)", "", line)
+        line = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", line)
+        line = re.sub(r"\[([^\]]+)\]\[[^\]]*\]", r"\1", line)
+
+        stripped_line = line.strip()
+        if any(
+            re.fullmatch(pattern, stripped_line)
+            for pattern in (r"(?:-\s*){3,}", r"(?:\*\s*){3,}", r"(?:_\s*){3,}")
+        ):
+            removed_separator = True
+            continue
+
+        heading_match = re.match(r"^\s{0,3}#{1,6}\s+(.*?)\s*#*\s*$", line)
+        if heading_match:
+            line = heading_match.group(1)
+        else:
+            line = re.sub(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)", "", line)
+            line = re.sub(r"^\s*\[[ xX]\]\s+", "", line)
+
+        line = re.sub(r"(`+)(.*?)\1", r"\2", line)
+        line = re.sub(r"(\*\*|__)(.*?)\1", r"\2", line)
+        line = re.sub(r"(~~)(.*?)\1", r"\2", line)
+        line = re.sub(r"(?<!\*)\*([^*\n]+)\*(?!\*)", r"\1", line)
+        line = re.sub(r"(?<!_)_([^_\n]+)_(?!_)", r"\1", line)
+        line = re.sub(r"[ \t]{2,}", " ", line)
+        cleaned_lines.append(line.strip())
+
+    cleaned_text = "\n".join(cleaned_lines).strip()
+    if removed_separator:
+        cleaned_text = re.sub(r"\n{3,}", "\n\n", cleaned_text)
+    return cleaned_text
+
+
 def normalize_script_for_subtitle_matching(video_script: str) -> str:
     """
     清理字幕匹配前的脚本文本。

--- a/test/services/test_utils.py
+++ b/test/services/test_utils.py
@@ -1,0 +1,55 @@
+import sys
+import unittest
+from pathlib import Path
+
+# 测试文件直接运行时，也能从仓库根目录导入 app 包。
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from app.utils import utils
+
+
+class TestUtils(unittest.TestCase):
+    def test_strip_markdown_removes_common_script_formatting(self):
+        source = (
+            "# Launch Plan\n"
+            "\n"
+            "Opening with **bold** energy.\n"
+            "\n"
+            "---\n"
+            "\n"
+            "- First beat\n"
+            "1. Second beat"
+        )
+
+        self.assertEqual(
+            utils.strip_markdown(source),
+            "Launch Plan\n\nOpening with bold energy.\n\nFirst beat\nSecond beat",
+        )
+
+    def test_strip_markdown_leaves_plain_text_unchanged(self):
+        source = "First line.\nSecond line with 1.5 values.\nNo markdown tokens here."
+
+        self.assertEqual(utils.strip_markdown(source), source)
+
+    def test_strip_markdown_handles_empty_and_whitespace_only_text(self):
+        self.assertEqual(utils.strip_markdown(""), "")
+        self.assertEqual(utils.strip_markdown(" \n\t\n "), "")
+
+    def test_strip_markdown_cleans_links_and_images(self):
+        source = (
+            "Read [the docs](https://example.com/docs) before recording.\n"
+            "![cover image](https://example.com/cover.png)\n"
+            "Keep [reference label][ref]."
+        )
+
+        cleaned = utils.strip_markdown(source)
+
+        self.assertEqual(
+            cleaned,
+            "Read the docs before recording.\n\nKeep reference label.",
+        )
+        self.assertNotIn("https://example.com", cleaned)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -854,8 +854,38 @@ with left_panel:
                 else:
                     st.session_state["video_script"] = script
                     st.session_state["video_terms"] = ", ".join(terms)
+
+        uploaded_script_file = st.file_uploader(
+            tr("Import Script File"),
+            type=["txt", "md"],
+            key="video_script_file_uploader",
+        )
+        if uploaded_script_file is not None:
+            uploaded_script_bytes = uploaded_script_file.getvalue()
+            try:
+                uploaded_script_text = uploaded_script_bytes.decode("utf-8")
+            except UnicodeDecodeError:
+                st.error(tr("Uploaded script file must be UTF-8 encoded"))
+            else:
+                uploaded_script_signature = (
+                    f"{uploaded_script_file.name}:{len(uploaded_script_bytes)}:"
+                    f"{utils.md5(uploaded_script_text)}"
+                )
+                if (
+                    st.session_state.get("video_script_file_signature")
+                    != uploaded_script_signature
+                ):
+                    st.session_state["video_script"] = utils.strip_markdown(
+                        uploaded_script_text
+                    )
+                    st.session_state["video_script_file_signature"] = (
+                        uploaded_script_signature
+                    )
+        else:
+            st.session_state.pop("video_script_file_signature", None)
+
         params.video_script = st.text_area(
-            tr("Video Script"), value=st.session_state["video_script"], height=280
+            tr("Video Script"), height=280, key="video_script"
         )
         if st.button(tr("Generate Video Keywords"), key="auto_generate_terms"):
             if not params.video_script:

--- a/webui/i18n/de.json
+++ b/webui/i18n/de.json
@@ -22,6 +22,8 @@
     "Generate Video Script and Keywords": "Klicken Sie hier, um mithilfe von KI ein [Video Drehbuch] und [Video Keywords] basierend auf dem **Keyword** zu generieren.",
     "Auto Detect": "Automatisch erkennen",
     "Video Script": "Drehbuch (Storybook) (:blue[① Optional, KI generiert  ② Die richtige Zeichensetzung hilft bei der Erstellung von Untertiteln])",
+    "Import Script File": "Skriptdatei importieren (.txt oder .md)",
+    "Uploaded script file must be UTF-8 encoded": "Die hochgeladene Skriptdatei muss UTF-8-codiert sein",
     "Generate Video Keywords": "Klicken Sie, um KI zum Generieren zu verwenden [Video Keywords] basierend auf dem **Drehbuch**",
     "Please Enter the Video Subject": "Bitte geben Sie zuerst das Drehbuch an",
     "Generating Video Script and Keywords": "KI generiert ein Drehbuch und Schlüsselwörter...",

--- a/webui/i18n/en.json
+++ b/webui/i18n/en.json
@@ -22,6 +22,8 @@
     "Generate Video Script and Keywords": "Click to use AI to generate [Video Script] and [Video Keywords] based on **subject**",
     "Auto Detect": "Auto Detect",
     "Video Script": "Video Script (:blue[① Optional, AI generated  ② Proper punctuation helps with subtitle generation])",
+    "Import Script File": "Import Script File (.txt or .md)",
+    "Uploaded script file must be UTF-8 encoded": "Uploaded script file must be UTF-8 encoded",
     "Generate Video Keywords": "Click to use AI to generate [Video Keywords] based on **script**",
     "Please Enter the Video Subject": "Please Enter the Video Script First",
     "Generating Video Script and Keywords": "AI is generating video script and keywords...",

--- a/webui/i18n/es.json
+++ b/webui/i18n/es.json
@@ -22,6 +22,8 @@
     "Generate Video Script and Keywords": "Haz clic para que la IA genere el [Guión del vídeo] y las [Palabras clave del vídeo] basándose en el **tema**",
     "Auto Detect": "Detección automática",
     "Video Script": "Guión del vídeo (:blue[① Opcional, generado por IA  ② La puntuación correcta ayuda a generar subtítulos])",
+    "Import Script File": "Importar archivo de guión (.txt o .md)",
+    "Uploaded script file must be UTF-8 encoded": "El archivo de guión subido debe estar codificado en UTF-8",
     "Generate Video Keywords": "Haz clic para que la IA genere las [Palabras clave del vídeo] basándose en el **guión**",
     "Please Enter the Video Subject": "Introduce primero el guión del vídeo",
     "Generating Video Script and Keywords": "La IA está generando el guión y las palabras clave del vídeo...",

--- a/webui/i18n/id.json
+++ b/webui/i18n/id.json
@@ -22,6 +22,8 @@
     "Generate Video Script and Keywords": "Klik untuk menggunakan AI menghasilkan [Skrip Video] dan [Kata Kunci Video] berdasarkan **subjek**",
     "Auto Detect": "Deteksi Otomatis",
     "Video Script": "Skrip Video (:blue[① Opsional, dihasilkan AI ② Tanda baca yang tepat membantu pembuatan subtitle])",
+    "Import Script File": "Impor File Skrip (.txt atau .md)",
+    "Uploaded script file must be UTF-8 encoded": "File skrip yang diunggah harus dikodekan sebagai UTF-8",
     "Generate Video Keywords": "Klik untuk menggunakan AI menghasilkan [Kata Kunci Video] berdasarkan **skrip**",
     "Please Enter the Video Subject": "Silakan Masukkan Skrip Video Terlebih Dahulu",
     "Generating Video Script and Keywords": "AI sedang menghasilkan skrip video dan kata kunci...",

--- a/webui/i18n/pt.json
+++ b/webui/i18n/pt.json
@@ -15,6 +15,8 @@
     "Generate Video Script and Keywords": "Clique para usar a IA para gerar o [Roteiro do Vídeo] e as [Palavras-chave do Vídeo] com base no **tema**",
     "Auto Detect": "Detectar Automaticamente",
     "Video Script": "Roteiro do Vídeo (:blue[① Opcional, gerado pela IA  ② Pontuação adequada ajuda na geração de legendas])",
+    "Import Script File": "Importar arquivo de roteiro (.txt ou .md)",
+    "Uploaded script file must be UTF-8 encoded": "O arquivo de roteiro enviado deve estar codificado em UTF-8",
     "Generate Video Keywords": "Clique para usar a IA para gerar [Palavras-chave do Vídeo] com base no **roteiro**",
     "Please Enter the Video Subject": "Por favor, insira o Roteiro do Vídeo primeiro",
     "Generating Video Script and Keywords": "A IA está gerando o roteiro do vídeo e as palavras-chave...",

--- a/webui/i18n/ru.json
+++ b/webui/i18n/ru.json
@@ -22,6 +22,8 @@
     "Generate Video Script and Keywords": "Сгенерировать [сценарий] и [ключевые слова] по **теме** с помощью ИИ",
     "Auto Detect": "Определить автоматически",
     "Video Script": "Сценарий (:blue[① необязательно, можно сгенерировать с помощью ИИ; ② аккуратная пунктуация помогает создать субтитры])",
+    "Import Script File": "Импортировать файл сценария (.txt или .md)",
+    "Uploaded script file must be UTF-8 encoded": "Загруженный файл сценария должен быть в кодировке UTF-8",
     "Generate Video Keywords": "Сгенерировать [ключевые слова] по **сценарию** с помощью ИИ",
     "Please Enter the Video Subject": "Сначала введите сценарий видео",
     "Generating Video Script and Keywords": "ИИ генерирует сценарий и ключевые слова...",

--- a/webui/i18n/tr.json
+++ b/webui/i18n/tr.json
@@ -22,6 +22,8 @@
     "Generate Video Script and Keywords": "**Konuya** dayalı olarak yapay zeka ile [Video Senaryosu] ve [Video Anahtar Kelimeleri] oluşturmak için tıklayın",
     "Auto Detect": "Otomatik Algılama",
     "Video Script": "Video Senaryosu (:blue[① İsteğe bağlı, yapay zeka tarafından oluşturulur ② Doğru noktalama altyazı oluşturmaya yardımcı olur])",
+    "Import Script File": "Senaryo Dosyası İçe Aktar (.txt veya .md)",
+    "Uploaded script file must be UTF-8 encoded": "Yüklenen senaryo dosyası UTF-8 kodlamalı olmalıdır",
     "Generate Video Keywords": "**Senaryoya** dayalı olarak yapay zeka ile [Video Anahtar Kelimeleri] oluşturmak için tıklayın",
     "Please Enter the Video Subject": "Lütfen Önce Video Senaryosunu Girin",
     "Generating Video Script and Keywords": "Yapay zeka video senaryosu ve anahtar kelimeleri oluşturuyor...",

--- a/webui/i18n/vi.json
+++ b/webui/i18n/vi.json
@@ -22,6 +22,8 @@
     "Generate Video Script and Keywords": "Nhấn để sử dụng AI để tạo [Kịch Bản Video] và [Từ Khóa Video] dựa trên **chủ đề**",
     "Auto Detect": "Tự Động Phát Hiện",
     "Video Script": "Kịch Bản Video (:blue[① Tùy chọn, AI tạo ra  ② Dấu câu chính xác giúp việc tạo phụ đề)",
+    "Import Script File": "Nhập tệp kịch bản (.txt hoặc .md)",
+    "Uploaded script file must be UTF-8 encoded": "Tệp kịch bản đã tải lên phải được mã hóa UTF-8",
     "Generate Video Keywords": "Nhấn để sử dụng AI để tạo [Từ Khóa Video] dựa trên **kịch bản**",
     "Please Enter the Video Subject": "Vui lòng Nhập Kịch Bản Video Trước",
     "Generating Video Script and Keywords": "AI đang tạo kịch bản video và từ khóa...",

--- a/webui/i18n/zh.json
+++ b/webui/i18n/zh.json
@@ -22,6 +22,8 @@
     "Generate Video Script and Keywords": "点击使用AI根据**主题**生成 【视频文案】 和 【视频关键词】",
     "Auto Detect": "自动检测",
     "Video Script": "视频文案（:blue[①可不填，使用AI生成  ②合理使用标点断句，有助于生成字幕]）",
+    "Import Script File": "导入脚本文件（.txt 或 .md）",
+    "Uploaded script file must be UTF-8 encoded": "上传的脚本文件必须使用 UTF-8 编码",
     "Generate Video Keywords": "点击使用AI根据**文案**生成【视频关键词】",
     "Please Enter the Video Subject": "请先填写视频文案",
     "Generating Video Script and Keywords": "AI正在生成视频文案和关键词...",


### PR DESCRIPTION
## Summary
Add a Streamlit `st.file_uploader` accepting `txt` and `md` directly above the existing Video Script `text_area` in `webui/Main.py` (the `tr("Video Script")` widget). When a file is uploaded, decode it as UTF-8 and run it through a new `strip_markdown(text: str) -> str` helper in `app/utils/utils.py` that removes Markdown headings, list bullets/numbering, horizontal-rule separators, emphasis markers, and link/image syntax while preserving the prose and line structure. Write the cleaned text into `st.session_state["video_script"]` so it populates the script field.

## Why this matters
The reporter has finished scripts and wants to feed an existing document into MoneyPrinterTurbo rather than generating a script from keywords. The maintainer (harry0703) confirmed pasting into the Video Script box already works, but there is no file-upload entry point for documents. He explicitly endorsed adding this as an enhancement and sketched the design: upload `.txt`/`.md`, auto-read the body into the video script, auto-clean Markdown formatting (headings, lists, separators), with longer-document segmentation/summarization and `.docx` as later steps. This plan implements the first, well-bounded slice of that design.

See https://github.com/harry0703/MoneyPrinterTurbo/issues/1002.

## Testing
- Happy path: a `.md` file with `# Heading`, `- bullet`, `---` separators, and `**bold**` produces clean prose with formatting markers removed and paragraph breaks intact. - A plain `.txt` file passes through `strip_markdown` essentially unchanged (no Markdown tokens to remove). - Edge: empty file or whitespace-only file yields an empty/stripped string without raising. - Edge: links `[text](url)` and images `![alt](url)` reduce to their visible text (or are removed for images) rather than leaking raw URLs.

Fixes #1002
