### PR TITLE
fix(voice): read duration for non-mp3 custom audio files

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1670,32 +1670,32 @@ def _get_audio_duration_from_submaker(sub_maker: SubMaker):
         return 0.0
     return legacy_offsets[-1][1] / 10000000
 
-def _get_audio_duration_from_mp3(mp3_file: str) -> float:
+def _get_audio_duration_from_file(audio_file: str) -> float:
     """
-    获取MP3音频时长
+    获取音频文件时长（支持 mp3/m4a/wav/aac 等 ffmpeg 可解码的格式）
     """
-    if not os.path.exists(mp3_file):
-        logger.error(f"MP3 file does not exist: {mp3_file}")
+    if not os.path.exists(audio_file):
+        logger.error(f"audio file does not exist: {audio_file}")
         return 0.0
 
     try:
-        # Use moviepy to get the duration of the MP3 file
-        with AudioFileClip(mp3_file) as audio:
+        # Use moviepy (ffmpeg) to read the duration of any supported audio format
+        with AudioFileClip(audio_file) as audio:
             return audio.duration  # Duration in seconds
     except Exception as e:
-        logger.error(f"Failed to get audio duration from MP3: {str(e)}")
+        logger.error(f"Failed to get audio duration from file: {str(e)}")
         return 0.0
 
 def get_audio_duration(target: Union[str, SubMaker]) -> float:
     """
     获取音频时长
     如果是SubMaker对象，则从SubMaker中获取时长
-    如果是MP3文件，则从MP3文件中获取时长
+    如果是音频文件路径，则从音频文件中获取时长（支持 mp3/m4a/wav 等格式）
     """
     if isinstance(target, SubMaker):
         return _get_audio_duration_from_submaker(target)
-    elif isinstance(target, str) and target.endswith(".mp3"):
-        return _get_audio_duration_from_mp3(target)
+    elif isinstance(target, str):
+        return _get_audio_duration_from_file(target)
     else:
         logger.error(f"Invalid target type: {type(target)}")
         return 0.0

--- a/test/services/test_voice.py
+++ b/test/services/test_voice.py
@@ -100,6 +100,24 @@ class TestVoiceService(unittest.TestCase):
         self.assertEqual(len(getattr(sub_maker, "offset", [])), 2)
         self.assertGreater(vs.get_audio_duration(sub_maker), 0)
 
+    def test_get_audio_duration_accepts_non_mp3_files(self):
+        """
+        自定义音频（custom_audio_file）常见为 m4a/wav/aac 等非 mp3 格式。
+        get_audio_duration 不应因扩展名不是 .mp3 就报 "Invalid target type" 并返回 0，
+        而应交给 moviepy(ffmpeg) 读取真实时长。
+        """
+        for path in ("custom-audio.m4a", "voice.wav", "clip.aac"):
+            with patch.object(vs.os.path, "exists", return_value=True), \
+                    patch.object(vs, "AudioFileClip") as mock_afc:
+                mock_afc.return_value.__enter__.return_value.duration = 28.89
+                self.assertEqual(vs.get_audio_duration(path), 28.89)
+                mock_afc.assert_called_once_with(path)
+
+    def test_get_audio_duration_missing_file_returns_zero(self):
+        """音频文件不存在时安全返回 0，而不是抛异常或读取失败。"""
+        with patch.object(vs.os.path, "exists", return_value=False):
+            self.assertEqual(vs.get_audio_duration("does-not-exist.m4a"), 0.0)
+
     def test_no_voice_alias_none_is_supported_temporarily(self):
         """
         兼容 PR #981 曾使用过的 none sentinel，避免少量直接调用 API 的用户


### PR DESCRIPTION
## Problem

Uploading a custom audio file that isn't `.mp3` (e.g. an `.m4a` from the WebUI, or `.wav`/`.aac`) aborts video generation:

```
ERROR | app.services.voice:get_audio_duration - Invalid target type: <class 'str'>
ERROR | app.services.task:generate_audio - failed to get audio duration from custom audio file.
ERROR | __main__ - Video Generation Failed
```

`get_audio_duration()` only routes string paths ending in `.mp3` to the moviepy/ffmpeg reader; every other extension falls through to the `else` branch, logs `Invalid target type`, and returns `0.0`, which fails the task.

## Fix

`moviepy`'s `AudioFileClip` already decodes any ffmpeg-supported container, so the `.mp3` guard is unnecessary. Route every string path to the reader and rename the helper `_get_audio_duration_from_mp3` → `_get_audio_duration_from_file` to reflect it is not mp3-specific. `SubMaker` handling is unchanged.

## Verification

- Reproduced with a real `.m4a` upload; with the fix `get_audio_duration()` returns the true duration (`28.89s`) instead of `0.0`.
- Added focused tests in `test/services/test_voice.py`:
  - non-mp3 paths (`.m4a` / `.wav` / `.aac`) return the real duration (mocked `AudioFileClip`)
  - a missing file returns `0.0`
- `python -m unittest` for the two new tests passes.
