### PR TITLE
feat(video): global clip speed multiplier from the UI

### DIFF
--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -77,6 +77,7 @@ class VideoParams(BaseModel):
     video_concat_mode: Optional[VideoConcatMode] = VideoConcatMode.random.value
     video_transition_mode: Optional[VideoTransitionMode] = None
     video_clip_duration: Optional[int] = 5
+    video_clip_speed: Optional[float] = 1.0
     match_materials_to_script: bool = False
     video_count: Optional[int] = 1
 

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -286,6 +286,7 @@ def generate_final_videos(
             video_transition_mode=video_transition_mode,
             max_clip_duration=params.video_clip_duration,
             threads=params.n_threads,
+            clip_speed=params.video_clip_speed,
         )
 
         _progress += 50 / params.video_count / 2

--- a/app/services/video.py
+++ b/app/services/video.py
@@ -541,6 +541,7 @@ def combine_videos(
     video_transition_mode: VideoTransitionMode = None,
     max_clip_duration: int = 5,
     threads: int = 2,
+    clip_speed: float = 1.0,
 ) -> str:
     audio_clip = AudioFileClip(audio_file)
     try:
@@ -666,7 +667,14 @@ def combine_videos(
 
             if clip.duration > max_clip_duration:
                 clip = clip.subclipped(0, max_clip_duration)
-                
+
+            # Apply the optional global speed multiplier to the visual clip only.
+            # Narration and subtitles are added in a later stage, so they are
+            # unaffected. speed == 1.0 is a no-op and preserves current output.
+            speed = utils.normalize_clip_speed(clip_speed)
+            if speed != 1.0:
+                clip = clip.with_speed_scaled(speed)
+
             # wirte clip to temp file
             clip_file = f"{output_dir}/temp-clip-{i+1}.mp4"
             _write_videofile_with_codec_fallback(

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -65,6 +65,30 @@ def get_uuid(remove_hyphen: bool = False):
     return u
 
 
+_CLIP_SPEED_MIN = 0.5
+_CLIP_SPEED_MAX = 2.0
+
+
+def normalize_clip_speed(value, default: float = 1.0) -> float:
+    """Coerce ``value`` to a float speed factor clamped into [0.5, 2.0].
+
+    Returns ``default`` (1.0) when the value is missing, non-numeric, or not
+    positive. Speed 0 or negative is nonsensical, so it falls back to the
+    default rather than clamping up to the minimum.
+    """
+    try:
+        speed = float(value)
+    except (TypeError, ValueError):
+        return default
+    if speed <= 0:
+        return default
+    if speed < _CLIP_SPEED_MIN:
+        return _CLIP_SPEED_MIN
+    if speed > _CLIP_SPEED_MAX:
+        return _CLIP_SPEED_MAX
+    return speed
+
+
 def root_dir():
     return os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 

--- a/test/services/test_clip_speed.py
+++ b/test/services/test_clip_speed.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from app.utils import utils
+
+
+def test_normalize_returns_default_for_none():
+    assert utils.normalize_clip_speed(None) == 1.0
+
+
+def test_normalize_clamps_below_min():
+    assert utils.normalize_clip_speed(0.1) == 0.5
+
+
+def test_normalize_clamps_above_max():
+    assert utils.normalize_clip_speed(5.0) == 2.0
+
+
+def test_normalize_passes_valid_value():
+    assert utils.normalize_clip_speed(1.3) == 1.3
+
+
+def test_normalize_rejects_non_numeric_and_non_positive():
+    assert utils.normalize_clip_speed("abc") == 1.0
+    assert utils.normalize_clip_speed(0) == 1.0
+    assert utils.normalize_clip_speed(-2) == 1.0

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -915,6 +915,13 @@ with middle_panel:
         params.video_clip_duration = st.selectbox(
             tr("Clip Duration"), options=[2, 3, 4, 5, 6, 7, 8, 9, 10], index=1
         )
+        params.video_clip_speed = st.slider(
+            tr("Clip Speed"),
+            min_value=0.5,
+            max_value=2.0,
+            value=1.0,
+            step=0.05,
+        )
         params.video_count = st.selectbox(
             tr("Number of Videos Generated Simultaneously"),
             options=[1, 2, 3, 4, 5],

--- a/webui/i18n/en.json
+++ b/webui/i18n/en.json
@@ -42,6 +42,7 @@
     "Portrait": "Portrait 9:16",
     "Landscape": "Landscape 16:9",
     "Clip Duration": "Maximum Duration of Video Clips (seconds)",
+    "Clip Speed": "Clip Speed (1.0 = normal, 2.0 = 2x faster)",
     "Number of Videos Generated Simultaneously": "Number of Videos Generated Simultaneously",
     "Match Materials to Script Order": "Match materials to script order",
     "Match Materials to Script Order Help": "Disabled by default. Mainly applies to online material sources. When enabled, keywords are generated in script order and materials are downloaded/combined in that order to reduce visual mismatch with the current voiceover.",

--- a/webui/i18n/pt.json
+++ b/webui/i18n/pt.json
@@ -35,6 +35,7 @@
     "Portrait": "Retrato 9:16",
     "Landscape": "Paisagem 16:9",
     "Clip Duration": "Duração Máxima dos Clipes de Vídeo (segundos)",
+    "Clip Speed": "Velocidade dos Clipes (1.0 = normal, 2.0 = 2x mais rápido)",
     "Number of Videos Generated Simultaneously": "Número de Vídeos Gerados Simultaneamente",
     "Audio Settings": "**Configurações de Áudio**",
     "Speech Synthesis": "Voz de Síntese de Fala",

--- a/webui/i18n/ru.json
+++ b/webui/i18n/ru.json
@@ -44,6 +44,7 @@
     "Portrait": "Вертикальное 9:16",
     "Landscape": "Горизонтальное 16:9",
     "Clip Duration": "Максимальная длительность одного фрагмента (сек.)",
+    "Clip Speed": "Скорость клипов (1.0 = обычная, 2.0 = 2x быстрее)",
     "Number of Videos Generated Simultaneously": "Количество видео за один запуск",
     "Audio Settings": "**Настройки аудио**",
     "Speech Synthesis": "Голос озвучки",

--- a/webui/i18n/zh.json
+++ b/webui/i18n/zh.json
@@ -42,6 +42,7 @@
     "Portrait": "竖屏 9:16（抖音视频）",
     "Landscape": "横屏 16:9（西瓜视频）",
     "Clip Duration": "视频片段最大时长(秒)（**不是视频总长度**，是指每个**合成片段**的长度）",
+    "Clip Speed": "片段播放速度（1.0 = 正常，2.0 = 2倍速）",
     "Number of Videos Generated Simultaneously": "同时生成视频数量",
     "Match Materials to Script Order": "按文案顺序匹配素材",
     "Match Materials to Script Order Help": "默认关闭。主要对在线素材源生效。开启后会按文案叙事顺序生成关键词，并尽量按关键词顺序下载和拼接素材，减少画面主题与当前旁白不匹配的问题。",


### PR DESCRIPTION
## What

Adds a global playback-speed multiplier for the background material clips,
exposed as a single slider in the WebUI (Video Settings → **Clip Speed**).

Short-form creators often want a slight speed-up (1.1x–1.5x) for pacing, or a
slow-down for emphasis. Today every clip plays at 1.0x with no way to change it.

## How

- New `VideoParams.video_clip_speed` (default `1.0`).
- New pure helper `utils.normalize_clip_speed(value)` — coerces to float and
  clamps into `[0.5, 2.0]`; returns `1.0` for missing, non-numeric, or
  non-positive input.
- `combine_videos` applies `clip.with_speed_scaled(speed)` per clip, after the
  resize/transition/max-duration trim and before the temp clip is written.

The speed affects **only the visual material clips**. Narration and subtitles are
composited in a later stage, so audio sync is untouched. Because the pipeline
already loops processed clips to cover the narration duration, speeding clips up
(each becomes shorter) is auto-compensated — more clips enter the loop.

## Backward compatibility

Default is `1.0`. `normalize_clip_speed` returns exactly `1.0` for the default,
and `combine_videos` **skips the moviepy effect entirely** when the factor is
`1.0`. Existing behavior and output are unchanged when the feature is unused.

## Scope

Deliberately limited to a single global multiplier. Out of scope: per-clip speed,
random per-clip variation, speed ramps, and any change to narration/subtitles.

## Tests

`test/services/test_clip_speed.py` — 5 unit tests covering the default, both
clamp bounds, a valid pass-through, and non-numeric/non-positive rejection.
i18n coverage (`en`/`ru`) verified by the existing `test_webui_i18n.py`.

## i18n

`"Clip Speed"` added to `en`, `ru`, `zh`, `pt`.