### PR TITLE
fix(material): redact Pixabay API key from logs

### DIFF
--- a/app/services/material.py
+++ b/app/services/material.py
@@ -127,7 +127,10 @@ def search_videos_pixabay(
         "key": api_key,
     }
     query_url = f"https://pixabay.com/api/videos/?{urlencode(params)}"
-    logger.info(f"searching videos: {query_url}, with proxies: {config.proxy}")
+    logger.info(
+        f"searching videos on pixabay: term={search_term!r}, "
+        f"with proxies: {config.proxy}"
+    )
 
     try:
         r = requests.get(

--- a/test/services/test_material.py
+++ b/test/services/test_material.py
@@ -88,6 +88,20 @@ class TestMaterialTlsVerification(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertFalse(get.call_args.kwargs["verify"])
 
+    def test_search_pixabay_does_not_log_api_key(self):
+        config.app["pixabay_api_keys"] = ["pixabay-secret-key"]
+        config.proxy.clear()
+
+        fake_response = SimpleNamespace(json=lambda: {"hits": []})
+
+        with patch(
+            "app.services.material.requests.get", return_value=fake_response
+        ), patch("app.services.material.logger.info") as log:
+            material.search_videos_pixabay("cat", minimum_duration=1)
+
+        logged_messages = " ".join(str(call.args[0]) for call in log.call_args_list)
+        self.assertNotIn("pixabay-secret-key", logged_messages)
+
     def test_save_video_uses_tls_verification_by_default(self):
         config.app.pop("tls_verify", None)
         config.proxy.clear()


### PR DESCRIPTION
## Summary
- stop logging the Pixabay request URL because it contains the API key query parameter
- retain useful diagnostics by logging the provider, search term, and proxy configuration
- add a regression test that prevents the API key from appearing in log messages

## Security impact
This prevents configured Pixabay API keys from being persisted in application logs during material searches.

## Validation
- uv run pytest test/services/test_material.py -q
- uv run ruff check app/services/material.py test/services/test_material.py