### PR TITLE
fix(video): tolerate material a few pixels below the minimum resolution

### DIFF
--- a/app/services/video.py
+++ b/app/services/video.py
@@ -73,6 +73,12 @@ fps = 30
 # 这里给视频素材多留一个很小的安全余量，避免音频末尾因为帧舍入出现黑屏、
 # 卡顿或最后一小段旁白没有画面的情况。
 _VIDEO_DURATION_SAFETY_MARGIN = 0.1
+_MIN_MATERIAL_DIMENSION = 480
+# 消息类应用和部分编码器会把画面尺寸向下取整，例如 WhatsApp 会把 9:16 的
+# 素材压成 478x850，比 480 少两个像素。直接按 480 硬卡会让这类素材全部被
+# 丢弃，最终以 "no valid materials found" 整体失败。这里留一个很小的容差，
+# 既能放行仅仅因为取整而略低于阈值的素材，也仍然能挡住真正的低清素材。
+_MIN_DIMENSION_TOLERANCE = 10
 _BGM_EXTENSIONS = (".mp3",)
 _DEFAULT_VIDEO_CODEC = "libx264"
 _SUPPORTED_VIDEO_CODECS = (
@@ -95,6 +101,17 @@ def _get_required_video_duration(audio_duration: float) -> float:
     轻量余量。函数独立出来，便于测试和后续按实际反馈调整余量大小。
     """
     return max(0.0, float(audio_duration) + _VIDEO_DURATION_SAFETY_MARGIN)
+
+
+def is_material_resolution_acceptable(width: int, height: int) -> bool:
+    """
+    判断素材分辨率是否足够用于合成。
+
+    标称最小值是 480x480，但允许比它低 `_MIN_DIMENSION_TOLERANCE` 个像素，
+    以兼容编码器/消息应用向下取整导致的尺寸（例如 WhatsApp 的 478x850）。
+    """
+    min_dimension = _MIN_MATERIAL_DIMENSION - _MIN_DIMENSION_TOLERANCE
+    return width >= min_dimension and height >= min_dimension
 
 
 def _prioritize_unique_source_clips(
@@ -1185,8 +1202,12 @@ def preprocess_video(materials: List[MaterialInfo], clip_duration=4):
         try:
             width = clip.size[0]
             height = clip.size[1]
-            if width < 480 or height < 480:
-                logger.warning(f"low resolution material: {width}x{height}, minimum 480x480 required")
+            if not is_material_resolution_acceptable(width, height):
+                logger.warning(
+                    f"low resolution material: {width}x{height}, minimum "
+                    f"{_MIN_MATERIAL_DIMENSION}x{_MIN_MATERIAL_DIMENSION} required "
+                    f"(tolerance {_MIN_DIMENSION_TOLERANCE}px)"
+                )
                 # 探测到低分辨率素材后立即关闭资源，并且不要把该素材返回给后续流程。
                 close_clip(clip)
                 continue

--- a/test/services/test_video.py
+++ b/test/services/test_video.py
@@ -635,5 +635,27 @@ class TestVideoService(unittest.TestCase):
                     self.assertEqual(result, "/some/output/dir")
 
 
+class TestMaterialResolutionTolerance(unittest.TestCase):
+    def test_accepts_material_at_the_nominal_minimum(self):
+        self.assertTrue(vd.is_material_resolution_acceptable(480, 480))
+
+    def test_accepts_whatsapp_recompressed_portrait_clip(self):
+        # WhatsApp delivers 9:16 clips as 478x850, two pixels under the
+        # nominal 480 minimum. Rejecting them fails the whole task.
+        self.assertTrue(vd.is_material_resolution_acceptable(478, 850))
+
+    def test_accepts_material_exactly_at_the_tolerance_bound(self):
+        bound = vd._MIN_MATERIAL_DIMENSION - vd._MIN_DIMENSION_TOLERANCE
+        self.assertTrue(vd.is_material_resolution_acceptable(bound, bound))
+
+    def test_rejects_material_just_below_the_tolerance_bound(self):
+        bound = vd._MIN_MATERIAL_DIMENSION - vd._MIN_DIMENSION_TOLERANCE
+        self.assertFalse(vd.is_material_resolution_acceptable(bound - 1, 850))
+        self.assertFalse(vd.is_material_resolution_acceptable(850, bound - 1))
+
+    def test_rejects_genuinely_low_resolution_material(self):
+        self.assertFalse(vd.is_material_resolution_acceptable(320, 240))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`preprocess_video` rejects any material whose width or height is below 480px.
Encoders and messaging apps round frame dimensions down, so legitimate 9:16
footage can land just under the bar — WhatsApp, for example, delivers portrait
clips as **478x850**. The hard cutoff discards every such clip and the task
fails entirely with `no valid materials found`, even though the material is
perfectly usable.

## Fix

Introduce an explicit tolerance below the nominal minimum instead of a bare
`< 480` check:

- `_MIN_MATERIAL_DIMENSION = 480` (nominal minimum, unchanged intent)
- `_MIN_DIMENSION_TOLERANCE = 10` → effective minimum **470**
- New pure helper `is_material_resolution_acceptable(width, height)`, used by
  `preprocess_video`. The warning now reports the minimum and the tolerance.

Rounding noise (478, 476, …) is accepted; genuinely low-resolution material
(e.g. 320x240) is still filtered out.

## Tests

`test/services/test_video.py::TestMaterialResolutionTolerance` — 5 cases:
nominal minimum, the WhatsApp 478x850 clip, exactly at the tolerance bound,
just below the bound (rejected), and genuinely low-res (rejected).