### PR TITLE
fix: warn at startup when the API key is empty on a non-loopback bind

### DIFF
--- a/app/asgi.py
+++ b/app/asgi.py
@@ -15,6 +15,24 @@ from app.router import root_api_router
 from app.utils import utils
 
 
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+
+def warn_if_api_unprotected(api_key: str, listen_host: str) -> str | None:
+    if str(api_key or "").strip():
+        return None
+
+    normalized_host = str(listen_host or "").strip().lower()
+    if normalized_host in _LOOPBACK_HOSTS:
+        return None
+
+    return (
+        "API authentication is disabled because app.api_key is empty while "
+        f"listen_host is '{listen_host}'. Set app.api_key or bind to a loopback "
+        "host before exposing this service."
+    )
+
+
 def exception_handler(request: Request, e: HttpException):
     return JSONResponse(
         status_code=e.status_code,
@@ -38,6 +56,12 @@ def get_application() -> FastAPI:
        FastAPI: Application object instance.
 
     """
+    auth_warning = warn_if_api_unprotected(
+        config.app.get("api_key", ""), config.listen_host
+    )
+    if auth_warning:
+        logger.warning(auth_warning)
+
     instance = FastAPI(
         title=config.project_name,
         description=config.project_description,

--- a/test/services/test_asgi_auth_warning.py
+++ b/test/services/test_asgi_auth_warning.py
@@ -1,0 +1,34 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from app.asgi import warn_if_api_unprotected
+
+
+class TestAsgiAuthWarning(unittest.TestCase):
+    def test_empty_api_key_warns_for_non_loopback_host(self):
+        warning = warn_if_api_unprotected("", "0.0.0.0")
+
+        self.assertTrue(warning)
+        self.assertIn("API authentication is disabled", warning)
+
+    def test_empty_api_key_allows_loopback_hosts(self):
+        for listen_host in ("127.0.0.1", "localhost", "::1"):
+            with self.subTest(listen_host=listen_host):
+                self.assertIsNone(warn_if_api_unprotected("", listen_host))
+
+    def test_non_empty_api_key_never_warns(self):
+        for listen_host in ("0.0.0.0", "127.0.0.1", "localhost", "::1"):
+            with self.subTest(listen_host=listen_host):
+                self.assertIsNone(warn_if_api_unprotected("secret", listen_host))
+
+    def test_whitespace_only_api_key_warns_for_non_loopback_host(self):
+        warning = warn_if_api_unprotected("  \t\n", "0.0.0.0")
+
+        self.assertTrue(warning)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Add a small, testable helper in `app/asgi.py`, e.g. `warn_if_api_unprotected(api_key: str, listen_host: str) -> str | None`, that returns a warning message when `api_key` is empty/blank and `listen_host` is not a loopback address (`127.0.0.1`, `localhost`, `::1`), and `None` otherwise. Invoke it once at application construction in `get_application()` (or immediately after `app = get_application()`), logging the returned message via the already-imported `loguru` `logger.warning(...)` so operators see it on startup.

## Why this matters
A reviewer filed a multi-point code-review issue; the maintainer (harry0703) agreed several items were worth tracking and, in a follow-up, confirmed he had already addressed `MemoryState` locking, `VideoAspect.to_resolution()` explicit failure, and `custom_audio_file` path resolution himself. One agreed item remains unaddressed: "documenting or warning more clearly when API authentication is disabled, especially for non-loopback deployments." In `app/controllers/base.py`, `verify_token` compares the request header against `config.app.get("api_key", "")`, and `config.listen_host` defaults to `0.0.0.0` (a non-loopback bind), so a deployment left with an empty `api_key` exposes the API on all interfaces with no clear operator warning.

See https://github.com/harry0703/MoneyPrinterTurbo/issues/1018.

## Testing
- Empty `api_key` with `listen_host="0.0.0.0"` returns a non-empty warning string. - Empty `api_key` with `listen_host="127.0.0.1"` (and `localhost`, `::1`) returns `None` (loopback is considered safe). - Non-empty `api_key` with any host returns `None`. - Whitespace-only `api_key` is treated as empty (still warns on non-loopback).

Fixes #1018
