### PR TITLE
fix(bgm): enforce ElevenLabs resource limits

### DIFF
--- a/app/services/elevenlabs_music.py
+++ b/app/services/elevenlabs_music.py
@@ -22,6 +22,7 @@ MAX_VIDEO_DURATION_SECONDS = 600
 MAX_PROMPT_LENGTH = 1000
 MAX_PROXY_BYTES = 200 * 1024 * 1024
 MAX_GENERATED_AUDIO_BYTES = 50 * 1024 * 1024
+MAX_ERROR_BODY_BYTES = 500
 
 
 class ElevenLabsMusicError(RuntimeError):
@@ -80,8 +81,22 @@ def _request_timeout() -> tuple[int, int]:
 
 
 def _safe_response_error(response: requests.Response) -> str:
-    """截断第三方错误正文，保留定位信息但不让 HTML 页面污染任务日志。"""
-    body = (response.text or "").strip().replace("\n", " ")[:500]
+    """只读取有限的第三方错误正文，避免异常响应耗尽内存或污染任务日志。"""
+    try:
+        body_bytes = next(
+            response.iter_content(chunk_size=MAX_ERROR_BODY_BYTES),
+            b"",
+        )
+    except requests.RequestException:
+        body_bytes = b""
+    if isinstance(body_bytes, bytes):
+        body = body_bytes.decode(
+            response.encoding or "utf-8",
+            errors="replace",
+        )
+    else:
+        body = str(body_bytes)
+    body = body.strip().replace("\n", " ")[:MAX_ERROR_BODY_BYTES]
     return body or response.reason or "request failed"
 
 
@@ -211,6 +226,8 @@ def _create_video_proxy(video_path: str) -> str:
         "yuv420p",
         "-movflags",
         "+faststart",
+        "-fs",
+        str(MAX_PROXY_BYTES),
         proxy_path,
     ]
     try:

--- a/app/services/elevenlabs_music.py
+++ b/app/services/elevenlabs_music.py
@@ -113,30 +113,32 @@ def test_connection() -> dict[str, Any]:
     if not api_key:
         raise ElevenLabsAuthenticationError("ElevenLabs API key is required")
     try:
-        response = requests.get(
+        with requests.get(
             f"{_base_url()}{SUBSCRIPTION_PATH}",
             headers={"xi-api-key": api_key},
             timeout=(15, 30),
-        )
+            stream=True,
+        ) as response:
+            if response.status_code == 401:
+                raise ElevenLabsAuthenticationError(
+                    "ElevenLabs API key was rejected (401): "
+                    f"{_safe_response_error(response)}"
+                )
+            if not response.ok:
+                raise ElevenLabsMusicError(
+                    "ElevenLabs account check failed "
+                    f"({response.status_code}): "
+                    f"{_safe_response_error(response)}"
+                )
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise ElevenLabsMusicError(
+                    "ElevenLabs returned an invalid subscription response"
+                ) from exc
     except requests.RequestException as exc:
         raise ElevenLabsMusicError(
             f"failed to connect to ElevenLabs: {exc}"
-        ) from exc
-    if response.status_code == 401:
-        raise ElevenLabsAuthenticationError(
-            "ElevenLabs API key was rejected (401): "
-            f"{_safe_response_error(response)}"
-        )
-    if not response.ok:
-        raise ElevenLabsMusicError(
-            f"ElevenLabs account check failed ({response.status_code}): "
-            f"{_safe_response_error(response)}"
-        )
-    try:
-        payload = response.json()
-    except ValueError as exc:
-        raise ElevenLabsMusicError(
-            "ElevenLabs returned an invalid subscription response"
         ) from exc
     if not isinstance(payload, dict):
         raise ElevenLabsMusicError(

--- a/test/services/test_elevenlabs_music.py
+++ b/test/services/test_elevenlabs_music.py
@@ -23,6 +23,7 @@ class _StreamingResponse:
         self.ok = 200 <= status_code < 300
         self.reason = "OK" if self.ok else "Request failed"
         self.text = "" if self.ok else "request failed"
+        self.encoding = "utf-8"
         self.payload = payload if payload is not None else {"user_id": "test"}
         self.iter_error = iter_error
 
@@ -42,6 +43,33 @@ class _StreamingResponse:
 
 
 class TestElevenLabsMusicService(unittest.TestCase):
+    def test_safe_response_error_reads_only_one_bounded_chunk(self):
+        class OversizedErrorResponse:
+            reason = "Request failed"
+            encoding = "utf-8"
+
+            @property
+            def text(self):
+                raise AssertionError("response.text must not be materialized")
+
+            def iter_content(self, chunk_size):
+                self.requested_chunk_size = chunk_size
+                yield b"x" * chunk_size
+                raise AssertionError("error body must not be read further")
+
+        response = OversizedErrorResponse()
+
+        detail = elevenlabs_music._safe_response_error(response)
+
+        self.assertEqual(
+            response.requested_chunk_size,
+            elevenlabs_music.MAX_ERROR_BODY_BYTES,
+        )
+        self.assertEqual(
+            detail,
+            "x" * elevenlabs_music.MAX_ERROR_BODY_BYTES,
+        )
+
     def test_api_key_prefers_config_and_falls_back_to_environment(self):
         with (
             patch.object(
@@ -240,6 +268,10 @@ class TestElevenLabsMusicService(unittest.TestCase):
             command = run.call_args.args[0]
             self.assertEqual(command[0], "test-ffmpeg")
             self.assertIn("-an", command)
+            self.assertEqual(
+                command[command.index("-fs") + 1],
+                str(elevenlabs_music.MAX_PROXY_BYTES),
+            )
             self.assertIn(
                 "force_original_aspect_ratio=decrease",
                 command[command.index("-vf") + 1],

--- a/test/services/test_elevenlabs_music.py
+++ b/test/services/test_elevenlabs_music.py
@@ -26,6 +26,7 @@ class _StreamingResponse:
         self.encoding = "utf-8"
         self.payload = payload if payload is not None else {"user_id": "test"}
         self.iter_error = iter_error
+        self.closed = False
 
     def iter_content(self, chunk_size):
         if self.iter_error:
@@ -39,6 +40,7 @@ class _StreamingResponse:
         return self
 
     def __exit__(self, *_args):
+        self.closed = True
         return False
 
 
@@ -143,6 +145,53 @@ class TestElevenLabsMusicService(unittest.TestCase):
         self.assertEqual(
             request.call_args.kwargs["headers"]["xi-api-key"], "test-key"
         )
+        self.assertTrue(request.call_args.kwargs["stream"])
+        self.assertTrue(response.closed)
+
+    def test_connection_reads_only_one_bounded_error_chunk(self):
+        class OversizedErrorResponse(_StreamingResponse):
+            def __init__(self):
+                super().__init__(status_code=500)
+                self.requested_chunk_sizes = []
+
+            @property
+            def text(self):
+                raise AssertionError("response.text must not be materialized")
+
+            @text.setter
+            def text(self, _value):
+                pass
+
+            def iter_content(self, chunk_size):
+                self.requested_chunk_sizes.append(chunk_size)
+                yield b"x" * chunk_size
+                raise AssertionError("error body must not be read further")
+
+        response = OversizedErrorResponse()
+        with (
+            patch.object(
+                elevenlabs_music.config,
+                "elevenlabs",
+                {"api_key": "test-key"},
+            ),
+            patch.object(
+                elevenlabs_music.requests,
+                "get",
+                return_value=response,
+            ) as request,
+            self.assertRaisesRegex(
+                elevenlabs_music.ElevenLabsMusicError,
+                r"account check failed \(500\)",
+            ),
+        ):
+            elevenlabs_music.test_connection()
+
+        self.assertTrue(request.call_args.kwargs["stream"])
+        self.assertEqual(
+            response.requested_chunk_sizes,
+            [elevenlabs_music.MAX_ERROR_BODY_BYTES],
+        )
+        self.assertTrue(response.closed)
 
     def test_connection_converts_http_network_and_payload_errors(self):
         failure_cases = [


### PR DESCRIPTION
## What changed

- read at most one 500-byte chunk from streamed ElevenLabs error responses before decoding and logging it
- pass FFmpeg `-fs` with the 200 MB proxy limit so the cap is enforced while encoding
- add regression coverage that rejects `.text` materialization and verifies the FFmpeg size option

## Why

The existing safeguards were applied only after resource consumption: `response.text` could materialize an oversized or endless error body, and the proxy size check ran only after FFmpeg finished writing. A faulty upstream or a high-entropy source could therefore exhaust worker memory or task-volume storage.

## Impact

Failed ElevenLabs generation requests now retain bounded diagnostic detail without unbounded memory use. Proxy encoding stops at the declared upload limit, while the existing post-encode validation remains as defense in depth.

## Validation

- `uv run pytest -q` — 469 passed, 11 skipped, 4032 subtests passed
- `uv run ruff check app/services/elevenlabs_music.py test/services/test_elevenlabs_music.py`
- `git diff --check`