### PR TITLE
chore: add .gitattributes for line-ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Auto detect text files and normalize line endings in the repository
+* text=auto
+
+# Binary assets
+*.mp3 binary
+*.mp4 binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.ttf binary
+*.ttc binary
+*.otf binary
+*.woff binary
+*.woff2 binary


### PR DESCRIPTION
The repo has no .gitattributes, so contributors on Windows can end up committing CRLF line endings depending on their local `core.autocrlf`, which then shows up as whole-file diffs in PRs.

This adds a minimal one: `* text=auto` for text normalization, plus explicit `binary` markers for the audio/image/font assets under `resource/` and `test/` so Git never attempts to normalize or diff them.

I ran `git add --renormalize .` on top of current main and it produced zero changes, so this is purely preventive — no working-tree churn for anyone.