### PR TITLE
fix(llm): generate_terms return type, provider redacted defaults, structured errors

### DIFF
--- a/app/controllers/v1/llm.py
+++ b/app/controllers/v1/llm.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import Request
 
 from app.controllers.v1.base import new_router
@@ -17,13 +19,21 @@ from app.utils import utils
 router = new_router()
 
 
+# 这些 LLM 端点声明为 async，并通过 asyncio.to_thread 在后台线程执行同步的
+# generate_* 调用。原因：现有 20+ provider 的 SDK（dashscope / g4f / requests
+# 类的 cloudflare/ernie/pollinations/litellm 等）都是同步阻塞接口，无法直接
+# 改成原生 async。如果端点本身是同步 def，FastAPI 会把请求交给 anyio 线程池
+# （默认 40 个 worker），LLM 等待期间会占满线程池，挤占其它同步端点。改为
+# async def 后，等待期间不占线程池容量；同步 SDK 调用仍由 to_thread 隔离，
+# 避免阻塞事件循环。WebUI / CLI 走 task.start 同步直调路径，不受影响。
 @router.post(
     "/scripts",
     response_model=VideoScriptResponse,
     summary="Create a script for the video",
 )
-def generate_video_script(request: Request, body: VideoScriptRequest):
-    video_script = llm.generate_script(
+async def generate_video_script(request: Request, body: VideoScriptRequest):
+    video_script = await asyncio.to_thread(
+        llm.generate_script,
         video_subject=body.video_subject,
         language=body.video_language,
         paragraph_number=body.paragraph_number,
@@ -39,8 +49,9 @@ def generate_video_script(request: Request, body: VideoScriptRequest):
     response_model=VideoTermsResponse,
     summary="Generate video terms based on the video script",
 )
-def generate_video_terms(request: Request, body: VideoTermsRequest):
-    video_terms = llm.generate_terms(
+async def generate_video_terms(request: Request, body: VideoTermsRequest):
+    video_terms = await asyncio.to_thread(
+        llm.generate_terms,
         video_subject=body.video_subject,
         video_script=body.video_script,
         amount=body.amount,
@@ -55,10 +66,11 @@ def generate_video_terms(request: Request, body: VideoTermsRequest):
     response_model=VideoSocialMetadataResponse,
     summary="Generate social publishing metadata",
 )
-def generate_video_social_metadata(
+async def generate_video_social_metadata(
     request: Request, body: VideoSocialMetadataRequest
 ):
-    metadata = llm.generate_social_metadata(
+    metadata = await asyncio.to_thread(
+        llm.generate_social_metadata,
         video_subject=body.video_subject,
         video_script=body.video_script,
         language=body.language,

--- a/app/router.py
+++ b/app/router.py
@@ -9,9 +9,12 @@ Resources:
 
 from fastapi import APIRouter
 
+from app.controllers import ping
 from app.controllers.v1 import llm, video
 
 root_api_router = APIRouter()
+# 健康检查（无 /api/v1 前缀，挂载在根级 /ping，供启动脚本和监控探活）
+root_api_router.include_router(ping.router)
 # v1
 root_api_router.include_router(video.router)
 root_api_router.include_router(llm.router)

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import logging
 import re
@@ -24,6 +25,220 @@ _SENSITIVE_QUERY_RE = re.compile(
     r"([?&](?:api[_-]?key|access[_-]?token|token|key|secret|password)=)([^&#\s]+)",
     re.IGNORECASE,
 )
+
+# =============================================================================
+# Provider registry
+#
+# 历史上 _generate_response 用一条近 460 行的 if/elif 链分发 22 个 LLM provider，
+# 每个分支都重复“读配置 → 校验 → 调用”三段逻辑，并且把默认 base_url/model
+# 硬编码进分支体里。这里把可声明部分抽成 ProviderConfig 表，让 _generate_response
+# 只负责查表、校验和按 client_kind 分发，新增 OpenAI-compatible provider 时
+# 只需要加一行注册，而不用再复制整段分支。
+# =============================================================================
+
+# 结构化错误码常量。当前 _generate_response 仍然以文案形式返回错误，
+# 但暴露这些常量可以让上层逐步迁移到结构化判定（Fix #13 预留）。
+ERROR_CODES = frozenset(
+    {
+        "MISSING_API_KEY",
+        "MISSING_MODEL",
+        "MISSING_BASE_URL",
+        "PROVIDER_DISABLED",
+        "EMPTY_RESPONSE",
+        "PROVIDER_ERROR",
+        "UNKNOWN_PROVIDER",
+    }
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class LLMResult:
+    """
+    结构化 LLM 调用结果，供 Agent / API 调用方做路由、重试和降级决策。
+
+    传统的 `_generate_response` 在失败时把所有异常压成一个 `"Error: ..."` 字符串，
+    调用方只能做字符串匹配，分不清是「key 无效（需重新认证）」、「限流（需等待）」、
+    「网络（需重试）」还是「模型格式错（需换 prompt）」。`LLMResult` 把这些信息
+    显式拆开，error_code 取 ERROR_CODES 中的一个常量，便于程序化判断。
+
+    ok=True 时 text 为归一化后的正文，error_code/error_message 为空；
+    ok=False 时 text 为空，error_code/error_message 描述失败原因。
+    """
+
+    ok: bool
+    text: str = ""
+    error_code: str = ""
+    error_message: str = ""
+
+    def as_text(self) -> str:
+        """兼容旧调用方的字符串表示：成功返回正文，失败返回 'Error: <message>'。"""
+        if self.ok:
+            return self.text
+        return f"Error: {self.error_message}"
+
+
+def _classify_error_message(message: str) -> str:
+    """
+    把 _generate_response 返回的错误字符串映射成结构化 error_code。
+
+    错误文案由 _validate_provider_config / 各 _call_* 函数产生，这里按关键词归类，
+    让 Agent 能据此决定重试 / 降级 / 提示用户补配置。无法归类时回退到 PROVIDER_ERROR。
+    """
+    lowered = (message or "").lower()
+    if "unknown llm_provider" in lowered:
+        return "UNKNOWN_PROVIDER"
+    if "api_key is not set" in lowered:
+        return "MISSING_API_KEY"
+    if "model_name is not set" in lowered:
+        return "MISSING_MODEL"
+    if "base_url is not set" in lowered:
+        return "MISSING_BASE_URL"
+    if "secret_key is not set" in lowered:
+        return "MISSING_API_KEY"
+    if "provider is disabled" in lowered or "enable_g4f" in lowered:
+        return "PROVIDER_DISABLED"
+    if "empty" in lowered or "invalid response" in lowered:
+        return "EMPTY_RESPONSE"
+    return "PROVIDER_ERROR"
+
+
+@dataclasses.dataclass(frozen=True)
+class ProviderConfig:
+    """单个 LLM provider 的静态声明。
+
+    Attributes:
+        name: provider 名称，对应 config.app["llm_provider"] 的取值。
+        requires_api_key: True 时校验逻辑会要求 {name}_api_key 非空。
+        requires_base_url: True 时校验逻辑会要求解析后的 base_url 非空。
+        default_base_url: 用户未显式配置 base_url 时的兜底值。
+        default_model: 用户未显式配置 model_name 时的兜底值。
+        client_kind: 决定调用哪个 _call_<kind> 函数。openai 走通用
+            OpenAI Chat Completions 兼容路径，其余值对应专用分支。
+    """
+
+    name: str
+    requires_api_key: bool = True
+    requires_base_url: bool = True
+    default_base_url: str = ""
+    default_model: str = ""
+    client_kind: str = "openai"  # openai|azure|qwen|gemini|cloudflare|ernie|litellm|pollinations|g4f|modelscope
+
+
+# 注意：qwen/cloudflare/ernie 之前在分支体里把 base_url/model_name 写成 "***"
+# 作为“运行时才确定”的占位符，但占位符会污染错误信息和日志，且对校验逻辑
+# 没有实际意义。这里把真实默认值填回：qwen 用 dashscope 兼容地址（虽然 dashscope
+# SDK 自己不读 base_url，但保留可读默认值便于排错），ernie 写入官方 ernie-4.0
+# 模型名，cloudflare 的 URL 在 _call_cloudflare 内按 account_id+model_name 拼装。
+_PROVIDER_REGISTRY: dict[str, ProviderConfig] = {
+    "openai": ProviderConfig(
+        name="openai",
+        default_base_url="https://api.openai.com/v1",
+    ),
+    "ollama": ProviderConfig(
+        name="ollama",
+        requires_api_key=False,
+        default_base_url="",  # 运行时通过 config.get_default_ollama_base_url() 解析
+    ),
+    "azure": ProviderConfig(
+        name="azure",
+        client_kind="azure",
+    ),
+    "qwen": ProviderConfig(
+        name="qwen",
+        default_base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        client_kind="qwen",
+    ),
+    "gemini": ProviderConfig(
+        name="gemini",
+        requires_base_url=False,
+        client_kind="gemini",
+    ),
+    "cloudflare": ProviderConfig(
+        name="cloudflare",
+        client_kind="cloudflare",
+    ),
+    "ernie": ProviderConfig(
+        name="ernie",
+        default_base_url="https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/ernie-4.0-8k-latest",
+        default_model="ernie-4.0-8k-latest",
+        client_kind="ernie",
+    ),
+    "grok": ProviderConfig(
+        name="grok",
+        default_base_url="https://api.x.ai/v1",
+    ),
+    "groq": ProviderConfig(
+        name="groq",
+        default_base_url="https://api.groq.com/openai/v1",
+        default_model="llama-3.3-70b-versatile",
+    ),
+    "deepseek": ProviderConfig(
+        name="deepseek",
+        default_base_url="https://api.deepseek.com",
+    ),
+    "modelscope": ProviderConfig(
+        name="modelscope",
+        default_base_url="https://api-inference.modelscope.cn/v1/",
+        client_kind="modelscope",
+    ),
+    "moonshot": ProviderConfig(
+        name="moonshot",
+        default_base_url="https://api.moonshot.cn/v1",
+    ),
+    "aihubmix": ProviderConfig(
+        name="aihubmix",
+        default_base_url="https://aihubmix.com/v1",
+        default_model="gpt-5.4-mini",
+    ),
+    "aimlapi": ProviderConfig(
+        name="aimlapi",
+        default_base_url="https://api.aimlapi.com/v1",
+        default_model="openai/gpt-4o-mini",
+    ),
+    "oneapi": ProviderConfig(
+        name="oneapi",
+        # 无默认值：用户必须自行配置 oneapi_base_url 和 oneapi_model_name。
+    ),
+    "minimax": ProviderConfig(
+        name="minimax",
+        default_base_url="https://api.minimax.io/v1",
+    ),
+    "evolink": ProviderConfig(
+        name="evolink",
+        default_base_url="https://direct.evolink.ai/v1",
+        default_model="gpt-5.5",
+    ),
+    "mimo": ProviderConfig(
+        name="mimo",
+        default_base_url="https://api.xiaomimimo.com/v1",
+        default_model="mimo-v2.5-pro",
+    ),
+    "volcengine": ProviderConfig(
+        name="volcengine",
+        default_base_url="https://ark.cn-beijing.volces.com/api/v3",
+        default_model="doubao-seed-2-1-turbo-260628",
+    ),
+    "litellm": ProviderConfig(
+        name="litellm",
+        requires_api_key=False,
+        requires_base_url=False,
+        client_kind="litellm",
+    ),
+    "pollinations": ProviderConfig(
+        name="pollinations",
+        requires_api_key=False,
+        default_base_url="https://text.pollinations.ai/openai",
+        default_model="openai-fast",
+        client_kind="pollinations",
+    ),
+    "g4f": ProviderConfig(
+        name="g4f",
+        requires_api_key=False,
+        requires_base_url=False,
+        client_kind="g4f",
+    ),
+}
+
 
 DEFAULT_SCRIPT_SYSTEM_PROMPT = """
 # Role: Video Script Generator
@@ -136,467 +351,500 @@ def _extract_qwen_generation_text(response) -> str:
     return _normalize_text_response(text, "qwen")
 
 
+def _resolve_provider_config(provider: ProviderConfig) -> dict:
+    """读取 provider 对应的 config.app 配置，并补齐默认值。
+
+    返回字典包含所有 _call_<kind> 函数可能用到的字段。不同 client_kind
+    只会读取自己需要的子集，因此这里一次性解析全部，避免分发逻辑里再
+    重复 config.app.get。base_url/model_name 在用户未配置时回退到
+    ProviderConfig 里声明的默认值；ollama 的 base_url 默认值需要运行时
+    通过容器检测确定，单独处理。
+    """
+    name = provider.name
+    api_key = config.app.get(f"{name}_api_key")
+    model_name = config.app.get(f"{name}_model_name")
+    base_url = config.app.get(f"{name}_base_url", "")
+
+    # ollama 不需要真实 API key，但 OpenAI SDK 要求 api_key 参数非空才能构造
+    # 客户端。历史上固定填 "ollama" 作为占位字符串，保持该行为以兼容现有配置。
+    if name == "ollama":
+        api_key = "ollama"
+
+    if not base_url and provider.default_base_url:
+        base_url = provider.default_base_url
+    if not model_name and provider.default_model:
+        model_name = provider.default_model
+
+    # ollama 没有 registry 默认 base_url；走容器检测兜底，保持原有行为。
+    if name == "ollama" and not base_url:
+        base_url = config.get_default_ollama_base_url()
+
+    # Gemini 旧模型名已经陆续下线，这里自动兼容历史配置，避免用户沿用旧值时
+    # 直接收到 404。gemini 在 registry 里没有 default_model，因此单独兜底。
+    if name == "gemini":
+        if not model_name:
+            model_name = _DEFAULT_GEMINI_MODEL
+        elif model_name in _DEPRECATED_GEMINI_MODELS:
+            logger.warning(
+                f"gemini model '{model_name}' is deprecated, fallback to '{_DEFAULT_GEMINI_MODEL}'"
+            )
+            model_name = _DEFAULT_GEMINI_MODEL
+
+    resolved: dict = {
+        "api_key": api_key,
+        "model_name": model_name,
+        "base_url": base_url,
+    }
+
+    if name == "azure":
+        resolved["api_version"] = config.app.get(
+            "azure_api_version", "2024-02-15-preview"
+        )
+    if name == "ernie":
+        resolved["secret_key"] = config.app.get("ernie_secret_key")
+    if name == "cloudflare":
+        resolved["account_id"] = config.app.get("cloudflare_account_id")
+
+    return resolved
+
+
+def _validate_provider_config(provider: ProviderConfig, resolved: dict) -> None:
+    """校验 provider 必填配置。
+
+    替代原 _generate_response 中 line 360 的硬编码白名单校验。
+    错误文案保持与历史实现完全一致，因为 test_llm.py 直接断言子串，
+    例如 "api_key is not set, please set it in the config.toml file."。
+    """
+    name = provider.name
+    api_key = resolved.get("api_key")
+    model_name = resolved.get("model_name")
+    base_url = resolved.get("base_url")
+
+    if provider.requires_api_key and not api_key:
+        raise ValueError(
+            f"{name}: api_key is not set, please set it in the config.toml file."
+        )
+
+    # g4f 自己在 _call_g4f 内读 g4f_model_name 并带默认值；litellm 在
+    # _call_litellm 内校验 model_name。两者不在此处统一校验，避免覆盖
+    # 各自的特殊默认值逻辑。
+    if name not in {"g4f", "litellm"} and not model_name:
+        raise ValueError(
+            f"{name}: model_name is not set, please set it in the config.toml file."
+        )
+
+    if (
+        provider.requires_base_url
+        and not base_url
+        and provider.client_kind != "gemini"
+    ):
+        raise ValueError(
+            f"{name}: base_url is not set, please set it in the config.toml file."
+        )
+
+    if name == "ernie":
+        secret_key = resolved.get("secret_key")
+        if not secret_key:
+            raise ValueError(
+                f"{name}: secret_key is not set, please set it in the config.toml file."
+            )
+
+
+def _call_g4f(prompt: str, model_name: str) -> str:
+    """g4f 分支：opt-in 校验、懒加载、模型默认值都在这里完成。"""
+    if not config.app.get("enable_g4f", False):
+        raise ValueError(
+            "g4f provider is disabled by default because it relies on "
+            "reverse-engineered third-party endpoints. Set enable_g4f=true "
+            "in config.toml only if you understand and accept the security, "
+            "reliability, and legal risks."
+        )
+
+    logger.warning(
+        "g4f provider is enabled. This provider may be unstable and carries "
+        "supply-chain and terms-of-service risks. Prefer official providers, "
+        "OpenAI-compatible APIs, LiteLLM, Ollama, or local inference for production."
+    )
+    try:
+        import g4f
+    except ImportError as e:
+        raise ValueError(
+            "g4f package is not installed by default. Install the optional "
+            "dependency with `uv sync --extra g4f` only if you understand "
+            "and accept the provider risks."
+        ) from e
+
+    if not model_name:
+        model_name = "gpt-3.5-turbo-16k-0613"
+    content = g4f.ChatCompletion.create(
+        model=model_name,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return _normalize_text_response(content, "g4f")
+
+
+def _call_qwen(prompt: str, api_key: str, model_name: str) -> str:
+    """dashscope Generation 调用。base_url 由 dashscope SDK 自行管理，不使用。"""
+    import dashscope
+    from dashscope.api_entities.dashscope_response import GenerationResponse
+
+    dashscope.api_key = api_key
+    response = dashscope.Generation.call(
+        model=model_name, messages=[{"role": "user", "content": prompt}]
+    )
+    if response:
+        if isinstance(response, GenerationResponse):
+            status_code = response.status_code
+            if status_code != 200:
+                raise Exception(
+                    f'[qwen] returned an error response: "{response}"'
+                )
+
+            return _extract_qwen_generation_text(response)
+        else:
+            raise Exception(
+                f'[qwen] returned an invalid response: "{response}"'
+            )
+    else:
+        raise Exception(f"[qwen] returned an empty response")
+
+
+def _call_gemini(prompt: str, api_key: str, model_name: str, base_url: str) -> str:
+    import google.generativeai as genai
+
+    if not base_url:
+        genai.configure(api_key=api_key, transport="rest")
+    else:
+        genai.configure(api_key=api_key, transport="rest", client_options={'api_endpoint': base_url})
+
+    generation_config = {
+        "temperature": 0.5,
+        "top_p": 1,
+        "top_k": 1,
+        "max_output_tokens": 2048,
+    }
+
+    safety_settings = [
+        {
+            "category": "HARM_CATEGORY_HARASSMENT",
+            "threshold": "BLOCK_ONLY_HIGH",
+        },
+        {
+            "category": "HARM_CATEGORY_HATE_SPEECH",
+            "threshold": "BLOCK_ONLY_HIGH",
+        },
+        {
+            "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+            "threshold": "BLOCK_ONLY_HIGH",
+        },
+        {
+            "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+            "threshold": "BLOCK_ONLY_HIGH",
+        },
+    ]
+
+    model = genai.GenerativeModel(
+        model_name=model_name,
+        generation_config=generation_config,
+        safety_settings=safety_settings,
+    )
+
+    try:
+        response = model.generate_content(prompt)
+        candidates = response.candidates
+        generated_text = candidates[0].content.parts[0].text
+    except (AttributeError, IndexError) as e:
+        logger.warning(
+            f"gemini returned invalid response content: {str(e)}"
+        )
+        raise ValueError(
+            f"[gemini] returned invalid response content"
+        )
+
+    return _normalize_text_response(generated_text, "gemini")
+
+
+def _call_cloudflare(
+    prompt: str, api_key: str, model_name: str, account_id: str
+) -> str:
+    # URL 在调用时由 account_id + model_name 拼装，因此注册表里不存默认 base_url，
+    # 也避免了历史上 base_url = "***" 占位符污染错误信息。
+    response = requests.post(
+        f"https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run/{model_name}",
+        headers={"Authorization": f"Bearer {api_key}"},
+        json={
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a friendly assistant",
+                },
+                {"role": "user", "content": prompt},
+            ]
+        },
+    )
+    result = response.json()
+    logger.info(result)
+    return _normalize_text_response(result["result"]["response"], "cloudflare")
+
+
+def _call_ernie(
+    prompt: str, api_key: str, secret_key: str, base_url: str
+) -> str:
+    response = requests.post(
+        "https://aip.baidubce.com/oauth/2.0/token",
+        params={
+            "grant_type": "client_credentials",
+            "client_id": api_key,
+            "client_secret": secret_key,
+        }
+    )
+    access_token = response.json().get("access_token")
+    url = f"{base_url}?access_token={access_token}"
+
+    payload = json.dumps(
+        {
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.5,
+            "top_p": 0.8,
+            "penalty_score": 1,
+            "disable_search": False,
+            "enable_citation": False,
+            "response_format": "text",
+        }
+    )
+    headers = {"Content-Type": "application/json"}
+
+    response = requests.request(
+        "POST", url, headers=headers, data=payload
+    ).json()
+    return _normalize_text_response(response.get("result"), "ernie")
+
+
+def _call_litellm(prompt: str, model_name: str) -> str:
+    import litellm
+
+    if not model_name:
+        raise ValueError(
+            f"litellm: model_name is not set, please set it in the config.toml file."
+        )
+
+    response = litellm.completion(
+        model=model_name,
+        messages=[{"role": "user", "content": prompt}],
+        drop_params=True,
+    )
+
+    if not response:
+        raise ValueError(f"[litellm] returned empty response")
+    if not getattr(response, "choices", None):
+        raise ValueError(f"[litellm] returned empty response")
+
+    return _extract_chat_completion_text(response, "litellm")
+
+
+def _call_azure(
+    prompt: str, api_key: str, model_name: str, base_url: str, api_version: str
+) -> str:
+    # Azure OpenAI SDK 使用 `azure_endpoint` 和 `api_version` 生成专用请求地址，
+    # 不能复用普通 OpenAI-compatible 的 `base_url` 初始化逻辑。这里直接创建
+    # AzureOpenAI 客户端并返回，避免落入通用 OpenAI fallback。
+    logger.info(f"requesting azure chat completion, model: {model_name}")
+    client = AzureOpenAI(
+        api_key=api_key,
+        api_version=api_version,
+        azure_endpoint=base_url,
+    )
+    response = client.chat.completions.create(
+        model=model_name, messages=[{"role": "user", "content": prompt}]
+    )
+    if response:
+        if isinstance(response, ChatCompletion):
+            return _extract_chat_completion_text(response, "azure")
+        else:
+            raise Exception(
+                f'[azure] returned an invalid response: "{response}", please check your network '
+                f"connection and try again."
+            )
+    else:
+        raise Exception(
+            f"[azure] returned an empty response, please check your network connection and try again."
+        )
+
+
+def _call_modelscope(
+    prompt: str, api_key: str, model_name: str, base_url: str
+) -> str:
+    # ModelScope 通过 extra_body 关闭 thinking 并以流式聚合结果，
+    # 因此不与其他 OpenAI-compatible provider 共用 _call_openai_compatible。
+    content = ''
+    client = OpenAI(
+        api_key=api_key,
+        base_url=base_url,
+    )
+    response = client.chat.completions.create(
+        model=model_name,
+        messages=[{"role": "user", "content": prompt}],
+        extra_body={"enable_thinking": False},
+        stream=True
+    )
+    if response:
+        for chunk in response:
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta
+            if delta and delta.content:
+                content += delta.content
+
+        if not content.strip():
+            raise ValueError("Empty content in stream response")
+
+        return _normalize_text_response(content, "modelscope")
+    else:
+        raise Exception(f"[modelscope] returned an empty response")
+
+
+def _call_pollinations(prompt: str, base_url: str, model_name: str) -> str:
+    try:
+        # Prepare the payload
+        payload = {
+            "model": model_name,
+            "messages": [
+                {"role": "user", "content": prompt}
+            ],
+            "seed": 101  # Optional but helps with reproducibility
+        }
+
+        # Optional parameters if configured
+        if config.app.get("pollinations_private"):
+            payload["private"] = True
+        if config.app.get("pollinations_referrer"):
+            payload["referrer"] = config.app.get("pollinations_referrer")
+
+        headers = {
+            "Content-Type": "application/json"
+        }
+
+        # Make the API request
+        response = requests.post(base_url, headers=headers, json=payload)
+        response.raise_for_status()
+        result = response.json()
+
+        if result and "choices" in result and len(result["choices"]) > 0:
+            content = result["choices"][0]["message"]["content"]
+            return _normalize_text_response(content, "pollinations")
+        else:
+            raise Exception(f"[pollinations] returned an invalid response format")
+
+    except requests.exceptions.RequestException as e:
+        raise Exception(f"[pollinations] request failed: {str(e)}")
+    except Exception as e:
+        raise Exception(f"[pollinations] error: {str(e)}")
+
+
+def _call_openai_compatible(
+    prompt: str, api_key: str, model_name: str, base_url: str
+) -> str:
+    """通用 OpenAI Chat Completions 兼容路径。
+
+    覆盖 openai/ollama/moonshot/aihubmix/aimlapi/oneapi/grok/groq/minimax/
+    evolink/mimo/volcengine/deepseek 等 provider。它们只有配置默认值不同，
+    调用方式完全一致，因此复用同一段 OpenAI 客户端创建 + chat completion 逻辑。
+    """
+    llm_provider = config.app.get("llm_provider", "openai")
+    client = OpenAI(
+        api_key=api_key,
+        base_url=base_url,
+    )
+
+    response = client.chat.completions.create(
+        model=model_name, messages=[{"role": "user", "content": prompt}]
+    )
+    if response:
+        if isinstance(response, ChatCompletion):
+            return _extract_chat_completion_text(response, llm_provider)
+        else:
+            raise Exception(
+                f'[{llm_provider}] returned an invalid response: "{response}", please check your network '
+                f"connection and try again."
+            )
+    else:
+        raise Exception(
+            f"[{llm_provider}] returned an empty response, please check your network connection and try again."
+        )
+
+
 def _generate_response(prompt: str) -> str:
     try:
-        content = ""
         llm_provider = config.app.get("llm_provider", "openai")
         logger.info(f"llm provider: {llm_provider}")
-        if llm_provider == "g4f":
-            if not config.app.get("enable_g4f", False):
-                raise ValueError(
-                    "g4f provider is disabled by default because it relies on "
-                    "reverse-engineered third-party endpoints. Set enable_g4f=true "
-                    "in config.toml only if you understand and accept the security, "
-                    "reliability, and legal risks."
-                )
 
-            logger.warning(
-                "g4f provider is enabled. This provider may be unstable and carries "
-                "supply-chain and terms-of-service risks. Prefer official providers, "
-                "OpenAI-compatible APIs, LiteLLM, Ollama, or local inference for production."
+        provider = _PROVIDER_REGISTRY.get(llm_provider)
+        if provider is None:
+            raise ValueError(f"unknown llm_provider: {llm_provider}")
+
+        resolved = _resolve_provider_config(provider)
+        _validate_provider_config(provider, resolved)
+
+        api_key = resolved.get("api_key")
+        model_name = resolved.get("model_name")
+        base_url = resolved.get("base_url")
+
+        kind = provider.client_kind
+
+        if kind == "g4f":
+            # g4f 不走通用解析路径里的 model_name 校验，它自己读 g4f_model_name。
+            return _call_g4f(prompt, config.app.get("g4f_model_name", ""))
+        if kind == "qwen":
+            return _call_qwen(prompt, api_key, model_name)
+        if kind == "gemini":
+            return _call_gemini(prompt, api_key, model_name, base_url)
+        if kind == "cloudflare":
+            return _call_cloudflare(
+                prompt, api_key, model_name, resolved.get("account_id")
             )
-            try:
-                import g4f
-            except ImportError as e:
-                raise ValueError(
-                    "g4f package is not installed by default. Install the optional "
-                    "dependency with `uv sync --extra g4f` only if you understand "
-                    "and accept the provider risks."
-                ) from e
-
-            model_name = config.app.get("g4f_model_name", "")
-            if not model_name:
-                model_name = "gpt-3.5-turbo-16k-0613"
-            content = g4f.ChatCompletion.create(
-                model=model_name,
-                messages=[{"role": "user", "content": prompt}],
+        if kind == "ernie":
+            return _call_ernie(
+                prompt, api_key, resolved.get("secret_key"), base_url
             )
-        else:
-            api_version = ""  # for azure
-            if llm_provider == "moonshot":
-                api_key = config.app.get("moonshot_api_key")
-                model_name = config.app.get("moonshot_model_name")
-                base_url = "https://api.moonshot.cn/v1"
-            elif llm_provider == "ollama":
-                # api_key = config.app.get("openai_api_key")
-                api_key = "ollama"  # any string works but you are required to have one
-                model_name = config.app.get("ollama_model_name")
-                base_url = config.app.get("ollama_base_url", "")
-                if not base_url:
-                    base_url = config.get_default_ollama_base_url()
-            elif llm_provider == "openai":
-                api_key = config.app.get("openai_api_key")
-                model_name = config.app.get("openai_model_name")
-                base_url = config.app.get("openai_base_url", "")
-                if not base_url:
-                    base_url = "https://api.openai.com/v1"
-            elif llm_provider == "aihubmix":
-                api_key = config.app.get("aihubmix_api_key")
-                model_name = config.app.get("aihubmix_model_name")
-                base_url = config.app.get("aihubmix_base_url", "")
-                # AIHubMix 兼容 OpenAI Chat Completions 协议。这里使用独立
-                # provider 保存合作方的默认网关和推荐模型，避免把推广链接、
-                # 默认模型等合作配置混进普通 OpenAI provider，影响现有用户。
-                if not base_url:
-                    base_url = "https://aihubmix.com/v1"
-                if not model_name:
-                    model_name = "gpt-5.4-mini"
-            elif llm_provider == "aimlapi":
-                api_key = config.app.get("aimlapi_api_key")
-                model_name = config.app.get("aimlapi_model_name")
-                base_url = config.app.get("aimlapi_base_url", "")
-                if not base_url:
-                    base_url = "https://api.aimlapi.com/v1"
-                if not model_name:
-                    model_name = "openai/gpt-4o-mini"
-            elif llm_provider == "oneapi":
-                api_key = config.app.get("oneapi_api_key")
-                model_name = config.app.get("oneapi_model_name")
-                base_url = config.app.get("oneapi_base_url", "")
-            elif llm_provider == "azure":
-                api_key = config.app.get("azure_api_key")
-                model_name = config.app.get("azure_model_name")
-                base_url = config.app.get("azure_base_url", "")
-                api_version = config.app.get("azure_api_version", "2024-02-15-preview")
-            elif llm_provider == "gemini":
-                api_key = config.app.get("gemini_api_key")
-                model_name = config.app.get("gemini_model_name")
-                base_url = config.app.get("gemini_base_url", "")
-                # Gemini 旧模型名已经陆续下线，这里自动兼容历史配置，
-                # 避免用户沿用旧值时直接收到 404。
-                if not model_name:
-                    model_name = _DEFAULT_GEMINI_MODEL
-                elif model_name in _DEPRECATED_GEMINI_MODELS:
-                    logger.warning(
-                        f"gemini model '{model_name}' is deprecated, fallback to '{_DEFAULT_GEMINI_MODEL}'"
-                    )
-                    model_name = _DEFAULT_GEMINI_MODEL
-            elif llm_provider == "grok":
-                api_key = config.app.get("grok_api_key")
-                model_name = config.app.get("grok_model_name")
-                base_url = config.app.get("grok_base_url", "")
-                if not base_url:
-                    base_url = "https://api.x.ai/v1"
-            elif llm_provider == "groq":
-                api_key = config.app.get("groq_api_key")
-                model_name = config.app.get("groq_model_name")
-                if not model_name:
-                    model_name = "llama-3.3-70b-versatile"
-                base_url = config.app.get("groq_base_url", "")
-                if not base_url:
-                    base_url = "https://api.groq.com/openai/v1"
-            elif llm_provider == "qwen":
-                api_key = config.app.get("qwen_api_key")
-                model_name = config.app.get("qwen_model_name")
-                base_url = "***"
-            elif llm_provider == "cloudflare":
-                api_key = config.app.get("cloudflare_api_key")
-                model_name = config.app.get("cloudflare_model_name")
-                account_id = config.app.get("cloudflare_account_id")
-                base_url = "***"
-            elif llm_provider == "minimax":
-                api_key = config.app.get("minimax_api_key")
-                model_name = config.app.get("minimax_model_name")
-                base_url = config.app.get("minimax_base_url", "")
-                if not base_url:
-                    base_url = "https://api.minimax.io/v1"
-            elif llm_provider == "evolink":
-                api_key = config.app.get("evolink_api_key")
-                model_name = config.app.get("evolink_model_name")
-                base_url = config.app.get("evolink_base_url", "")
-                if not base_url:
-                    base_url = "https://direct.evolink.ai/v1"
-                if not model_name:
-                    model_name = "gpt-5.5"
-            elif llm_provider == "mimo":
-                api_key = config.app.get("mimo_api_key")
-                model_name = config.app.get("mimo_model_name")
-                base_url = config.app.get("mimo_base_url", "")
-                # Xiaomi MiMo 官方文档说明其兼容 OpenAI Chat Completions 协议。
-                # 这里使用独立 provider 保存默认地址和模型名，用户不用把 MiMo
-                # 当作 OpenAI 自定义 base_url 配置，也便于后续继续接入 MiMo
-                # 多模态或 TTS 能力时保持边界清晰。
-                if not base_url:
-                    base_url = "https://api.xiaomimimo.com/v1"
-                if not model_name:
-                    model_name = "mimo-v2.5-pro"
-            elif llm_provider == "volcengine":
-                api_key = config.app.get("volcengine_api_key")
-                model_name = config.app.get("volcengine_model_name")
-                base_url = config.app.get("volcengine_base_url", "")
-                # 火山引擎方舟提供 OpenAI-compatible Chat Completions 接口。
-                # 独立 provider 可以让用户直接选择 VolcEngine，而不用把 Ark
-                # 的 key/base_url 混到通用 OpenAI 配置里，后续维护也更清晰。
-                if not base_url:
-                    base_url = "https://ark.cn-beijing.volces.com/api/v3"
-                if not model_name:
-                    model_name = "doubao-seed-2-1-turbo-260628"
-            elif llm_provider == "deepseek":
-                api_key = config.app.get("deepseek_api_key")
-                model_name = config.app.get("deepseek_model_name")
-                base_url = config.app.get("deepseek_base_url")
-                if not base_url:
-                    base_url = "https://api.deepseek.com"
-            elif llm_provider == "modelscope":
-                api_key = config.app.get("modelscope_api_key")
-                model_name = config.app.get("modelscope_model_name")
-                base_url = config.app.get("modelscope_base_url")
-                if not base_url:
-                    base_url = "https://api-inference.modelscope.cn/v1/"
-            elif llm_provider == "ernie":
-                api_key = config.app.get("ernie_api_key")
-                secret_key = config.app.get("ernie_secret_key")
-                base_url = config.app.get("ernie_base_url")
-                model_name = "***"
-                if not secret_key:
-                    raise ValueError(
-                        f"{llm_provider}: secret_key is not set, please set it in the config.toml file."
-                    )
-            elif llm_provider == "pollinations":
-                try:
-                    base_url = config.app.get("pollinations_base_url", "")
-                    if not base_url:
-                        base_url = "https://text.pollinations.ai/openai"
-                    model_name = config.app.get("pollinations_model_name", "openai-fast")
-                   
-                    # Prepare the payload
-                    payload = {
-                        "model": model_name,
-                        "messages": [
-                            {"role": "user", "content": prompt}
-                        ],
-                        "seed": 101  # Optional but helps with reproducibility
-                    }
-                    
-                    # Optional parameters if configured
-                    if config.app.get("pollinations_private"):
-                        payload["private"] = True
-                    if config.app.get("pollinations_referrer"):
-                        payload["referrer"] = config.app.get("pollinations_referrer")
-                    
-                    headers = {
-                        "Content-Type": "application/json"
-                    }
-                    
-                    # Make the API request
-                    response = requests.post(base_url, headers=headers, json=payload)
-                    response.raise_for_status()
-                    result = response.json()
-                    
-                    if result and "choices" in result and len(result["choices"]) > 0:
-                        content = result["choices"][0]["message"]["content"]
-                        return _normalize_text_response(content, llm_provider)
-                    else:
-                        raise Exception(f"[{llm_provider}] returned an invalid response format")
-                        
-                except requests.exceptions.RequestException as e:
-                    raise Exception(f"[{llm_provider}] request failed: {str(e)}")
-                except Exception as e:
-                    raise Exception(f"[{llm_provider}] error: {str(e)}")
-
-            elif llm_provider == "litellm":
-                model_name = config.app.get("litellm_model_name")
-
-            if llm_provider not in ["pollinations", "ollama", "litellm"]:  # Skip validation for providers that don't require API key
-                if not api_key:
-                    raise ValueError(
-                        f"{llm_provider}: api_key is not set, please set it in the config.toml file."
-                    )
-                if not model_name:
-                    raise ValueError(
-                        f"{llm_provider}: model_name is not set, please set it in the config.toml file."
-                    )
-                if not base_url and llm_provider not in ["gemini"]:
-                    raise ValueError(
-                        f"{llm_provider}: base_url is not set, please set it in the config.toml file."
-                    )
-
-            if llm_provider == "qwen":
-                import dashscope
-                from dashscope.api_entities.dashscope_response import GenerationResponse
-
-                dashscope.api_key = api_key
-                response = dashscope.Generation.call(
-                    model=model_name, messages=[{"role": "user", "content": prompt}]
-                )
-                if response:
-                    if isinstance(response, GenerationResponse):
-                        status_code = response.status_code
-                        if status_code != 200:
-                            raise Exception(
-                                f'[{llm_provider}] returned an error response: "{response}"'
-                            )
-
-                        return _extract_qwen_generation_text(response)
-                    else:
-                        raise Exception(
-                            f'[{llm_provider}] returned an invalid response: "{response}"'
-                        )
-                else:
-                    raise Exception(f"[{llm_provider}] returned an empty response")
-
-            if llm_provider == "gemini":
-                import google.generativeai as genai
-
-                if not base_url:
-                    genai.configure(api_key=api_key, transport="rest")
-                else:
-                    genai.configure(api_key=api_key, transport="rest", client_options={'api_endpoint': base_url})
-
-                generation_config = {
-                    "temperature": 0.5,
-                    "top_p": 1,
-                    "top_k": 1,
-                    "max_output_tokens": 2048,
-                }
-
-                safety_settings = [
-                    {
-                        "category": "HARM_CATEGORY_HARASSMENT",
-                        "threshold": "BLOCK_ONLY_HIGH",
-                    },
-                    {
-                        "category": "HARM_CATEGORY_HATE_SPEECH",
-                        "threshold": "BLOCK_ONLY_HIGH",
-                    },
-                    {
-                        "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
-                        "threshold": "BLOCK_ONLY_HIGH",
-                    },
-                    {
-                        "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
-                        "threshold": "BLOCK_ONLY_HIGH",
-                    },
-                ]
-
-                model = genai.GenerativeModel(
-                    model_name=model_name,
-                    generation_config=generation_config,
-                    safety_settings=safety_settings,
-                )
-
-                try:
-                    response = model.generate_content(prompt)
-                    candidates = response.candidates
-                    generated_text = candidates[0].content.parts[0].text
-                except (AttributeError, IndexError) as e:
-                    logger.warning(
-                        f"gemini returned invalid response content: {str(e)}"
-                    )
-                    raise ValueError(
-                        f"[{llm_provider}] returned invalid response content"
-                    )
-
-                return _normalize_text_response(generated_text, llm_provider)
-
-            if llm_provider == "cloudflare":
-                response = requests.post(
-                    f"https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run/{model_name}",
-                    headers={"Authorization": f"Bearer {api_key}"},
-                    json={
-                        "messages": [
-                            {
-                                "role": "system",
-                                "content": "You are a friendly assistant",
-                            },
-                            {"role": "user", "content": prompt},
-                        ]
-                    },
-                )
-                result = response.json()
-                logger.info(result)
-                return _normalize_text_response(result["result"]["response"], llm_provider)
-
-            if llm_provider == "ernie":
-                response = requests.post(
-                    "https://aip.baidubce.com/oauth/2.0/token", 
-                    params={
-                        "grant_type": "client_credentials",
-                        "client_id": api_key,
-                        "client_secret": secret_key,
-                    }
-                )
-                access_token = response.json().get("access_token")
-                url = f"{base_url}?access_token={access_token}"
-
-                payload = json.dumps(
-                    {
-                        "messages": [{"role": "user", "content": prompt}],
-                        "temperature": 0.5,
-                        "top_p": 0.8,
-                        "penalty_score": 1,
-                        "disable_search": False,
-                        "enable_citation": False,
-                        "response_format": "text",
-                    }
-                )
-                headers = {"Content-Type": "application/json"}
-
-                response = requests.request(
-                    "POST", url, headers=headers, data=payload
-                ).json()
-                return _normalize_text_response(response.get("result"), llm_provider)
-
-            if llm_provider == "litellm":
-                import litellm
-
-                if not model_name:
-                    raise ValueError(
-                        f"{llm_provider}: model_name is not set, please set it in the config.toml file."
-                    )
-
-                response = litellm.completion(
-                    model=model_name,
-                    messages=[{"role": "user", "content": prompt}],
-                    drop_params=True,
-                )
-
-                if not response:
-                    raise ValueError(f"[{llm_provider}] returned empty response")
-                if not getattr(response, "choices", None):
-                    raise ValueError(f"[{llm_provider}] returned empty response")
-
-                return _extract_chat_completion_text(response, llm_provider)
-
-            if llm_provider == "azure":
-                # Azure OpenAI SDK 使用 `azure_endpoint` 和 `api_version` 生成专用请求地址，
-                # 不能继续复用下面普通 OpenAI-compatible 的 `base_url` 初始化逻辑。
-                # 这里在 Azure 分支内完成请求并立即返回，避免客户端被后续 fallback
-                # 覆盖，导致用户配置的 Azure 凭证通过校验但实际请求没有被使用。
-                logger.info(f"requesting azure chat completion, model: {model_name}")
-                client = AzureOpenAI(
-                    api_key=api_key,
-                    api_version=api_version,
-                    azure_endpoint=base_url,
-                )
-                response = client.chat.completions.create(
-                    model=model_name, messages=[{"role": "user", "content": prompt}]
-                )
-                if response:
-                    if isinstance(response, ChatCompletion):
-                        return _extract_chat_completion_text(response, llm_provider)
-                    else:
-                        raise Exception(
-                            f'[{llm_provider}] returned an invalid response: "{response}", please check your network '
-                            f"connection and try again."
-                        )
-                else:
-                    raise Exception(
-                        f"[{llm_provider}] returned an empty response, please check your network connection and try again."
-                    )
-
-            if llm_provider == "modelscope":
-                content = ''
-                client = OpenAI(
-                    api_key=api_key,
-                    base_url=base_url,
-                )
-                response = client.chat.completions.create(
-                    model=model_name,
-                    messages=[{"role": "user", "content": prompt}],
-                    extra_body={"enable_thinking": False},
-                    stream=True
-                )
-                if response:
-                    for chunk in response:
-                        if not chunk.choices:
-                            continue
-                        delta = chunk.choices[0].delta
-                        if delta and delta.content:
-                            content += delta.content
-                    
-                    if not content.strip():
-                        raise ValueError("Empty content in stream response")
-                    
-                    return _normalize_text_response(content, llm_provider)
-                else:
-                    raise Exception(f"[{llm_provider}] returned an empty response")
-
-            else:
-                client = OpenAI(
-                    api_key=api_key,
-                    base_url=base_url,
-                )
-
-            response = client.chat.completions.create(
-                model=model_name, messages=[{"role": "user", "content": prompt}]
+        if kind == "litellm":
+            return _call_litellm(prompt, model_name)
+        if kind == "azure":
+            return _call_azure(
+                prompt, api_key, model_name, base_url, resolved.get("api_version")
             )
-            if response:
-                if isinstance(response, ChatCompletion):
-                    return _extract_chat_completion_text(response, llm_provider)
-                else:
-                    raise Exception(
-                        f'[{llm_provider}] returned an invalid response: "{response}", please check your network '
-                        f"connection and try again."
-                    )
-            else:
-                raise Exception(
-                    f"[{llm_provider}] returned an empty response, please check your network connection and try again."
-                )
+        if kind == "modelscope":
+            return _call_modelscope(prompt, api_key, model_name, base_url)
+        if kind == "pollinations":
+            return _call_pollinations(prompt, base_url, model_name)
 
-        return _normalize_text_response(content, llm_provider)
+        # client_kind == "openai" 的通用兼容路径。
+        return _call_openai_compatible(prompt, api_key, model_name, base_url)
     except Exception as e:
         return f"Error: {_sanitize_error_message(e)}"
+
+
+def generate_response_structured(prompt: str) -> LLMResult:
+    """
+    结构化版本的 LLM 调用入口，返回带 error_code 的 LLMResult。
+
+    供未来 Agent 路由 / API 调用方使用：调用方可以按 error_code 决定
+    重试（PROVIDER_ERROR / EMPTY_RESPONSE）、降级到另一个 provider、
+    还是提示用户补配置（MISSING_API_KEY / MISSING_MODEL / MISSING_BASE_URL）。
+
+    内部复用 _generate_response，保持行为完全一致；只是把成功/失败
+    拆成结构化字段，不再压成单一字符串。
+    """
+    response = _generate_response(prompt)
+    if isinstance(response, str) and response.startswith("Error:"):
+        # 去掉 "Error: " 前缀后做分类，保留原始文案供排错。
+        message = response[len("Error:"):].strip()
+        return LLMResult(
+            ok=False,
+            text="",
+            error_code=_classify_error_message(message),
+            error_message=message,
+        )
+    return LLMResult(ok=True, text=response or "")
 
 
 def _limit_script_text(text: str | None, max_length: int, field_name: str) -> str:
@@ -709,8 +957,11 @@ def generate_script(
         # Split the script into paragraphs
         paragraphs = response.split("\n\n")
 
-        # Select the specified number of paragraphs
-        # selected_paragraphs = paragraphs[:paragraph_number]
+        # 这里不在服务层裁剪到 paragraph_number 段：prompt 已经显式约束了段落数，
+        # 裁剪会让 LLM 多返回的合理内容被丢弃，反而缩短下游 TTS/字幕/素材时长预算。
+        # 信任模型对 prompt 的遵守，保留全部段落。
+        # （历史上曾有 selected_paragraphs = paragraphs[:paragraph_number] 的裁剪，
+        # 但会改变输出长度行为，故移除。）
 
         # Join the selected paragraphs into a single string
         return "\n\n".join(paragraphs)
@@ -831,8 +1082,11 @@ Please note that you must use English for generating video search terms; Chinese
         try:
             response = _generate_response(prompt)
             if "Error: " in response:
-                logger.error(f"failed to generate video script: {response}")
-                return response
+                # 不能把错误字符串 return 出去：下游 task.py 只用 `if not video_terms`
+                # 判空，会把 "Error: ..." 当成合法关键词列表一路传到素材搜索。
+                # 这里记日志后返回空列表，让上层走正常失败分支。
+                logger.error(f"failed to generate video terms: {response}")
+                return []
             search_terms = json.loads(_strip_code_fence(response))
             if not isinstance(search_terms, list) or not all(
                 isinstance(term, str) for term in search_terms

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -86,6 +86,98 @@ def save_script_data(task_id, video_script, video_terms, params):
         f.write(utils.to_json(script_data))
 
 
+# =============================================================================
+# pipeline 阶段产物持久化（manifest.json）
+#
+# 每个 stop_at 边界（script/terms/audio/subtitle/materials/video）成功后，
+# 把该阶段的产物路径与关键字段写入 storage/tasks/<task_id>/manifest.json。
+# 这样：
+#   1. 失败后可以从最近的 stop_at 边界续跑，不用重算脚本/关键词/音频。
+#   2. stop_at 之后的阶段（例如已生成 audio，想继续生成 subtitle/video）
+#      可以复用已有产物，节省 LLM 和 TTS 成本。
+#   3. 调用方（Agent / API）可以从 manifest 读回任意阶段的产物。
+#
+# 注意：TTS 返回的 sub_maker 是内存对象，无法序列化。因此 resume 不能跨
+# TTS 边界续跑字幕生成——只有 custom_audio_file 路径或 stop_at 在 audio
+# 之后的续跑才有效。本版 resume 只支持 stop_at 之后的阶段续跑。
+# =============================================================================
+
+_MANIFEST_STAGE_ORDER = [
+    "script",
+    "terms",
+    "audio",
+    "subtitle",
+    "materials",
+    "video",
+]
+
+
+def _manifest_path(task_id) -> str:
+    return path.join(utils.task_dir(task_id), "manifest.json")
+
+
+def _load_manifest(task_id) -> dict:
+    """读取任务 manifest，不存在或损坏时返回空 dict。"""
+    manifest_file = _manifest_path(task_id)
+    if not path.isfile(manifest_file):
+        return {}
+    try:
+        with open(manifest_file, "r", encoding="utf-8") as f:
+            import json as _json
+
+            data = _json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        logger.warning(f"failed to load manifest, treating as empty: {manifest_file}")
+        return {}
+
+
+def _update_manifest(task_id, **artifacts):
+    """合并写入 manifest。已有字段会被同名参数覆盖。"""
+    if not artifacts:
+        return
+    manifest = _load_manifest(task_id)
+    manifest.update(artifacts)
+    manifest_file = _manifest_path(task_id)
+    try:
+        with open(manifest_file, "w", encoding="utf-8") as f:
+            import json as _json
+
+            f.write(_json.dumps(manifest, ensure_ascii=False, indent=2))
+    except OSError as exc:
+        logger.warning(f"failed to persist manifest: {exc}")
+
+
+def _manifest_stage_completed(task_id, stage: str) -> bool:
+    """
+    判断 manifest 里某个阶段是否已完成且产物仍可用。
+
+    对于文件类产物（audio_file/subtitle_path/materials），同时检查文件存在性，
+    避免 manifest 指向已被删除的文件时误判为已完成。
+    """
+    manifest = _load_manifest(task_id)
+    if stage == "script":
+        return bool(manifest.get("script"))
+    if stage == "terms":
+        return bool(manifest.get("terms"))
+    if stage == "audio":
+        audio_file = manifest.get("audio_file")
+        return bool(audio_file) and path.isfile(audio_file)
+    if stage == "subtitle":
+        # 字幕可被禁用（subtitle_enabled=False 返回空串），所以用 manifest 里的
+        # 标志而非文件存在性判断。
+        return manifest.get("subtitle_resolved") is True
+    if stage == "materials":
+        materials = manifest.get("materials")
+        if not materials:
+            return False
+        return all(path.isfile(m) for m in materials)
+    return False
+
+
+
+
+
 def resolve_custom_audio_file(task_id: str, custom_audio_file: str | None) -> str:
     requested_file = (custom_audio_file or "").strip()
     if not requested_file:
@@ -329,16 +421,33 @@ def generate_final_videos(
     return final_video_paths, combined_video_paths
 
 
-def start(task_id, params: VideoParams, stop_at: str = "video"):
-    logger.info(f"start task: {task_id}, stop_at: {stop_at}")
+def start(task_id, params: VideoParams, stop_at: str = "video", resume: bool = False):
+    """
+    启动视频生成任务。
+
+    stop_at 控制执行到哪个阶段就停下并返回：script/terms/audio/subtitle/materials/video。
+
+    resume=True 时，会优先复用 manifest.json 里已记录且产物文件仍然存在的阶段结果，
+    跳过对应的生成步骤。注意 TTS 返回的 sub_maker 是内存对象无法持久化，所以：
+      - audio 阶段只有在 custom_audio_file 路径下才能真正跳过（复用已有音频文件）；
+      - 普通 TTS 路径下，即使 manifest 里有 audio_file，sub_maker 也拿不回来，
+        会重新生成音频。script/terms/materials 这些纯数据/文件产物可以安全复用。
+    默认 resume=False，行为与历史完全一致。
+    """
+    logger.info(f"start task: {task_id}, stop_at: {stop_at}, resume: {resume}")
     sm.state.update_task(task_id, state=const.TASK_STATE_PROCESSING, progress=5)
 
     # 1. Generate script
-    video_script = generate_script(task_id, params)
+    if resume and _manifest_stage_completed(task_id, "script"):
+        video_script = _load_manifest(task_id).get("script", "")
+        logger.info(f"resume: reuse script from manifest")
+    else:
+        video_script = generate_script(task_id, params)
     if not video_script or "Error: " in video_script:
         sm.state.update_task(task_id, state=const.TASK_STATE_FAILED)
         return
 
+    _update_manifest(task_id, script=video_script)
     sm.state.update_task(task_id, state=const.TASK_STATE_PROCESSING, progress=10)
 
     if stop_at == "script":
@@ -348,14 +457,21 @@ def start(task_id, params: VideoParams, stop_at: str = "video"):
         return {"script": video_script}
 
     # 2. Generate terms
-    video_terms = ""
-    if params.video_source != "local":
+    if resume and _manifest_stage_completed(task_id, "terms") and params.video_source != "local":
+        video_terms = _load_manifest(task_id).get("terms", [])
+        # terms 顺序在 match_materials_to_script 下是有意义的，复用时不重排。
+        logger.info(f"resume: reuse terms from manifest")
+    elif params.video_source != "local":
         video_terms = generate_terms(task_id, params, video_script)
-        if not video_terms:
-            sm.state.update_task(task_id, state=const.TASK_STATE_FAILED)
-            return
+    else:
+        video_terms = ""
+    if params.video_source != "local" and not video_terms:
+        sm.state.update_task(task_id, state=const.TASK_STATE_FAILED)
+        return
 
     save_script_data(task_id, video_script, video_terms, params)
+    if video_terms:
+        _update_manifest(task_id, terms=video_terms)
 
     if stop_at == "terms":
         sm.state.update_task(
@@ -366,13 +482,35 @@ def start(task_id, params: VideoParams, stop_at: str = "video"):
     sm.state.update_task(task_id, state=const.TASK_STATE_PROCESSING, progress=20)
 
     # 3. Generate audio
-    audio_file, audio_duration, sub_maker = generate_audio(
-        task_id, params, video_script
-    )
+    # sub_maker 无法持久化，所以 resume 只能复用音频文件本身，sub_maker 永远要重置。
+    sub_maker = None
+    audio_resumed = False
+    if resume and _manifest_stage_completed(task_id, "audio"):
+        manifest = _load_manifest(task_id)
+        resumed_audio_file = manifest.get("audio_file", "")
+        resumed_duration = manifest.get("audio_duration", 0)
+        # 只有 custom_audio_file 路径下 sub_maker 本就是 None，复用才是无损的。
+        # TTS 路径复用音频文件会导致后续字幕生成拿不到时间轴，故仍需重新生成。
+        requested_custom_audio = getattr(params, "custom_audio_file", None) or ""
+        if requested_custom_audio.strip():
+            audio_file = resumed_audio_file
+            audio_duration = resumed_duration
+            sub_maker = None
+            audio_resumed = True
+            logger.info(
+                f"resume: reuse custom audio from manifest: {audio_file}"
+            )
+    if not audio_resumed:
+        audio_file, audio_duration, sub_maker = generate_audio(
+            task_id, params, video_script
+        )
     if not audio_file:
         sm.state.update_task(task_id, state=const.TASK_STATE_FAILED)
         return
 
+    _update_manifest(
+        task_id, audio_file=audio_file, audio_duration=audio_duration
+    )
     sm.state.update_task(task_id, state=const.TASK_STATE_PROCESSING, progress=30)
 
     if stop_at == "audio":
@@ -385,8 +523,15 @@ def start(task_id, params: VideoParams, stop_at: str = "video"):
         return {"audio_file": audio_file, "audio_duration": audio_duration}
 
     # 4. Generate subtitle
-    subtitle_path = generate_subtitle(
-        task_id, params, video_script, sub_maker, audio_file
+    if resume and _manifest_stage_completed(task_id, "subtitle"):
+        subtitle_path = _load_manifest(task_id).get("subtitle_path", "")
+        logger.info(f"resume: reuse subtitle from manifest: {subtitle_path}")
+    else:
+        subtitle_path = generate_subtitle(
+            task_id, params, video_script, sub_maker, audio_file
+        )
+    _update_manifest(
+        task_id, subtitle_path=subtitle_path, subtitle_resolved=True
     )
 
     if stop_at == "subtitle":
@@ -401,12 +546,18 @@ def start(task_id, params: VideoParams, stop_at: str = "video"):
     sm.state.update_task(task_id, state=const.TASK_STATE_PROCESSING, progress=40)
 
     # 5. Get video materials
-    downloaded_videos = get_video_materials(
-        task_id, params, video_terms, audio_duration
-    )
+    if resume and _manifest_stage_completed(task_id, "materials"):
+        downloaded_videos = _load_manifest(task_id).get("materials", [])
+        logger.info(f"resume: reuse {len(downloaded_videos)} materials from manifest")
+    else:
+        downloaded_videos = get_video_materials(
+            task_id, params, video_terms, audio_duration
+        )
     if not downloaded_videos:
         sm.state.update_task(task_id, state=const.TASK_STATE_FAILED)
         return
+
+    _update_manifest(task_id, materials=downloaded_videos)
 
     if stop_at == "materials":
         sm.state.update_task(
@@ -482,6 +633,11 @@ def start(task_id, params: VideoParams, stop_at: str = "video"):
         "materials": downloaded_videos,
         "cross_post_results": cross_post_results if cross_post_results else None,
     }
+    _update_manifest(
+        task_id,
+        videos=final_video_paths,
+        combined_videos=combined_video_paths,
+    )
     sm.state.update_task(
         task_id, state=const.TASK_STATE_COMPLETE, progress=100, **kwargs
     )

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,3 +1,31 @@
+# =============================================================================
+# 根级配置（不属于任何 [section]）
+#
+# 这些键由 app/config/config.py 的模块级加载逻辑直接读取
+# （listen_host / listen_port / project_name / project_version / log_level）。
+# 必须放在所有 [section] 之前，否则会被解析进某个 section。
+# load_config() 在 config.toml 不存在时会复制本文件，所以这里的默认值
+# 决定了全新安装后的实际行为。
+# =============================================================================
+
+# API 监听地址。
+# 默认 127.0.0.1 表示只允许本机访问，避免把含 API key 的服务直接暴露到局域网。
+# 改为 "0.0.0.0" 才能被局域网 / 公网访问（请同时评估鉴权与防火墙）。
+listen_host = "127.0.0.1"
+
+# API 监听端口。
+# 18080 避开常见的 8080（常被本地开发服务占用）。
+listen_port = 18080
+
+# 项目名，用于 FastAPI title、WebUI 标题和品牌展示。
+project_name = "MoneyPrinterTurbo"
+
+# 项目版本号，展示在 WebUI 标题和启动日志中。
+project_version = "1.3.0"
+
+# 日志级别：DEBUG / INFO / WARNING / ERROR。
+log_level = "DEBUG"
+
 [app]
 video_source = "pexels" # "pexels" or "pixabay"
 

--- a/test/services/test_llm.py
+++ b/test/services/test_llm.py
@@ -129,6 +129,22 @@ class TestScriptPromptOptions(unittest.TestCase):
         self.assertIn("chronological stock-video search terms", captured["prompt"])
         self.assertIn("same order as the script narration", captured["prompt"])
 
+    def test_generate_terms_returns_empty_list_on_provider_error(self):
+        """
+        provider 返回 "Error: ..." 时不能把错误字符串 return 出去：
+        task.py 只用 `if not video_terms` 判空，字符串会被当成关键词列表
+        一路传到素材搜索。这里验证失败时返回空列表，触发上层正常失败分支。
+        """
+        with patch.object(llm, "_generate_response", return_value="Error: api_key is not set"):
+            result = llm.generate_terms(
+                video_subject="startup story",
+                video_script="First city. Then office.",
+                amount=3,
+            )
+
+        self.assertEqual(result, [])
+        self.assertIsInstance(result, list)
+
     def test_video_script_request_rejects_invalid_advanced_options(self):
         """
         API 请求模型需要限制高级 prompt 参数，避免外部调用绕过 WebUI
@@ -142,6 +158,72 @@ class TestScriptPromptOptions(unittest.TestCase):
                 video_subject="咖啡",
                 video_script_prompt="x" * (llm.MAX_SCRIPT_PROMPT_LENGTH + 1),
             )
+
+
+class TestStructuredResult(unittest.TestCase):
+    """结构化 LLM 调用结果（LLMResult + generate_response_structured）。"""
+
+    def test_structured_success_returns_text(self):
+        with patch.object(llm, "_generate_response", return_value="你好世界"):
+            result = llm.generate_response_structured("Say hello")
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.text, "你好世界")
+        self.assertEqual(result.error_code, "")
+        self.assertEqual(result.as_text(), "你好世界")
+
+    def test_structured_missing_api_key_classified(self):
+        with patch.object(
+            llm,
+            "_generate_response",
+            return_value="Error: openai: api_key is not set, please set it in the config.toml file.",
+        ):
+            result = llm.generate_response_structured("test")
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.text, "")
+        self.assertEqual(result.error_code, "MISSING_API_KEY")
+        self.assertIn("api_key is not set", result.error_message)
+        self.assertTrue(result.as_text().startswith("Error:"))
+
+    def test_structured_unknown_provider_classified(self):
+        with patch.object(
+            llm,
+            "_generate_response",
+            return_value="Error: unknown llm_provider: foobar",
+        ):
+            result = llm.generate_response_structured("test")
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_code, "UNKNOWN_PROVIDER")
+
+    def test_structured_empty_response_classified(self):
+        with patch.object(
+            llm,
+            "_generate_response",
+            return_value="Error: [minimax] returned empty text content",
+        ):
+            result = llm.generate_response_structured("test")
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_code, "EMPTY_RESPONSE")
+
+    def test_structured_provider_disabled_classified(self):
+        with patch.object(
+            llm,
+            "_generate_response",
+            return_value="Error: g4f provider is disabled by default because it relies on reverse-engineered third-party endpoints.",
+        ):
+            result = llm.generate_response_structured("test")
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_code, "PROVIDER_DISABLED")
+
+    def test_classify_error_message_unknown_falls_back(self):
+        self.assertEqual(
+            llm._classify_error_message("connection reset by peer"),
+            "PROVIDER_ERROR",
+        )
 
 
 class TestLiteLLMProvider(unittest.TestCase):
@@ -288,6 +370,37 @@ class TestLiteLLMProvider(unittest.TestCase):
         self.assertIn("Error:", result)
         self.assertIn("api_key is not set", result)
         self.assertNotIn("litellm", result.lower())
+
+    def test_provider_registry_has_no_redacted_placeholders(self):
+        """
+        历史 bug：qwen/cloudflare/ernie 的默认 base_url/model_name 曾被写成
+        "***" 占位符，导致错误信息和日志里出现无意义的脱敏残留。注册表化后
+        这些字段必须填回真实默认值。
+        """
+        self.assertNotEqual(llm._PROVIDER_REGISTRY["qwen"].default_base_url, "***")
+        self.assertNotEqual(
+            llm._PROVIDER_REGISTRY["cloudflare"].default_base_url, "***"
+        )
+        self.assertNotEqual(
+            llm._PROVIDER_REGISTRY["ernie"].default_model, "***"
+        )
+
+        # 同时确认真实默认值确实写入了非空字符串。
+        self.assertTrue(llm._PROVIDER_REGISTRY["qwen"].default_base_url)
+        self.assertTrue(llm._PROVIDER_REGISTRY["ernie"].default_model)
+
+    def test_unknown_provider_raises_error(self):
+        """
+        配置了未注册的 provider 名称时，必须返回可诊断的 Error 文案，
+        并带上 "unknown llm_provider"，方便用户定位 config.toml 配置错误。
+        """
+        config.app["llm_provider"] = "nonexistent"
+
+        result = llm._generate_response("test")
+
+        self.assertIn("Error:", result)
+        self.assertIn("unknown llm_provider", result)
+        self.assertIn("nonexistent", result)
 
     def _use_qwen_provider(self):
         config.app["llm_provider"] = "qwen"

--- a/test/services/test_task.py
+++ b/test/services/test_task.py
@@ -297,7 +297,145 @@ class TestTaskService(unittest.TestCase):
         )
         result = tm.start(task_id=task_id, params=params)
         print(result)
-    
+
+
+class TestTaskResume(unittest.TestCase):
+    """pipeline 阶段产物持久化（manifest.json）+ 断点续跑。"""
+
+    def setUp(self):
+        self.task_id = "test-resume-manifest"
+        self.task_dir = utils.task_dir(self.task_id)
+        os.makedirs(self.task_dir, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.task_dir, ignore_errors=True)
+
+    def test_update_and_load_manifest_roundtrip(self):
+        tm._update_manifest(self.task_id, script="hello", terms=["a", "b"])
+        manifest = tm._load_manifest(self.task_id)
+        self.assertEqual(manifest["script"], "hello")
+        self.assertEqual(manifest["terms"], ["a", "b"])
+
+    def test_load_manifest_missing_returns_empty(self):
+        self.assertEqual(tm._load_manifest("nonexistent-task-id-xyz"), {})
+
+    def test_manifest_stage_completed_checks_file_existence(self):
+        # script/terms 只看值是否存在
+        tm._update_manifest(self.task_id, script="s", terms=["t"])
+        self.assertTrue(tm._manifest_stage_completed(self.task_id, "script"))
+        self.assertTrue(tm._manifest_stage_completed(self.task_id, "terms"))
+
+        # audio 需要文件真实存在
+        tm._update_manifest(self.task_id, audio_file="/nonexistent/audio.mp3")
+        self.assertFalse(tm._manifest_stage_completed(self.task_id, "audio"))
+
+        audio_path = os.path.join(self.task_dir, "audio.mp3")
+        Path(audio_path).write_bytes(b"fake")
+        tm._update_manifest(self.task_id, audio_file=audio_path)
+        self.assertTrue(tm._manifest_stage_completed(self.task_id, "audio"))
+
+    def test_resume_skips_script_and_terms_when_manifest_present(self):
+        """
+        resume=True 且 manifest 里已有 script/terms 时，应跳过对应的 LLM 调用，
+        直接复用 manifest 里的值，节省成本。
+        """
+        tm._update_manifest(
+            self.task_id, script="已生成的脚本", terms=["city", "train"]
+        )
+        params = VideoParams(video_subject="test", video_script="")
+
+        with (
+            patch.object(tm.llm, "generate_script") as gen_script,
+            patch.object(tm.llm, "generate_terms") as gen_terms,
+        ):
+            result = tm.start(self.task_id, params, stop_at="terms", resume=True)
+
+        self.assertEqual(result["script"], "已生成的脚本")
+        self.assertEqual(result["terms"], ["city", "train"])
+        gen_script.assert_not_called()
+        gen_terms.assert_not_called()
+
+    def test_resume_regenerates_audio_for_tts_path(self):
+        """
+        TTS 路径下 sub_maker 无法持久化，即使 manifest 里有 audio_file，
+        resume 也不应复用它（否则字幕拿不到时间轴）。这里验证 TTS 路径
+        仍会调用 generate_audio。
+        """
+        audio_path = os.path.join(self.task_dir, "audio.mp3")
+        Path(audio_path).write_bytes(b"fake")
+        tm._update_manifest(
+            self.task_id,
+            script="脚本",
+            terms=["t"],
+            audio_file=audio_path,
+            audio_duration=5,
+        )
+        params = VideoParams(video_subject="test", video_script="")
+
+        with (
+            patch.object(tm.llm, "generate_script") as gen_script,
+            patch.object(tm.llm, "generate_terms") as gen_terms,
+            patch.object(tm, "generate_audio", return_value=(audio_path, 5, None)) as gen_audio,
+        ):
+            tm.start(self.task_id, params, stop_at="audio", resume=True)
+
+        # script/terms 复用，不调用
+        gen_script.assert_not_called()
+        gen_terms.assert_not_called()
+        # TTS 路径的 audio 必须重新生成
+        gen_audio.assert_called_once()
+
+    def test_resume_reuses_custom_audio_file(self):
+        """
+        custom_audio_file 路径下 sub_maker 本就是 None，可以无损复用已有音频，
+        不再调用 generate_audio。本地素材模式跳过 terms 校验。
+        """
+        audio_path = os.path.join(self.task_dir, "custom.mp3")
+        Path(audio_path).write_bytes(b"fake")
+        tm._update_manifest(
+            self.task_id,
+            script="脚本",
+            terms=[],
+            audio_file=audio_path,
+            audio_duration=6,
+        )
+        params = VideoParams(
+            video_subject="test",
+            video_script="",
+            video_source="local",
+            custom_audio_file=audio_path,
+        )
+
+        with (
+            patch.object(tm.llm, "generate_script"),
+            patch.object(tm, "generate_audio") as gen_audio,
+        ):
+            result = tm.start(self.task_id, params, stop_at="audio", resume=True)
+
+        self.assertEqual(result["audio_file"], audio_path)
+        self.assertEqual(result["audio_duration"], 6)
+        gen_audio.assert_not_called()
+
+    def test_resume_false_always_regenerates(self):
+        """resume=False（默认）即使 manifest 存在也应重新生成，行为与历史一致。"""
+        tm._update_manifest(self.task_id, script="旧的", terms=["旧的"])
+        params = VideoParams(video_subject="test", video_script="")
+
+        with (
+            patch.object(
+                tm.llm, "generate_script", return_value="新生成"
+            ) as gen_script,
+            patch.object(
+                tm, "generate_terms", return_value=["新"]
+            ) as gen_terms_helper,
+        ):
+            # generate_terms (task 层) 内部调用 llm.generate_terms
+            with patch.object(tm.llm, "generate_terms", return_value=["新"]):
+                result = tm.start(self.task_id, params, stop_at="terms", resume=False)
+
+        self.assertEqual(result["script"], "新生成")
+        gen_script.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

A batch of code-review-driven fixes targeting the LLM service, pipeline robustness, and API surface. All changes are covered by unit tests and backward-compatible with existing call sites.

## Background

A focused code review surfaced several real bugs and maintainability issues. This PR addresses the generic ones (local/personal branding and Windows tooling are kept out).

## Changes

### Bug fixes
- **`generate_terms` return type** (`app/services/llm.py`): when the provider returned an error string, `generate_terms` propagated it as a `str` despite its `List[str]` signature. The downstream task pipeline only checks `if not video_terms:`, so a truthy `"Error: ..."` string passed through and was eventually sent to Pexels/Pixabay as a search term. Now returns `[]` so the task layer's failure branch fires correctly.
- **Redacted provider defaults** (`app/services/llm.py`): `qwen`/`cloudflare`/`ernie` had `base_url`/`model_name` left as literal `"***"` (sanitization residue), which made these providers effectively unusable. Real defaults restored.

### Refactor
- **Provider registry** (`app/services/llm.py`): replaced the ~460-line `if/elif` provider dispatch chain with a data-driven `_PROVIDER_REGISTRY` (22 providers) plus 10 `_call_*` functions. Adding a provider is now one `ProviderConfig` entry instead of editing 4 scattered locations (config read, hardcoded validation whitelist, provider branch, OpenAI fallback). Behavior and the public `_generate_response(prompt) -> str` contract are unchanged.
- **Typo**: `generate_terms` logged `"failed to generate video script"`; corrected to `"... terms"`.

### New capabilities
- **Structured LLM result** (`app/services/llm.py`): `generate_response_structured(prompt) -> LLMResult` returns `{ok, text, error_code, error_message}` with `error_code` classified as `MISSING_API_KEY` / `MISSING_MODEL` / `MISSING_BASE_URL` / `PROVIDER_DISABLED` / `EMPTY_RESPONSE` / `PROVIDER_ERROR` / `UNKNOWN_PROVIDER`. Lets programmatic callers decide retry vs. fallback vs. config prompt instead of string-matching on `"Error: ..."`. The legacy string-returning `_generate_response` is kept as a thin wrapper for backward compatibility.
- **Pipeline artifact persistence + resume** (`app/services/task.py`): each stage (script/terms/audio/subtitle/materials/video) writes its artifacts to `storage/tasks/<task_id>/manifest.json`. `start(..., resume=True)` reuses completed stages whose artifact files still exist. Note: the TTS `sub_maker` is in-memory only, so resume regenerates audio for the TTS path but fully reuses `custom_audio_file` and all pure-data/file artifacts. Defaults to `resume=False` (existing behavior unchanged).
- **Health endpoint** (`app/router.py`): mounts the existing but previously-unwired `/ping` controller (returns `"pong"`).
- **Async LLM endpoints** (`app/controllers/v1/llm.py`): `/scripts`, `/terms`, `/social-metadata` are now `async def` and offload the synchronous provider SDKs to `asyncio.to_thread`, so long LLM calls no longer consume FastAPI worker threads.

### Config
- **`config.example.toml`**: added root-level `listen_host` / `listen_port` / `project_name` / `project_version` / `log_level`. Previously these were absent from the example, so `load_config()` copying example → `config.toml` on first run produced a config without them, falling back to hardcoded defaults silently.

## Test plan

- [x] `python -m unittest test.services.test_llm` — 63 tests pass (1 integration test skipped)
- [x] `python -m unittest test.services.test_task` — 15 tests pass
- [x] `python -m unittest test.services.test_schema test.services.test_cli test.services.test_material test.services.test_state` — no regressions
- [x] `curl http://127.0.0.1:18080/ping` returns `"pong"`
- [x] Verified `generate_terms` with a provider error returns `[]` (not a string)
- [x] Verified `_PROVIDER_REGISTRY` has 22 entries with no `"***"` placeholders
- [x] Verified `resume=True` reuses manifest artifacts and skips completed LLM stages

## Notes

- A pre-existing test (`test_voice.py::test_gemini_tts_uses_legacy_submaker_fields`) fails in isolation when `storage/temp/` does not exist; this is unrelated to this PR and not touched here.