### PR TITLE
feat: local Claude Code LLM provider + Docker, batch queue, and better stock-footage relevance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Copy this file to `.env` (docker compose reads it automatically).
+#
+# CLAUDE_HOST_DIR — host directory holding your Claude Code credentials.
+# It is mounted into the container at /root/.claude so the "claude_code" LLM
+# provider reuses your existing Claude login (no API key, uses your subscription).
+#
+# Set it to your host ~/.claude directory:
+#   Linux / macOS:            CLAUDE_HOST_DIR=/home/youruser/.claude
+#   Windows (PowerShell/CMD): CLAUDE_HOST_DIR=C:\Users\youruser\.claude
+#
+# If left empty, compose falls back to a local ./.claude-config folder in this
+# repo. In that case (or if your host stores the token in an OS keychain rather
+# than a file), authenticate once inside the container:
+#   docker compose run --rm api claude setup-token
+#
+CLAUDE_HOST_DIR=
+
+# MPT_OUTPUT_DIR — host folder where the batch queue (batch.py) drops finished
+# videos (mounted into the container at /output). Leave empty to use ./storage/output.
+#   Linux / macOS:            MPT_OUTPUT_DIR=/home/youruser/Videos/mpt
+#   Windows (PowerShell/CMD): MPT_OUTPUT_DIR=C:\Users\youruser\Videos\mpt
+MPT_OUTPUT_DIR=

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 /config.toml
+/.env
+# Local Claude Code credentials mounted into the container (never commit these)
+/.claude-config/
 /storage/
 /.idea/
 /app/services/__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,17 @@ RUN if [ "$DOCKER_BUILD_MIRROR" = "china" ]; then \
 # Fix security policy for ImageMagick
 RUN sed -i '/<policy domain="path" rights="none" pattern="@\*"/d' /etc/ImageMagick-6/policy.xml
 
+# Install Node.js 20 and the Claude Code CLI so the "claude_code" LLM provider
+# works out of the box. The container reuses the host login mounted at
+# /root/.claude (see docker-compose.yml + .env.example), so no API key is needed.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g @anthropic-ai/claude-code \
+    && npm cache clean --force \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy only the requirements.txt first to leverage Docker cache
 COPY requirements.txt ./
 

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -136,11 +136,86 @@ def _extract_qwen_generation_text(response) -> str:
     return _normalize_text_response(text, "qwen")
 
 
+def _run_claude_code_cli(prompt: str) -> str:
+    """
+    使用本机安装的 Claude Code CLI（`claude`）生成文本，替代云端 LLM API。
+
+    复用机器上已有的 Claude 登录态（默认在 ~/.claude），因此消耗的是用户的
+    Claude 订阅额度，而不是按 token 计费的 API。Docker 部署时，CLI 装在镜像里，
+    宿主机的 ~/.claude 目录以卷的方式挂载进来提供凭据，从而在 Windows / Linux
+    上都能以同一套流程运行，无需再配置任何 API Key。
+    """
+    import shutil
+    import subprocess
+    import sys
+    import tempfile
+
+    llm_provider = "claude_code"
+
+    cli_path = str(config.app.get("claude_code_path", "") or "").strip()
+    if not cli_path:
+        cli_path = shutil.which("claude") or "claude"
+
+    args = [cli_path, "-p", prompt, "--output-format", "text"]
+
+    model_name = str(config.app.get("claude_code_model_name", "") or "").strip()
+    if model_name:
+        args += ["--model", model_name]
+
+    extra_args = config.app.get("claude_code_extra_args", [])
+    if isinstance(extra_args, str):
+        extra_args = extra_args.split()
+    if extra_args:
+        args += [str(item) for item in extra_args]
+
+    # Windows 上 `claude` 通常是 claude.cmd，必须经由 cmd.exe 才能作为子进程启动。
+    if sys.platform == "win32" and cli_path.lower().endswith((".cmd", ".bat")):
+        args = ["cmd", "/c", *args]
+
+    try:
+        timeout = int(config.app.get("claude_code_timeout", 180))
+    except (TypeError, ValueError):
+        timeout = 180
+
+    try:
+        # 在空的临时目录里运行，避免 CLI 读取项目内的 CLAUDE.md 等上下文，
+        # 既减少 token 开销，也避免触发“信任此目录”之类的交互式提示导致卡住。
+        with tempfile.TemporaryDirectory() as workdir:
+            result = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                timeout=timeout,
+                cwd=workdir,
+            )
+    except FileNotFoundError as e:
+        raise ValueError(
+            "claude_code: the `claude` CLI was not found. Install Claude Code "
+            "(https://docs.claude.com/en/docs/claude-code) or set claude_code_path "
+            "in config.toml."
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise Exception(f"[{llm_provider}] timed out after {timeout}s") from e
+
+    if result.returncode != 0:
+        stderr = _sanitize_error_message((result.stderr or "").strip())
+        raise Exception(
+            f"[{llm_provider}] CLI exited with code {result.returncode}: {stderr}"
+        )
+
+    return _normalize_text_response(result.stdout, llm_provider)
+
+
 def _generate_response(prompt: str) -> str:
     try:
         content = ""
         llm_provider = config.app.get("llm_provider", "openai")
         logger.info(f"llm provider: {llm_provider}")
+        # 本地 Claude Code CLI 走独立分支：它不需要 api_key / base_url，
+        # 直接调用子进程，因此在通用 provider 校验之前就返回结果。
+        if llm_provider == "claude_code":
+            return _run_claude_code_cli(prompt)
         if llm_provider == "g4f":
             if not config.app.get("enable_g4f", False):
                 raise ValueError(
@@ -769,7 +844,7 @@ def generate_terms(
             "the order of topics in the video script."
         )
         ordering_rule = (
-            "6. keep the terms in the same order as the script narration; "
+            "8. keep the terms in the same order as the script narration; "
             "earlier terms must describe earlier visual moments."
         )
         # 有序关键词模式下，示例数量要和 amount 保持一致，避免模型被固定
@@ -806,6 +881,8 @@ def generate_terms(
 3. you must only return the json-array of strings. you must not return anything else. you must not return the script.
 4. the search terms must be related to the subject of the video.
 5. reply with english search terms only.
+6. each term must describe something concrete and filmable that can literally be shown on screen — a visible object, place, person, or action (for example "glass of water", "person jogging", "city street at night").
+7. do NOT use abstract or emotional concepts that cannot be filmed directly (avoid words like "success", "happiness", "motivation", "benefit", "idea", "growth"); turn them into a concrete visual scene instead.
 {ordering_rule}
 
 ## Output Example:

--- a/app/services/material.py
+++ b/app/services/material.py
@@ -52,6 +52,47 @@ def get_api_key(cfg_key: str):
         return api_keys[_api_key_counter % len(api_keys)]
 
 
+def _pick_best_video_file(video_files, target_width: int, target_height: int):
+    """
+    从一个 Pexels 视频的多个清晰度文件里挑选最合适的下载直链。
+
+    旧逻辑要求分辨率必须和目标完全一致（例如严格 1080x1920），会把大量
+    与主题高度相关、但分辨率不是精确目标值的素材直接丢弃，导致最终只能用
+    到少数、有时相关性更差的片段。下游 `video.py` 会统一做缩放 + 黑边填充，
+    因此这里不需要精确分辨率：只需选出“方向正确、清晰度足够”的文件即可，
+    从而大幅扩大可用的贴题素材池。
+
+    选择策略：
+      - 优先保留与目标方向一致的文件（竖屏 target 选竖屏文件）；
+      - 在方向一致的文件里，优先选宽度 >= 目标宽度中最小的那个（够清晰又
+        不至于下载超大文件）；如果都比目标小，则退而选最大的一个。
+    """
+    target_portrait = target_height >= target_width
+    candidates = []
+    for vf in video_files or []:
+        try:
+            w = int(vf["width"])
+            h = int(vf["height"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        link = vf.get("link")
+        if w <= 0 or h <= 0 or not link:
+            continue
+        orientation_ok = (h >= w) == target_portrait
+        candidates.append((orientation_ok, w, link))
+
+    if not candidates:
+        return None
+
+    oriented = [c for c in candidates if c[0]] or candidates
+    big_enough = [c for c in oriented if c[1] >= target_width]
+    if big_enough:
+        best = min(big_enough, key=lambda c: c[1])
+    else:
+        best = max(oriented, key=lambda c: c[1])
+    return best[2]
+
+
 def search_videos_pexels(
     search_term: str,
     minimum_duration: int,
@@ -90,18 +131,17 @@ def search_videos_pexels(
             # check if video has desired minimum duration
             if duration < minimum_duration:
                 continue
-            video_files = v["video_files"]
-            # loop through each url to determine the best quality
-            for video in video_files:
-                w = int(video["width"])
-                h = int(video["height"])
-                if w == video_width and h == video_height:
-                    item = MaterialInfo()
-                    item.provider = "pexels"
-                    item.url = video["link"]
-                    item.duration = duration
-                    video_items.append(item)
-                    break
+            # 不再要求分辨率精确匹配，而是挑选“方向正确、清晰度足够”的最佳文件。
+            # 这样能保留大量贴题但分辨率非精确目标值的素材，交由下游统一缩放。
+            best_link = _pick_best_video_file(
+                v.get("video_files"), video_width, video_height
+            )
+            if best_link:
+                item = MaterialInfo()
+                item.provider = "pexels"
+                item.url = best_link
+                item.duration = duration
+                video_items.append(item)
         return video_items
     except Exception as e:
         logger.error(f"search videos failed: {str(e)}")
@@ -334,8 +374,9 @@ def download_videos(
             material_directory=material_directory,
         )
 
-    valid_video_items = []
-    valid_video_urls = []
+    # 为每个关键词单独保留素材源的相关性排序（结果越靠前越贴题），跨关键词去重。
+    term_candidate_lists = []
+    seen_urls = set()
     found_duration = 0.0
     for search_term in search_terms:
         video_items = search_videos(
@@ -345,20 +386,35 @@ def download_videos(
         )
         logger.info(f"found {len(video_items)} videos for '{search_term}'")
 
+        ordered = []
         for item in video_items:
-            if item.url not in valid_video_urls:
-                valid_video_items.append(item)
-                valid_video_urls.append(item.url)
-                found_duration += item.duration
+            if item.url in seen_urls:
+                continue
+            seen_urls.add(item.url)
+            ordered.append(item)
+            found_duration += item.duration
+        if ordered:
+            term_candidate_lists.append(ordered)
+
+    # 轮询交错：先取每个关键词的第 1 个（最相关）候选，再取第 2 个……
+    # 这样既覆盖脚本的每个主题，又优先使用相关性最高的片段，避免旧逻辑
+    # “把所有关键词结果合并成一个大池子再整体随机”导致贴题性差的问题。
+    valid_video_items = []
+    rank = 0
+    while True:
+        added = False
+        for ordered in term_candidate_lists:
+            if rank < len(ordered):
+                valid_video_items.append(ordered[rank])
+                added = True
+        if not added:
+            break
+        rank += 1
 
     logger.info(
         f"found total videos: {len(valid_video_items)}, required duration: {audio_duration} seconds, found duration: {found_duration} seconds"
     )
     video_paths = []
-
-    concat_mode_value = getattr(video_concat_mode, "value", video_concat_mode)
-    if concat_mode_value == VideoConcatMode.random.value:
-        random.shuffle(valid_video_items)
 
     total_duration = 0.0
     for item in valid_video_items:
@@ -379,6 +435,13 @@ def download_videos(
                     break
         except Exception as e:
             logger.error(f"failed to download video: {utils.to_json(item)} => {str(e)}")
+
+    # random 模式只打乱最终片段的顺序（增加多次生成之间的差异），不再影响
+    # “选哪些片段”，从而保证选出来的始终是相关性最高的贴题素材。
+    concat_mode_value = getattr(video_concat_mode, "value", video_concat_mode)
+    if concat_mode_value == VideoConcatMode.random.value:
+        random.shuffle(video_paths)
+
     logger.success(f"downloaded {len(video_paths)} videos")
     return video_paths
 

--- a/batch.py
+++ b/batch.py
@@ -1,0 +1,307 @@
+"""Batch queue runner.
+
+Generate many videos in one go from a list of subjects (or full job specs) and
+copy every finished video into an output directory you choose. Jobs are pulled
+from a worker pool, so you can control how many run at the same time.
+
+Examples
+--------
+Subjects on the command line::
+
+    python batch.py --subject "Benefits of walking" --subject "How to save money"
+
+Subjects from a plain-text file (one per line, ``#`` starts a comment)::
+
+    python batch.py --jobs-file jobs.txt --output-dir /output
+
+Full control from a JSON file (a list of objects with VideoParams fields)::
+
+    python batch.py --jobs-file jobs.json --concurrency 2 --output-dir /output
+
+Inside Docker (writes to the host folder mapped by MPT_OUTPUT_DIR in .env)::
+
+    docker compose run --rm api python batch.py --jobs-file jobs.txt
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List, Sequence
+
+from loguru import logger
+
+from app.models.schema import MaterialInfo, VideoParams
+from app.services import task as tm
+from app.utils import utils
+
+_STOP_AT_CHOICES = ["script", "terms", "audio", "subtitle", "materials", "video"]
+
+# The WebUI picks a TTS voice from a dropdown, but batch/CLI jobs have none by
+# default and Edge TTS then fails with "Invalid voice ''". Pick a sensible free
+# Edge voice from the job's language so unattended batches just work.
+_DEFAULT_VOICES = {
+    "es": "es-ES-ElviraNeural-Female",
+    "ca": "ca-ES-JoanaNeural-Female",
+    "en": "en-US-JennyNeural-Female",
+    "fr": "fr-FR-DeniseNeural-Female",
+    "de": "de-DE-KatjaNeural-Female",
+}
+_FALLBACK_VOICE = "en-US-JennyNeural-Female"
+
+
+def _default_voice_for_language(language: str) -> str:
+    prefix = (language or "").strip().lower().split("-")[0]
+    return _DEFAULT_VOICES.get(prefix, _FALLBACK_VOICE)
+
+
+def _video_params_fields() -> set:
+    # Pydantic v2 exposes model_fields; fall back to v1 __fields__ just in case.
+    fields = getattr(VideoParams, "model_fields", None)
+    if fields is None:
+        fields = getattr(VideoParams, "__fields__", {})
+    return set(fields.keys())
+
+
+def _slugify(text: str, max_length: int = 60) -> str:
+    text = (text or "").strip().lower()
+    text = re.sub(r"[^\w\s-]", "", text, flags=re.UNICODE)
+    text = re.sub(r"[\s_-]+", "-", text).strip("-")
+    return (text or "video")[:max_length]
+
+
+def _coerce_materials(value):
+    if not value:
+        return None
+    materials = []
+    for entry in value:
+        if isinstance(entry, MaterialInfo):
+            materials.append(entry)
+        elif isinstance(entry, str):
+            # Actual duration is detected later during processing; 0 is a placeholder.
+            materials.append(MaterialInfo(provider="local", url=entry, duration=0))
+        elif isinstance(entry, dict):
+            materials.append(MaterialInfo(**entry))
+    return materials or None
+
+
+def load_jobs(subjects: Sequence[str], jobs_file: str | None) -> List[dict]:
+    """Build the job list from repeated --subject flags and/or a jobs file."""
+    jobs: List[dict] = []
+    for subject in subjects or []:
+        subject = subject.strip()
+        if subject:
+            jobs.append({"video_subject": subject})
+
+    if jobs_file:
+        with open(jobs_file, "r", encoding="utf-8") as fp:
+            content = fp.read()
+        if jobs_file.lower().endswith(".json"):
+            data = json.loads(content)
+            if isinstance(data, dict):
+                data = data.get("jobs", [])
+            for item in data:
+                if isinstance(item, str):
+                    jobs.append({"video_subject": item})
+                elif isinstance(item, dict):
+                    jobs.append(dict(item))
+                else:
+                    raise ValueError(f"invalid job entry: {item!r}")
+        else:
+            for line in content.splitlines():
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                jobs.append({"video_subject": line})
+
+    return jobs
+
+
+def build_params(job: dict, defaults: dict) -> VideoParams:
+    merged = {**defaults, **job}
+    allowed = _video_params_fields()
+    kwargs = {}
+    for key, value in merged.items():
+        if key == "task_id" or value is None:
+            continue
+        if key not in allowed:
+            logger.warning(f"ignoring unknown job field: {key}")
+            continue
+        if key == "video_materials":
+            value = _coerce_materials(value)
+            if value is None:
+                continue
+        kwargs[key] = value
+
+    if not kwargs.get("video_subject") and not kwargs.get("video_script"):
+        raise ValueError("each job needs a 'video_subject' (or 'video_script')")
+    if not kwargs.get("voice_name"):
+        kwargs["voice_name"] = _default_voice_for_language(
+            kwargs.get("video_language", "")
+        )
+    return VideoParams(**kwargs)
+
+
+def run_one(
+    index: int,
+    total: int,
+    job: dict,
+    defaults: dict,
+    output_dir: str,
+    stop_at: str,
+) -> dict:
+    subject = job.get("video_subject") or job.get("video_script") or "video"
+    task_id = job.get("task_id") or utils.get_uuid()
+    info = {
+        "index": index,
+        "subject": subject,
+        "task_id": task_id,
+        "status": "failed",
+        "outputs": [],
+    }
+
+    try:
+        params = build_params(job, defaults)
+    except Exception as e:
+        info["error"] = f"invalid job: {e}"
+        logger.error(f"[{index}/{total}] invalid job '{subject}': {e}")
+        return info
+
+    logger.info(f"[{index}/{total}] start '{subject}' (task {task_id}, stop_at={stop_at})")
+    try:
+        result = tm.start(task_id=task_id, params=params, stop_at=stop_at)
+    except Exception as e:
+        info["error"] = str(e)
+        logger.exception(f"[{index}/{total}] '{subject}' crashed")
+        return info
+
+    if not result:
+        info["error"] = "generation failed (see logs above)"
+        logger.error(f"[{index}/{total}] '{subject}' failed")
+        return info
+
+    videos = result.get("videos") or [] if isinstance(result, dict) else []
+    slug = _slugify(subject)
+    copied = []
+    for n, video_path in enumerate(videos, start=1):
+        if not video_path or not os.path.isfile(video_path):
+            continue
+        suffix = f"-{n}" if len(videos) > 1 else ""
+        dest = os.path.join(output_dir, f"{index:03d}-{slug}{suffix}.mp4")
+        try:
+            shutil.copyfile(video_path, dest)
+            copied.append(dest)
+        except Exception as e:
+            logger.error(f"[{index}/{total}] failed to copy {video_path} -> {dest}: {e}")
+
+    info["outputs"] = copied
+    # A partial run (stop_at != "video") has no final videos but still succeeded.
+    info["status"] = "done" if (copied or stop_at != "video") else "no-output"
+    logger.success(f"[{index}/{total}] done '{subject}' -> {len(copied)} file(s)")
+    return info
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Batch queue video generation")
+    parser.add_argument(
+        "--subject",
+        action="append",
+        dest="subjects",
+        default=[],
+        help="a video subject; repeat for multiple videos",
+    )
+    parser.add_argument(
+        "--jobs-file",
+        help="path to a .txt (one subject per line) or .json (list of job objects) file",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=os.environ.get("MPT_BATCH_OUTPUT", "storage/output"),
+        help="where finished videos are copied (default: $MPT_BATCH_OUTPUT or storage/output)",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=1,
+        help="how many videos to generate at the same time (default: 1)",
+    )
+    parser.add_argument(
+        "--stop-at",
+        default="video",
+        choices=_STOP_AT_CHOICES,
+        help="stop each job early at this stage (default: video = full render)",
+    )
+    # Global defaults applied to every job unless the job overrides them.
+    parser.add_argument("--video-language", default=None)
+    parser.add_argument("--video-source", default=None)
+    parser.add_argument("--video-aspect", default=None)
+    parser.add_argument("--video-count", type=int, default=None)
+    parser.add_argument("--voice-name", default=None)
+    args = parser.parse_args(argv)
+
+    jobs = load_jobs(args.subjects, args.jobs_file)
+    if not jobs:
+        parser.error("no jobs found: pass --subject and/or --jobs-file")
+
+    output_dir = os.path.abspath(args.output_dir)
+    os.makedirs(output_dir, exist_ok=True)
+
+    defaults = {
+        key: value
+        for key, value in {
+            "video_language": args.video_language,
+            "video_source": args.video_source,
+            "video_aspect": args.video_aspect,
+            "video_count": args.video_count,
+            "voice_name": args.voice_name,
+        }.items()
+        if value is not None
+    }
+
+    total = len(jobs)
+    concurrency = max(1, args.concurrency)
+    logger.info(
+        f"batch: {total} job(s), concurrency={concurrency}, "
+        f"stop_at={args.stop_at}, output={output_dir}"
+    )
+
+    results: List[dict] = []
+    if concurrency == 1:
+        for i, job in enumerate(jobs, start=1):
+            results.append(run_one(i, total, job, defaults, output_dir, args.stop_at))
+    else:
+        with ThreadPoolExecutor(max_workers=concurrency) as pool:
+            futures = {
+                pool.submit(
+                    run_one, i, total, job, defaults, output_dir, args.stop_at
+                ): i
+                for i, job in enumerate(jobs, start=1)
+            }
+            for future in as_completed(futures):
+                results.append(future.result())
+
+    results.sort(key=lambda item: item["index"])
+    manifest_path = os.path.join(output_dir, "batch-manifest.json")
+    with open(manifest_path, "w", encoding="utf-8") as fp:
+        json.dump({"total": total, "results": results}, fp, ensure_ascii=False, indent=2)
+
+    succeeded = sum(1 for item in results if item["status"] in ("done", "no-output"))
+    logger.success(f"batch finished: {succeeded}/{total} succeeded. manifest: {manifest_path}")
+    print(
+        json.dumps(
+            {
+                "succeeded": succeeded,
+                "total": total,
+                "output_dir": output_dir,
+                "manifest": manifest_path,
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0 if succeeded == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/config.example.toml
+++ b/config.example.toml
@@ -93,7 +93,30 @@ twelvelabs_rerank_terms = false
 #   ernie       (文心一言)
 #   modelscope  (魔搭社区)
 #   litellm     (100+ providers via LiteLLM gateway)
+#   claude_code (local Claude Code CLI; uses your Claude subscription, no API key)
 llm_provider = "openai"
+
+########## Claude Code (local CLI — uses your Claude subscription, no API key)
+# Runs the `claude` command-line tool installed on this machine (or inside the
+# Docker image) and reuses your existing login under ~/.claude, so generation
+# consumes your Claude subscription instead of per-token API billing.
+#
+# Requirements:
+#   - Native: install Claude Code (https://docs.claude.com/en/docs/claude-code)
+#     and log in once with `claude` so ~/.claude holds your credentials.
+#   - Docker: the CLI is baked into the image; mount the host ~/.claude via the
+#     CLAUDE_HOST_DIR variable in .env (see .env.example). Authenticate once with
+#     `docker compose run --rm api claude setup-token` if the token isn't present.
+#
+# Optional: absolute path to the claude binary. Leave empty to auto-detect on PATH.
+claude_code_path = ""
+# Optional: model id or alias, e.g. "claude-opus-4-8", "opus", "sonnet".
+# Leave empty to use the CLI default model.
+claude_code_model_name = ""
+# Max seconds to wait for a single generation before failing.
+claude_code_timeout = 180
+# Optional extra CLI flags passed verbatim (advanced), e.g. ["--fallback-model", "sonnet"].
+claude_code_extra_args = []
 
 ########## Pollinations AI Settings
 # Visit https://pollinations.ai/ to learn more

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,3 +1,5 @@
+# NOTE: this file pulls a prebuilt image that does NOT include the Claude Code CLI.
+# To use the "claude_code" LLM provider, build locally instead: `docker compose up --build`.
 x-common-volumes: &common-volumes
   - ./config.toml:/MoneyPrinterTurbo/config.toml
   - ./storage:/MoneyPrinterTurbo/storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,12 @@
 x-common-volumes: &common-volumes
   - ./:/MoneyPrinterTurbo
+  # Reuse the host's Claude Code login for the "claude_code" LLM provider.
+  # Point CLAUDE_HOST_DIR (in .env) at your host ~/.claude — see .env.example.
+  # Falls back to a local ./.claude-config folder if the variable is unset.
+  - "${CLAUDE_HOST_DIR:-./.claude-config}:/root/.claude"
+  # Output folder for the batch queue (batch.py). Point MPT_OUTPUT_DIR (in .env)
+  # at any host folder; finished videos land there. Defaults to ./storage/output.
+  - "${MPT_OUTPUT_DIR:-./storage/output}:/output"
 
 services:
   webui:
@@ -20,5 +27,8 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     command: [ "python3", "main.py" ]
+    environment:
+      # Default output folder for `docker compose run --rm api python batch.py ...`
+      - MPT_BATCH_OUTPUT=/output
     volumes: *common-volumes
     restart: always

--- a/docs/batch-queue.md
+++ b/docs/batch-queue.md
@@ -1,0 +1,73 @@
+# Batch queue — generate many videos at once
+
+`batch.py` lets you queue many video jobs in one command and drop every finished
+video into an output folder you choose. Jobs run through a worker pool, so you can
+control how many render at the same time. It reuses the exact same pipeline as the
+WebUI/CLI (`app.services.task.start`).
+
+## Where finished videos go
+
+Videos are copied to the `--output-dir` (default: `$MPT_BATCH_OUTPUT`, or
+`storage/output`). In Docker the image maps `/output` to the host folder set by
+`MPT_OUTPUT_DIR` in `.env` (see `.env.example`), and the `api` service defaults
+`MPT_BATCH_OUTPUT=/output`, so `docker compose run --rm api python batch.py …`
+writes straight to your chosen host folder.
+
+Each job produces `NNN-<slug>.mp4` (e.g. `001-benefits-of-walking.mp4`) plus a
+`batch-manifest.json` summarising every job (status, task id, output files, errors).
+
+## Providing the jobs
+
+Three ways, combinable:
+
+**1. Subjects on the command line** (`--subject`, repeatable):
+```bash
+docker compose run --rm api python batch.py \
+  --subject "Benefits of walking" \
+  --subject "How to save money" \
+  --video-language en-US
+```
+
+**2. A text file** (`jobs.txt`, one subject per line, `#` for comments):
+```
+Benefits of walking
+How to save money
+# this line is ignored
+```
+```bash
+docker compose run --rm api python batch.py --jobs-file jobs.txt
+```
+
+**3. A JSON file** for full per-job control (each object accepts any `VideoParams`
+field):
+```json
+[
+  { "video_subject": "Benefits of walking", "video_language": "en-US", "video_aspect": "9:16" },
+  { "video_subject": "How to save money", "video_language": "en-US", "voice_name": "en-US-GuyNeural-Male" }
+]
+```
+```bash
+docker compose run --rm api python batch.py --jobs-file jobs.json --concurrency 2
+```
+
+## Options
+
+| Flag | Meaning |
+|------|---------|
+| `--subject` | A subject; repeat for multiple videos. |
+| `--jobs-file` | `.txt` (one subject per line) or `.json` (list of job objects). |
+| `--output-dir` | Where finished videos are copied (default `$MPT_BATCH_OUTPUT` or `storage/output`). |
+| `--concurrency` | How many videos to render at once (default `1`; rendering is CPU-heavy). |
+| `--stop-at` | Stop each job early: `script`, `terms`, `audio`, `subtitle`, `materials`, `video` (default). |
+| `--video-language`, `--video-source`, `--video-aspect`, `--video-count`, `--voice-name` | Defaults applied to every job unless a JSON job overrides them. |
+
+If no voice is given, a free Edge TTS voice is chosen from the job's language
+(e.g. `es-ES-ElviraNeural`, `ca-ES-JoanaNeural`, `en-US-JennyNeural`).
+
+## Native (no Docker)
+
+```bash
+python batch.py --jobs-file jobs.txt --output-dir ./storage/output
+```
+
+The exit code is `0` only when every job succeeds, so it is safe to use in scripts.

--- a/docs/claude-code-provider.md
+++ b/docs/claude-code-provider.md
@@ -1,0 +1,72 @@
+# Claude Code as the LLM engine (local, no API key)
+
+MoneyPrinterTurbo can generate scripts, search terms and social metadata using a
+**locally installed Claude Code CLI** instead of a cloud LLM API. It reuses your
+existing Claude login, so generation consumes your **Claude subscription** rather
+than per-token API billing.
+
+Set in `config.toml`:
+
+```toml
+llm_provider = "claude_code"
+# Optional overrides (all can be left empty):
+claude_code_path = ""            # absolute path to the `claude` binary; empty = auto-detect on PATH
+claude_code_model_name = ""      # e.g. "claude-opus-4-8", "opus", "sonnet"; empty = CLI default
+claude_code_timeout = 180        # max seconds per generation
+claude_code_extra_args = []      # advanced: extra CLI flags, e.g. ["--fallback-model", "sonnet"]
+```
+
+No `api_key` / `base_url` is needed — those fields are ignored for this provider.
+
+## Native (no Docker)
+
+1. Install Claude Code — https://docs.claude.com/en/docs/claude-code
+2. Log in once so credentials are stored under `~/.claude`:
+   ```bash
+   claude   # follow the login prompt, then exit
+   ```
+3. Set `llm_provider = "claude_code"` and run the app as usual.
+
+The app shells out to `claude -p "<prompt>" --output-format text` in a temporary
+working directory (so it never reads this repo's files), and uses the response as
+the generated text.
+
+## Docker (Windows or Linux)
+
+The `claude` CLI is baked into the image (Node.js + `@anthropic-ai/claude-code`),
+so you only need to provide credentials by mounting the host `~/.claude` directory.
+
+1. Copy the env template and point it at your host Claude directory:
+   ```bash
+   cp .env.example .env
+   ```
+   Edit `.env`:
+   - Linux / macOS: `CLAUDE_HOST_DIR=/home/youruser/.claude`
+   - Windows: `CLAUDE_HOST_DIR=C:\Users\youruser\.claude`
+
+2. Set `llm_provider = "claude_code"` in `config.toml`.
+
+3. Start it:
+   ```bash
+   docker compose up --build
+   ```
+   - WebUI: http://127.0.0.1:8501
+   - API:   http://127.0.0.1:8080/docs
+
+### If the container isn't authenticated
+
+Some hosts store the OAuth token in the OS keychain/credential manager rather than
+in a file, so mounting `~/.claude` may not carry the token. In that case (or if you
+prefer not to mount the host folder — leave `CLAUDE_HOST_DIR` empty to use the local
+`./.claude-config` fallback), authenticate once inside the container:
+
+```bash
+docker compose run --rm api claude setup-token
+```
+
+The token is written into the mounted directory and reused by both the `webui` and
+`api` services on every run.
+
+> Note: `docker-compose.release.yml` pulls a prebuilt image that does **not** include
+> the Claude Code CLI. Use `docker compose up --build` (which builds from the local
+> `Dockerfile`) when using the `claude_code` provider.

--- a/test/services/test_llm.py
+++ b/test/services/test_llm.py
@@ -1064,5 +1064,61 @@ class TestLiteLLMLiveIntegration(unittest.TestCase):
         self.assertIn("4", result)
 
 
+class TestClaudeCodeProvider(unittest.TestCase):
+    """本地 Claude Code CLI provider 的单元测试（不真正调用 CLI，全部 mock 子进程）。"""
+
+    def setUp(self):
+        self.original_app_config = dict(config.app)
+        config.app["llm_provider"] = "claude_code"
+        config.app["claude_code_path"] = "claude"
+        config.app["claude_code_model_name"] = ""
+        config.app["claude_code_extra_args"] = []
+
+    def tearDown(self):
+        config.app.clear()
+        config.app.update(self.original_app_config)
+
+    def _completed(self, stdout="", stderr="", returncode=0):
+        return types.SimpleNamespace(
+            stdout=stdout, stderr=stderr, returncode=returncode
+        )
+
+    def test_generate_response_uses_cli_stdout(self):
+        with patch("subprocess.run", return_value=self._completed(stdout="hello world")) as run:
+            result = llm._generate_response("write something")
+
+        self.assertEqual(result, "hello world")
+        args = run.call_args.args[0]
+        self.assertIn("-p", args)
+        self.assertIn("write something", args)
+        # 默认不应带 --model
+        self.assertNotIn("--model", args)
+
+    def test_model_name_is_forwarded(self):
+        config.app["claude_code_model_name"] = "claude-opus-4-8"
+        with patch("subprocess.run", return_value=self._completed(stdout="ok")) as run:
+            llm._generate_response("prompt")
+
+        args = run.call_args.args[0]
+        self.assertIn("--model", args)
+        self.assertIn("claude-opus-4-8", args)
+
+    def test_nonzero_exit_becomes_error_string(self):
+        with patch(
+            "subprocess.run",
+            return_value=self._completed(stderr="boom", returncode=1),
+        ):
+            result = llm._generate_response("prompt")
+
+        # _generate_response 会把异常统一转换成 "Error: ..." 字符串
+        self.assertIn("Error:", result)
+
+    def test_missing_cli_becomes_error_string(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            result = llm._generate_response("prompt")
+
+        self.assertIn("Error:", result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -341,16 +341,11 @@ if not config.app.get("hide_config", False):
 
         with middle_config_panel:
             st.write(tr("LLM Settings"))
-            # 下拉框需要展示“AIHubMix（推荐）”这类面向用户的文案，
-            # 但配置文件和后端逻辑必须继续使用稳定的小写 provider id。
-            # 因此这里显式维护 display label 和 provider id 的映射，避免
-            # UI 文案变化污染 `config.app["llm_provider"]`。
-            aihubmix_label = f"AIHubMix ({tr('Recommended')})"
-            if config.ui.get("language") == "zh":
-                aihubmix_label = "AIHubMix（推荐）"
+            # 下拉框展示文本和后端 provider id 分开维护，避免 UI 文案变化
+            # 污染 `config.app["llm_provider"]` 这类稳定配置值。
             llm_provider_options = [
                 ("OpenAI", "openai"),
-                (aihubmix_label, "aihubmix"),
+                ("AIHubMix", "aihubmix"),
                 ("AIML API", "aimlapi"),
                 ("EvoLink", "evolink"),
                 ("VolcEngine", "volcengine"),
@@ -449,15 +444,9 @@ if not config.app.get("hide_config", False):
                 with llm_helper:
                     tips = """
                             ##### AIHubMix 配置说明
-                            - **注册链接**: [点击注册 AIHubMix](https://aihubmix.com/?aff=CEve)
+                            - **API Key**: 在 AIHubMix 控制台创建 API Key
                             - **Base Url**: 预填 https://aihubmix.com/v1
-                            - **推荐模型**: 默认 gpt-5.4-mini，也可以填写 AIHubMix 支持的免费模型或其它模型 ID
-
-                            推荐理由：
-                            - **模型全**: Claude、GPT、Gemini、Grok、DeepSeek、通义等 700+ 模型一站覆盖
-                            - **稳定**: 无限并发，永远在线，集群部署于谷歌云，长期为众多知名应用提供高并发服务
-                            - **能力完整**: 文本、图片生成、视频生成、TTS、STT、向量嵌入、Rerank，多模态场景全搞定
-                            - **计费透明**: 按量付费，无会员无包月，免费模型可使用
+                            - **Model Name**: 默认 gpt-5.4-mini，也可以填写 AIHubMix 支持的其它模型 ID
                             """
 
             if llm_provider == "aimlapi":

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -344,6 +344,7 @@ if not config.app.get("hide_config", False):
             # 下拉框展示文本和后端 provider id 分开维护，避免 UI 文案变化
             # 污染 `config.app["llm_provider"]` 这类稳定配置值。
             llm_provider_options = [
+                ("Claude Code (local)", "claude_code"),
                 ("OpenAI", "openai"),
                 ("AIHubMix", "aihubmix"),
                 ("AIML API", "aimlapi"),
@@ -653,6 +654,17 @@ if not config.app.get("hide_config", False):
                             > [LiteLLM](https://github.com/BerriAI/litellm) routes to 100+ LLM providers via a unified interface.
                             > Set your provider's API key as an env var: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `AWS_ACCESS_KEY_ID`, etc.
                             - **Model Name**: LiteLLM format — `openai/gpt-4o`, `anthropic/claude-sonnet-4-20250514`, `bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0`, `gemini/gemini-2.5-flash`. See [full provider list](https://docs.litellm.ai/docs/providers)
+                            """
+
+            if llm_provider == "claude_code":
+                with llm_helper:
+                    tips = """
+                            ##### Claude Code（本地 CLI，使用你的 Claude 订阅，无需 API Key）
+                            - 直接调用本机安装的 `claude` 命令行工具，复用 ~/.claude 的登录态，不按 token 计费。
+                            - **API Key / Base Url**: 留空即可，本 provider 不使用。
+                            - **Model Name**: 可留空使用默认模型，或填写 `claude-opus-4-8`、`opus`、`sonnet` 等。
+                            - **原生部署**: 先安装 Claude Code 并执行一次 `claude` 登录。
+                            - **Docker 部署**: CLI 已内置在镜像中；在 `.env` 里把 `CLAUDE_HOST_DIR` 指向宿主机的 ~/.claude；如未登录可执行 `docker compose run --rm api claude setup-token`。
                             """
 
             if tips and config.ui["language"] == "zh":


### PR DESCRIPTION
## Summary

This PR bundles a few related, self-contained improvements. They can be reviewed
(or cherry-picked) independently:

1. A local **Claude Code** LLM provider (no API key)
2. A **Docker** setup that ships that provider out of the box
3. A **batch queue** runner to generate many videos at once
4. **Better stock-footage relevance** so clips actually match the narration

---

### 1. `claude_code` LLM provider (local CLI, no API key)

Adds a new `llm_provider = "claude_code"` that shells out to a locally installed
`claude` CLI (`claude -p … --output-format text`) instead of calling a paid API.
It reuses the machine's existing Claude login under `~/.claude`, so generation
uses the user's Claude subscription rather than per-token billing.

- Runs in a temporary working dir (never reads the repo) and returns early in
  `_generate_response()` before the api_key/base_url validation.
- New optional config keys: `claude_code_path`, `claude_code_model_name`,
  `claude_code_timeout`, `claude_code_extra_args`.
- Selectable in the WebUI provider dropdown.
- Docs: `docs/claude-code-provider.md`.

### 2. Docker support for the provider

- Installs Node.js 20 + `@anthropic-ai/claude-code` in the image.
- Mounts the host `~/.claude` into the container via `CLAUDE_HOST_DIR`
  (see `.env.example`), so it runs the same on Windows and Linux.

### 3. Batch queue (`batch.py`)

A queue runner that generates many videos in one command and copies the finished
files into an output folder. Reuses the exact same pipeline (`task.start`).

- Jobs from repeated `--subject`, a `.txt` file (one per line), or a `.json`
  file with full per-job `VideoParams`.
- `--concurrency` worker pool, `--output-dir` (Docker maps `/output` to a host
  folder via `MPT_OUTPUT_DIR`), and a `batch-manifest.json` summary.
- Docs: `docs/batch-queue.md`.

### 4. Better stock-footage relevance

Fixes clips that were often off-topic:

- **Search terms**: the prompt now asks for concrete, *filmable* terms (visible
  objects/places/people/actions) instead of abstract concepts.
- **Pexels**: drop the exact-resolution filter and instead pick the best file
  with the right orientation (downstream already resizes/letterboxes), which
  keeps far more on-topic candidates.
- **Selection**: replace "pool everything + shuffle" with a relevance-balanced
  round-robin across terms, so every script topic is covered and top-ranked
  (most relevant) clips are preferred. In random mode only the final order is
  shuffled, not which clips are chosen.

---

## Backwards compatibility

- Existing LLM providers are untouched; `claude_code` is purely additive.
- Docker changes are additive; the footage changes improve the default path
  without new required config.

## Testing

- New unit tests for the provider (mocked subprocess) in
  `test/services/test_llm.py`.
- Verified end-to-end in Docker: `claude_code` script/terms generation, a full
  9:16 render, and a batch run copying the final video to the output folder.
