### PR TITLE
feat(material): preserve provider provenance

### DIFF
--- a/app/services/material.py
+++ b/app/services/material.py
@@ -1,8 +1,12 @@
+import hashlib
+import json
 import os
 import random
+import tempfile
 import threading
-from typing import Callable, List
-from urllib.parse import quote_plus, urlencode
+from pathlib import Path
+from typing import Any, Callable, List
+from urllib.parse import quote_plus, urlencode, urlsplit, urlunsplit
 
 import requests
 from loguru import logger
@@ -16,6 +20,302 @@ from app.utils import utils
 # Thread-safe counter for API key rotation
 _api_key_counter = 0
 _api_key_lock = threading.Lock()
+
+
+class ProvenanceWriteError(RuntimeError):
+    """The material result cannot be returned without its provenance sidecar."""
+
+
+def _get_provenance(item: MaterialInfo) -> dict[str, Any]:
+    value = getattr(item, "_provider_provenance", None)
+    return value if isinstance(value, dict) else {}
+
+
+def _set_provenance(item: MaterialInfo, value: dict[str, Any]) -> None:
+    setattr(item, "_provider_provenance", value)
+
+
+def _canonical_json_sha256(value: Any) -> str:
+    rendered = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(rendered).hexdigest()
+
+
+def _safe_public_url(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = urlsplit(value.strip())
+    except ValueError:
+        return None
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        return None
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+
+
+def _creator(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, str) and value.strip():
+        return {"id": None, "name": value.strip(), "profile_page": None}
+    if not isinstance(value, dict):
+        return None
+    creator_id = value.get("id")
+    name = value.get("name") or value.get("username")
+    profile_page = _safe_public_url(
+        value.get("url") or value.get("profile_url") or value.get("profile_page")
+    )
+    if creator_id is None and not name and profile_page is None:
+        return None
+    return {
+        "id": str(creator_id) if creator_id is not None else None,
+        "name": str(name) if name else None,
+        "profile_page": profile_page,
+    }
+
+
+def _material_identity(item: MaterialInfo) -> tuple[Any, ...]:
+    provenance = _get_provenance(item)
+    rendition = provenance.get("rendition")
+    rendition_id = rendition.get("id") if isinstance(rendition, dict) else None
+    asset_id = provenance.get("asset_id")
+    if asset_id is not None and rendition_id is not None:
+        return item.provider, str(asset_id), str(rendition_id)
+    return item.provider, _safe_public_url(item.url)
+
+
+def _safe_attempt(item: MaterialInfo, status: str, error_code: str | None = None) -> dict[str, Any]:
+    provenance = _get_provenance(item)
+    rendition = provenance.get("rendition")
+    result = {
+        "status": status,
+        "provider": item.provider,
+        "asset_id": provenance.get("asset_id"),
+        "rendition_id": rendition.get("id") if isinstance(rendition, dict) else None,
+        "search_term": provenance.get("search_term"),
+        "rendition_url": _safe_public_url(item.url),
+    }
+    if error_code is not None:
+        result["error_code"] = error_code
+    return result
+
+
+def _local_artifact(path_value: str) -> dict[str, Any]:
+    path = Path(path_value).expanduser().absolute()
+    try:
+        if not path.is_file() or path.stat().st_size <= 0:
+            raise ProvenanceWriteError("material provenance local artifact is missing")
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return {
+            "path": str(path),
+            "sha256": digest.hexdigest(),
+            "bytes": path.stat().st_size,
+        }
+    except ProvenanceWriteError:
+        raise
+    except OSError as error:
+        raise ProvenanceWriteError(
+            "material provenance local artifact could not be hashed"
+        ) from error
+
+
+def _material_record(
+    item: MaterialInfo,
+    path: str,
+    selection_index: int,
+    max_clip_duration: int,
+) -> dict[str, Any]:
+    source = _get_provenance(item)
+    creator = source.get("creator")
+    safe_creator = None
+    if isinstance(creator, dict):
+        safe_creator = {
+            "id": creator.get("id"),
+            "name": creator.get("name"),
+            "profile_page": _safe_public_url(creator.get("profile_page")),
+        }
+    rendition = source.get("rendition")
+    safe_rendition: dict[str, Any] = {}
+    if isinstance(rendition, dict):
+        allowed_rendition_fields = (
+            "id",
+            "kind",
+            "quality",
+            "mime_type",
+            "width",
+            "height",
+            "fps",
+            "declared_bytes",
+            "aspect_ratio",
+        )
+        safe_rendition = {
+            field: rendition.get(field) for field in allowed_rendition_fields
+        }
+        safe_rendition["url"] = _safe_public_url(rendition.get("url") or item.url)
+    rights = source.get("rights")
+    safe_rights: dict[str, Any] = {}
+    if isinstance(rights, dict):
+        for field in (
+            "license_status",
+            "attribution_status",
+            "commercial_use",
+            "api_attribution_logo_required",
+        ):
+            if field in rights:
+                safe_rights[field] = rights[field]
+        if "reference" in rights:
+            safe_rights["reference"] = _safe_public_url(rights.get("reference"))
+    warnings = []
+    if item.provider == "coverr":
+        warnings.append(
+            "Coverr API and content-license attribution terms require separate review."
+        )
+    elif not source.get("asset_id"):
+        warnings.append("Provider identity was unavailable from the search result.")
+    return {
+        "selection_index": selection_index,
+        "search_term": source.get("search_term"),
+        "provider": item.provider,
+        "asset_id": source.get("asset_id"),
+        "canonical_page": _safe_public_url(source.get("canonical_page")),
+        "creator": safe_creator,
+        "provider_response_sha256": source.get("provider_response_sha256"),
+        "provider_result_index": source.get("provider_result_index"),
+        "provider_duration_sec": source.get("provider_duration_sec"),
+        "rendition": safe_rendition,
+        "rights": safe_rights,
+        "warnings": warnings,
+        "effective_clip_duration_sec": min(max_clip_duration, item.duration),
+        "local": _local_artifact(path),
+    }
+
+
+def _provenance_status(materials: list[dict[str, Any]]) -> str:
+    if not materials:
+        return "FAIL"
+    required = ("provider", "asset_id", "search_term", "provider_response_sha256", "rendition")
+    def complete(item: dict[str, Any]) -> bool:
+        response_hash = item.get("provider_response_sha256")
+        local = item.get("local")
+        local_path = local.get("path") if isinstance(local, dict) else None
+        local_sha256 = local.get("sha256") if isinstance(local, dict) else None
+        local_bytes = local.get("bytes") if isinstance(local, dict) else None
+        return (
+            all(item.get(field) not in (None, "") for field in required)
+            and isinstance(local_path, str)
+            and Path(local_path).is_absolute()
+            and isinstance(local_sha256, str)
+            and len(local_sha256) == 64
+            and all(character in "0123456789abcdef" for character in local_sha256)
+            and isinstance(local_bytes, int)
+            and not isinstance(local_bytes, bool)
+            and local_bytes > 0
+            and isinstance(item.get("rendition"), dict)
+            and item["rendition"].get("id") not in (None, "")
+            and isinstance(response_hash, str)
+            and len(response_hash) == 64
+            and all(character in "0123456789abcdef" for character in response_hash)
+        )
+
+    return (
+        "PASS"
+        if all(complete(item) for item in materials)
+        else "INCONCLUSIVE"
+    )
+
+
+def _fsync_parent_directory(path: Path, platform: str | None = None) -> None:
+    if (platform or os.name) == "nt":
+        return
+    directory_fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _write_provenance_sidecar(task_id: str, receipt: dict[str, Any]) -> None:
+    target = Path(utils.task_dir(task_id)) / "materials-provenance.json"
+    rendered = (
+        json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    ).encode("utf-8")
+    temp_path: Path | None = None
+    published = False
+    try:
+        if target.exists() or target.is_symlink():
+            if not target.is_symlink() and target.is_file() and target.read_bytes() == rendered:
+                return
+            raise ProvenanceWriteError("material provenance sidecar collision")
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            delete=False,
+        ) as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+            temp_path = Path(handle.name)
+        os.link(temp_path, target)
+        published = True
+        temp_path.unlink()
+        temp_path = None
+        _fsync_parent_directory(target.parent)
+    except ProvenanceWriteError:
+        raise
+    except OSError as error:
+        if published:
+            try:
+                target.unlink()
+            except OSError:
+                pass
+        raise ProvenanceWriteError("material provenance sidecar write failed") from error
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+
+
+def _publish_download_provenance(
+    *,
+    task_id: str,
+    source: str,
+    search_terms: List[str],
+    video_aspect: VideoAspect,
+    video_concat_mode: VideoConcatMode,
+    match_script_order: bool,
+    audio_duration: float,
+    max_clip_duration: int,
+    materials: list[dict[str, Any]],
+    attempts: list[dict[str, Any]],
+) -> None:
+    aspect_value = getattr(video_aspect, "value", video_aspect)
+    concat_value = getattr(video_concat_mode, "value", video_concat_mode)
+    receipt = {
+        "schema_version": 1,
+        "scope": "material_provider_provenance",
+        "status": _provenance_status(materials),
+        "task_id": task_id,
+        "provider": source,
+        "request": {
+            "search_terms": list(search_terms),
+            "video_aspect": aspect_value,
+            "video_concat_mode": concat_value,
+            "match_script_order": match_script_order,
+            "audio_duration_sec": audio_duration,
+            "max_clip_duration_sec": max_clip_duration,
+        },
+        "materials": materials,
+        "attempts": attempts,
+        "approval_scope": "provider_identity_and_local_byte_binding_only",
+    }
+    _write_provenance_sidecar(task_id, receipt)
 
 
 def _get_tls_verify() -> bool:
@@ -40,7 +340,6 @@ def get_api_key(cfg_key: str):
     if not api_keys:
         raise ValueError(
             f"\n\n##### {cfg_key} is not set #####\n\nPlease set it in the config.toml file: {config.config_file}\n\n"
-            f"{utils.to_json(config.app)}"
         )
 
     # if only one key is provided, return it
@@ -108,7 +407,7 @@ def search_videos_pexels(
     # Build URL
     params = {"query": search_term, "per_page": 20, "orientation": video_orientation}
     query_url = f"https://api.pexels.com/videos/search?{urlencode(params)}"
-    logger.info(f"searching videos: {query_url}, with proxies: {config.proxy}")
+    logger.info(f"searching videos on pexels: term={search_term!r}")
 
     try:
         r = requests.get(
@@ -119,13 +418,14 @@ def search_videos_pexels(
             timeout=(30, 60),
         )
         response = r.json()
+        response_sha256 = _canonical_json_sha256(response)
         video_items = []
         if "videos" not in response:
-            logger.error(f"search videos failed: {response}")
+            logger.error("pexels video search returned an unsupported response")
             return video_items
         videos = response["videos"]
         # loop through each video in the result
-        for v in videos:
+        for result_index, v in enumerate(videos):
             duration = v["duration"]
             # check if video has desired minimum duration
             if duration < minimum_duration:
@@ -140,11 +440,38 @@ def search_videos_pexels(
                     item.provider = "pexels"
                     item.url = video["link"]
                     item.duration = duration
+                    user = v.get("user")
+                    _set_provenance(item, {
+                        "search_term": search_term,
+                        "provider": "pexels",
+                        "asset_id": str(v.get("id")) if v.get("id") is not None else None,
+                        "canonical_page": _safe_public_url(v.get("url")),
+                        "creator": _creator(user),
+                        "provider_response_sha256": response_sha256,
+                        "provider_result_index": result_index,
+                        "provider_duration_sec": duration,
+                        "rendition": {
+                            "id": str(video.get("id")) if video.get("id") is not None else None,
+                            "kind": "video_file",
+                            "quality": video.get("quality"),
+                            "mime_type": video.get("file_type"),
+                            "width": w,
+                            "height": h,
+                            "fps": video.get("fps"),
+                            "declared_bytes": video.get("file_size") or video.get("size"),
+                            "url": _safe_public_url(video.get("link")),
+                        },
+                        "rights": {
+                            "license_status": "not_evaluated",
+                            "attribution_status": "not_evaluated",
+                        },
+                        "warnings": [],
+                    })
                     video_items.append(item)
                     break
         return video_items
     except Exception as e:
-        logger.error(f"search videos failed: {str(e)}")
+        logger.error(f"pexels video search failed: {type(e).__name__}")
 
     return []
 
@@ -212,22 +539,21 @@ def search_videos_pixabay(
                 f"status={status_code}, content_type={content_type or 'unknown'}"
             )
             return []
-
+        response_sha256 = _canonical_json_sha256(response)
         video_items = []
         if "hits" not in response:
-            logger.error(f"search videos failed: {response}")
+            logger.error("pixabay video search returned an unsupported response")
             return video_items
         videos = response["hits"]
         # loop through each video in the result
-        for v in videos:
+        for result_index, v in enumerate(videos):
             duration = v["duration"]
             # check if video has desired minimum duration
             if duration < minimum_duration:
                 continue
             video_files = v["videos"]
             # loop through each url to determine the best quality
-            for video_type in video_files:
-                video = video_files[video_type]
+            for video_type, video in video_files.items():
                 w = int(video["width"])
                 # h = int(video["height"])
                 if w >= video_width:
@@ -235,6 +561,33 @@ def search_videos_pixabay(
                     item.provider = "pixabay"
                     item.url = video["url"]
                     item.duration = duration
+                    _set_provenance(item, {
+                        "search_term": search_term,
+                        "provider": "pixabay",
+                        "asset_id": str(v.get("id")) if v.get("id") is not None else None,
+                        "canonical_page": _safe_public_url(v.get("pageURL")),
+                        "creator": {
+                            "id": str(v.get("user_id")) if v.get("user_id") is not None else None,
+                            "name": v.get("user"),
+                            "profile_page": None,
+                        },
+                        "provider_response_sha256": response_sha256,
+                        "provider_result_index": result_index,
+                        "provider_duration_sec": duration,
+                        "rendition": {
+                            "id": video_type,
+                            "kind": "video_variant",
+                            "width": w,
+                            "height": video.get("height"),
+                            "declared_bytes": video.get("size"),
+                            "url": _safe_public_url(video.get("url")),
+                        },
+                        "rights": {
+                            "license_status": "not_evaluated",
+                            "attribution_status": "not_evaluated",
+                        },
+                        "warnings": [],
+                    })
                     video_items.append(item)
                     break
         return video_items
@@ -286,7 +639,7 @@ def search_videos_coverr(
         "sort": "popular",
     }
     query_url = f"https://api.coverr.co/videos?{urlencode(params)}"
-    logger.info(f"searching videos: {query_url}, with proxies: {config.proxy}")
+    logger.info(f"searching videos on coverr: term={search_term!r}")
 
     try:
         r = requests.get(
@@ -297,13 +650,14 @@ def search_videos_coverr(
             timeout=(30, 60),
         )
         response = r.json()
+        response_sha256 = _canonical_json_sha256(response)
         video_items: List[MaterialInfo] = []
 
         if not isinstance(response, dict) or "hits" not in response:
-            logger.error(f"search videos failed: {response}")
+            logger.error("coverr video search returned an unsupported response")
             return video_items
 
-        for v in response["hits"]:
+        for result_index, v in enumerate(response["hits"]):
             # duration 在不同响应里可能是 number(11.625) 或 string("10.500000")
             try:
                 duration = int(float(v.get("duration") or 0))
@@ -321,10 +675,40 @@ def search_videos_coverr(
             item.provider = "coverr"
             item.url = mp4_download_url
             item.duration = duration
+            _set_provenance(item, {
+                "search_term": search_term,
+                "provider": "coverr",
+                "asset_id": str(video_id),
+                "canonical_page": _safe_public_url(
+                    v.get("canonical_url") or v.get("url")
+                ),
+                "creator": _creator(v.get("creator") or v.get("author")),
+                "provider_response_sha256": response_sha256,
+                "provider_result_index": result_index,
+                "provider_duration_sec": float(v.get("duration") or 0),
+                "rendition": {
+                    "id": "mp4_download",
+                    "kind": "mp4_download",
+                    "width": v.get("max_width"),
+                    "height": v.get("max_height"),
+                    "aspect_ratio": v.get("aspect_ratio"),
+                    "url": _safe_public_url(mp4_download_url),
+                },
+                "rights": {
+                    "license_status": "ambiguous",
+                    "attribution_status": "ambiguous",
+                    "commercial_use": "ambiguous",
+                    "api_attribution_logo_required": True,
+                    "reference": "https://coverr.co/license",
+                },
+                "warnings": [
+                    "Coverr API and content-license attribution terms require separate review."
+                ],
+            })
             video_items.append(item)
         return video_items
     except Exception as e:
-        logger.error(f"search videos failed: {str(e)}")
+        logger.error(f"coverr video search failed: {type(e).__name__}")
 
     return []
 
@@ -463,14 +847,14 @@ def download_videos(
     max_clip_duration: int = 5,
     match_script_order: bool = False,
 ) -> List[str]:
-    provider = "pexels"
-    remote_search_videos = search_videos_pexels
-    if source == "pixabay":
-        provider = "pixabay"
-        remote_search_videos = search_videos_pixabay
-    elif source == "coverr":
-        provider = "coverr"
-        remote_search_videos = search_videos_coverr
+    providers = {
+        "pexels": search_videos_pexels,
+        "pixabay": search_videos_pixabay,
+        "coverr": search_videos_coverr,
+    }
+    if source not in providers:
+        raise ValueError(f"unsupported online material source: {source}")
+    remote_search_videos = providers[source]
 
     def search_videos(
         search_term: str,
@@ -478,7 +862,7 @@ def download_videos(
         video_aspect: VideoAspect,
     ) -> List[MaterialInfo]:
         return _search_videos_with_cache(
-            provider=provider,
+            provider=source,
             search_videos=remote_search_videos,
             search_term=search_term,
             minimum_duration=minimum_duration,
@@ -495,15 +879,18 @@ def download_videos(
         return _download_videos_by_script_order(
             task_id=task_id,
             search_terms=search_terms,
+            source=source,
             search_videos=search_videos,
             video_aspect=video_aspect,
+            video_concat_mode=video_concat_mode,
             audio_duration=audio_duration,
             max_clip_duration=max_clip_duration,
             material_directory=material_directory,
         )
 
     valid_video_items = []
-    valid_video_urls = []
+    valid_video_identities = set()
+    attempts: list[dict[str, Any]] = []
     found_duration = 0.0
     for search_term in search_terms:
         video_items = search_videos(
@@ -514,15 +901,39 @@ def download_videos(
         logger.info(f"found {len(video_items)} videos for '{search_term}'")
 
         for item in video_items:
-            if item.url not in valid_video_urls:
-                valid_video_items.append(item)
-                valid_video_urls.append(item.url)
-                found_duration += item.duration
+            if not _get_provenance(item):
+                _set_provenance(item, {
+                    "search_term": search_term,
+                    "provider": item.provider,
+                    "asset_id": None,
+                    "canonical_page": None,
+                    "creator": None,
+                    "provider_response_sha256": None,
+                    "provider_result_index": None,
+                    "rendition": {
+                        "id": None,
+                        "kind": "download_url",
+                        "url": _safe_public_url(item.url),
+                    },
+                    "rights": {
+                        "license_status": "not_evaluated",
+                        "attribution_status": "not_evaluated",
+                    },
+                    "warnings": ["Provider identity was unavailable from the search result."],
+                })
+            identity = _material_identity(item)
+            if identity in valid_video_identities:
+                attempts.append(_safe_attempt(item, "DUPLICATE_SKIPPED"))
+                continue
+            valid_video_items.append(item)
+            valid_video_identities.add(identity)
+            found_duration += item.duration
 
     logger.info(
         f"found total videos: {len(valid_video_items)}, required duration: {audio_duration} seconds, found duration: {found_duration} seconds"
     )
-    video_paths = []
+    video_paths: list[str] = []
+    material_records: list[dict[str, Any]] = []
 
     concat_mode_value = getattr(video_concat_mode, "value", video_concat_mode)
     if concat_mode_value == VideoConcatMode.random.value:
@@ -531,13 +942,23 @@ def download_videos(
     total_duration = 0.0
     for item in valid_video_items:
         try:
-            logger.info(f"downloading video: {item.url}")
+            provenance = _get_provenance(item)
+            logger.info(
+                f"downloading {item.provider} video asset={provenance.get('asset_id')!r}"
+            )
             saved_video_path = save_video(
                 video_url=item.url, save_dir=material_directory
             )
             if saved_video_path:
                 logger.info(f"video saved: {saved_video_path}")
+                record = _material_record(
+                    item,
+                    saved_video_path,
+                    len(material_records),
+                    max_clip_duration,
+                )
                 video_paths.append(saved_video_path)
+                material_records.append(record)
                 seconds = min(max_clip_duration, item.duration)
                 total_duration += seconds
                 if total_duration > audio_duration:
@@ -545,17 +966,46 @@ def download_videos(
                         f"total duration of downloaded videos: {total_duration} seconds, skip downloading more"
                     )
                     break
+            else:
+                attempts.append(
+                    _safe_attempt(item, "DOWNLOAD_FAILED", "E_EMPTY_DOWNLOAD")
+                )
+        except ProvenanceWriteError:
+            raise
         except Exception as e:
-            logger.error(f"failed to download video: {utils.to_json(item)} => {str(e)}")
+            attempts.append(
+                _safe_attempt(
+                    item,
+                    "DOWNLOAD_FAILED",
+                    f"E_{type(e).__name__.upper()}",
+                )
+            )
+            logger.error(
+                f"failed to download {item.provider} material: {type(e).__name__}"
+            )
     logger.success(f"downloaded {len(video_paths)} videos")
+    _publish_download_provenance(
+        task_id=task_id,
+        source=source,
+        search_terms=search_terms,
+        video_aspect=video_aspect,
+        video_concat_mode=video_concat_mode,
+        match_script_order=False,
+        audio_duration=audio_duration,
+        max_clip_duration=max_clip_duration,
+        materials=material_records,
+        attempts=attempts,
+    )
     return video_paths
 
 
 def _download_videos_by_script_order(
     task_id: str,
     search_terms: List[str],
+    source: str,
     search_videos,
     video_aspect: VideoAspect,
+    video_concat_mode: VideoConcatMode,
     audio_duration: float,
     max_clip_duration: int,
     material_directory: str,
@@ -571,7 +1021,8 @@ def _download_videos_by_script_order(
     """
     logger.info("downloading videos with script-order material matching")
     candidate_groups = []
-    valid_video_urls = set()
+    valid_video_identities = set()
+    attempts: list[dict[str, Any]] = []
     found_duration = 0.0
 
     for search_term in search_terms:
@@ -584,10 +1035,32 @@ def _download_videos_by_script_order(
 
         term_items = []
         for item in video_items:
-            if item.url in valid_video_urls:
+            if not _get_provenance(item):
+                _set_provenance(item, {
+                    "search_term": search_term,
+                    "provider": item.provider,
+                    "asset_id": None,
+                    "canonical_page": None,
+                    "creator": None,
+                    "provider_response_sha256": None,
+                    "provider_result_index": None,
+                    "rendition": {
+                        "id": None,
+                        "kind": "download_url",
+                        "url": _safe_public_url(item.url),
+                    },
+                    "rights": {
+                        "license_status": "not_evaluated",
+                        "attribution_status": "not_evaluated",
+                    },
+                    "warnings": ["Provider identity was unavailable from the search result."],
+                })
+            identity = _material_identity(item)
+            if identity in valid_video_identities:
+                attempts.append(_safe_attempt(item, "DUPLICATE_SKIPPED"))
                 continue
             term_items.append(item)
-            valid_video_urls.add(item.url)
+            valid_video_identities.add(identity)
             found_duration += item.duration
 
         if term_items:
@@ -598,7 +1071,8 @@ def _download_videos_by_script_order(
         f"required duration: {audio_duration} seconds, found duration: {found_duration} seconds"
     )
 
-    video_paths = []
+    video_paths: list[str] = []
+    material_records: list[dict[str, Any]] = []
     total_duration = 0.0
     candidate_index = 0
     while candidate_groups and total_duration <= audio_duration:
@@ -610,24 +1084,46 @@ def _download_videos_by_script_order(
             has_candidate = True
             item = term_items[candidate_index]
             try:
+                provenance = _get_provenance(item)
                 logger.info(
-                    f"downloading ordered video for '{search_term}': {item.url}"
+                    f"downloading ordered {item.provider} video for {search_term!r}, "
+                    f"asset={provenance.get('asset_id')!r}"
                 )
                 saved_video_path = save_video(
                     video_url=item.url, save_dir=material_directory
                 )
                 if saved_video_path:
                     logger.info(f"video saved: {saved_video_path}")
+                    record = _material_record(
+                        item,
+                        saved_video_path,
+                        len(material_records),
+                        max_clip_duration,
+                    )
                     video_paths.append(saved_video_path)
+                    material_records.append(record)
                     total_duration += min(max_clip_duration, item.duration)
                     if total_duration > audio_duration:
                         logger.info(
                             f"total duration of downloaded videos: {total_duration} seconds, skip downloading more"
                         )
                         break
+                else:
+                    attempts.append(
+                        _safe_attempt(item, "DOWNLOAD_FAILED", "E_EMPTY_DOWNLOAD")
+                    )
+            except ProvenanceWriteError:
+                raise
             except Exception as e:
+                attempts.append(
+                    _safe_attempt(
+                        item,
+                        "DOWNLOAD_FAILED",
+                        f"E_{type(e).__name__.upper()}",
+                    )
+                )
                 logger.error(
-                    f"failed to download ordered video: {utils.to_json(item)} => {str(e)}"
+                    f"failed to download ordered {item.provider} material: {type(e).__name__}"
                 )
 
         if not has_candidate:
@@ -635,6 +1131,18 @@ def _download_videos_by_script_order(
         candidate_index += 1
 
     logger.success(f"downloaded {len(video_paths)} ordered videos")
+    _publish_download_provenance(
+        task_id=task_id,
+        source=source,
+        search_terms=search_terms,
+        video_aspect=video_aspect,
+        video_concat_mode=video_concat_mode,
+        match_script_order=True,
+        audio_duration=audio_duration,
+        max_clip_duration=max_clip_duration,
+        materials=material_records,
+        attempts=attempts,
+    )
     return video_paths
 
 

--- a/app/services/material_cache.py
+++ b/app/services/material_cache.py
@@ -19,7 +19,7 @@ from app.utils import utils
 
 
 MATERIAL_SEARCH_CACHE_TTL_SECONDS = 24 * 60 * 60
-_CACHE_FORMAT_VERSION = 1
+_CACHE_FORMAT_VERSION = 2
 _CACHE_CLEANUP_INTERVAL_SECONDS = 60 * 60
 _CACHE_FILE_PATTERN = re.compile(r"^[0-9a-f]{64}\.json$")
 
@@ -124,6 +124,26 @@ def load_material_search_cache(
     ``None`` 表示缓存未命中，需要请求远端 API；空列表不作为有效缓存返回，
     避免网络错误或上游异常被误缓存后持续阻断后续任务。
     """
+    if str(provider).strip().lower() == "coverr":
+        # Coverr 的 mp4_download URL 包含绑定 API key 的 signed JWT。它可以在
+        # 当前请求内下载，但不能写入磁盘缓存。若旧版本留下过缓存，访问同一
+        # 搜索条件时顺带清理，避免凭证继续驻留。
+        try:
+            _remove_invalid_cache(
+                _cache_path(
+                    provider=provider,
+                    search_term=search_term,
+                    minimum_duration=minimum_duration,
+                    video_aspect=video_aspect,
+                )
+            )
+        except Exception as exc:
+            logger.warning(
+                "failed to remove disabled Coverr material search cache: "
+                f"error={type(exc).__name__}, detail={exc}"
+            )
+        return None
+
     try:
         cache_path = _cache_path(
             provider=provider,
@@ -187,13 +207,18 @@ def load_material_search_cache(
                 or item_duration <= 0
             ):
                 raise ValueError("invalid material fields")
-            items.append(
-                MaterialInfo(
-                    provider=item_provider,
-                    url=item_url,
-                    duration=int(item_duration),
-                )
+            provenance = raw_item.get("provider_provenance")
+            if not isinstance(provenance, dict) or not provenance:
+                raise ValueError("invalid provider provenance")
+            provenance = dict(provenance)
+            provenance["search_term"] = search_term
+            item = MaterialInfo(
+                provider=item_provider,
+                url=item_url,
+                duration=int(item_duration),
             )
+            setattr(item, "_provider_provenance", provenance)
+            items.append(item)
     except (OSError, ValueError, TypeError) as exc:
         logger.warning(
             f"failed to load material search cache: "
@@ -223,17 +248,26 @@ def save_material_search_cache(
     ``os.replace`` 发布，可以保证读进程只会看到完整旧文件或完整新文件；
     即使两个写进程同时完成，最终内容也都是同一缓存键对应的合法结果。
     """
+    if str(provider).strip().lower() == "coverr":
+        return False
+
     temp_path = None
     try:
-        serialized_items = [
-            {
+        serialized_items = []
+        for item in items:
+            serialized_item = {
                 "provider": item.provider,
                 "url": item.url,
                 "duration": int(item.duration),
             }
-            for item in items
-            if item.url and item.duration > 0
-        ]
+            provenance = getattr(item, "_provider_provenance", None)
+            if not isinstance(provenance, dict) or not provenance:
+                raise ValueError("invalid provider provenance")
+            cached_provenance = dict(provenance)
+            cached_provenance.pop("search_term", None)
+            serialized_item["provider_provenance"] = cached_provenance
+            if item.url and item.duration > 0:
+                serialized_items.append(serialized_item)
         if not serialized_items:
             return False
 

--- a/test/services/test_material.py
+++ b/test/services/test_material.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import os
 import sys
 import tempfile
@@ -276,11 +278,14 @@ class TestMaterialTlsVerification(unittest.TestCase):
         VideoConcatMode 枚举。这里用空搜索词避免真实网络请求，只验证
         字符串 "random" 不会再因为访问 `.value` 抛 AttributeError。
         """
-        result = material.download_videos(
-            task_id="string-concat-mode",
-            search_terms=[],
-            video_concat_mode="random",
-        )
+        with tempfile.TemporaryDirectory() as temp_dir, patch.object(
+            material.utils, "task_dir", return_value=temp_dir
+        ):
+            result = material.download_videos(
+                task_id="string-concat-mode",
+                search_terms=[],
+                video_concat_mode="random",
+            )
 
         self.assertEqual(result, [])
 
@@ -305,39 +310,57 @@ class TestMaterialTlsVerification(unittest.TestCase):
         def fake_search(search_term, minimum_duration, video_aspect):
             return search_results[search_term]
 
-        def fake_save_video(video_url, save_dir=""):
-            downloaded_urls.append(video_url)
-            return f"/tmp/{video_url.rsplit('/', 1)[-1]}"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            task_dir = Path(temp_dir) / "task"
+            task_dir.mkdir()
 
-        with (
-            patch.dict(config.app, {"material_directory": ""}),
-            patch.object(material, "search_videos_pexels", side_effect=fake_search),
-            patch.object(material, "save_video", side_effect=fake_save_video),
-            patch.object(
-                material.material_cache,
-                "load_material_search_cache",
-                return_value=None,
-            ),
-            patch.object(material.material_cache, "save_material_search_cache"),
-        ):
-            result = material.download_videos(
-                task_id="ordered-materials",
-                search_terms=["opening city", "middle office"],
-                source="pexels",
-                audio_duration=7,
-                max_clip_duration=3,
-                match_script_order=True,
+            def fake_save_video(video_url, save_dir=""):
+                downloaded_urls.append(video_url)
+                target = Path(temp_dir) / video_url.rsplit("/", 1)[-1]
+                target.write_bytes(video_url.encode())
+                return str(target)
+
+            with (
+                patch.dict(config.app, {"material_directory": ""}),
+                patch.object(material, "search_videos_pexels", side_effect=fake_search),
+                patch.object(material, "save_video", side_effect=fake_save_video),
+                patch.object(material.utils, "task_dir", return_value=str(task_dir)),
+                patch.object(
+                    material.material_cache,
+                    "load_material_search_cache",
+                    return_value=None,
+                ),
+                patch.object(material.material_cache, "save_material_search_cache"),
+            ):
+                result = material.download_videos(
+                    task_id="ordered-materials",
+                    search_terms=["opening city", "middle office"],
+                    source="pexels",
+                    audio_duration=7,
+                    max_clip_duration=3,
+                    match_script_order=True,
+                )
+
+            self.assertEqual(
+                downloaded_urls,
+                [
+                    "https://v.example/a1.mp4",
+                    "https://v.example/b1.mp4",
+                    "https://v.example/a2.mp4",
+                ],
             )
-
-        self.assertEqual(
-            downloaded_urls,
-            [
-                "https://v.example/a1.mp4",
-                "https://v.example/b1.mp4",
-                "https://v.example/a2.mp4",
-            ],
-        )
-        self.assertEqual(result, ["/tmp/a1.mp4", "/tmp/b1.mp4", "/tmp/a2.mp4"])
+            self.assertEqual(
+                result,
+                [
+                    str(Path(temp_dir) / "a1.mp4"),
+                    str(Path(temp_dir) / "b1.mp4"),
+                    str(Path(temp_dir) / "a2.mp4"),
+                ],
+            )
+            sidecar = json.loads((task_dir / "materials-provenance.json").read_text())
+            self.assertEqual(
+                [item["local"]["path"] for item in sidecar["materials"]], result
+            )
 
 
 class TestCoverrProvider(unittest.TestCase):
@@ -381,6 +404,8 @@ class TestCoverrProvider(unittest.TestCase):
                         "id": "S1YbPl1NfI",
                         "duration": 11.625,
                         "aspect_ratio": "16:9",
+                        "max_width": 3840,
+                        "max_height": 2160,
                         "urls": {
                             "mp4": "https://storage.coverr.co/videos/abc?token=xyz",
                             "mp4_preview": "https://storage.coverr.co/videos/abc/preview?token=xyz",
@@ -400,6 +425,12 @@ class TestCoverrProvider(unittest.TestCase):
         item = results[0]
         self.assertEqual(item.provider, "coverr")
         self.assertEqual(item.duration, 11)
+        provenance = material._get_provenance(item)
+        self.assertEqual(provenance["asset_id"], "S1YbPl1NfI")
+        self.assertEqual(provenance["rendition"]["id"], "mp4_download")
+        self.assertEqual(provenance["rendition"]["width"], 3840)
+        self.assertEqual(provenance["provider_duration_sec"], 11.625)
+        self.assertEqual(provenance["rights"]["commercial_use"], "ambiguous")
         # url 字段就是 mp4_download URL,不再做 coverr://id|url 编码
         self.assertEqual(
             item.url, "https://storage.coverr.co/videos/abc/download?token=xyz"
@@ -559,25 +590,34 @@ class TestCoverrProvider(unittest.TestCase):
         fake_item.url = "https://storage.coverr.co/videos/abc/download?token=xyz"
         fake_item.duration = 10
 
-        with patch(
-            "app.services.material.search_videos_coverr",
-            return_value=[fake_item],
-        ) as search, patch(
-            "app.services.material.save_video",
-            return_value="/tmp/coverr-saved.mp4",
-        ) as save, patch(
-            "app.services.material.material_cache.load_material_search_cache",
-            return_value=None,
-        ), patch(
-            "app.services.material.material_cache.save_material_search_cache",
-        ):
-            result = material.download_videos(
-                task_id="t-coverr",
-                search_terms=["nature"],
-                source="coverr",
-                audio_duration=5,
-                max_clip_duration=5,
-            )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            saved = Path(temp_dir) / "coverr-saved.mp4"
+            saved.write_bytes(b"coverr")
+            task_dir = Path(temp_dir) / "task"
+            task_dir.mkdir()
+            with patch(
+                "app.services.material.search_videos_coverr",
+                return_value=[fake_item],
+            ) as search, patch(
+                "app.services.material.save_video",
+                return_value=str(saved),
+            ) as save, patch.object(
+                material.utils, "task_dir", return_value=str(task_dir)
+            ), patch.object(
+                material.material_cache,
+                "load_material_search_cache",
+                return_value=None,
+            ), patch.object(
+                material.material_cache,
+                "save_material_search_cache",
+            ):
+                result = material.download_videos(
+                    task_id="t-coverr",
+                    search_terms=["nature"],
+                    source="coverr",
+                    audio_duration=5,
+                    max_clip_duration=5,
+                )
 
         # 1. dispatch
         self.assertEqual(search.call_count, 1)
@@ -589,7 +629,293 @@ class TestCoverrProvider(unittest.TestCase):
         )
 
         # 3. 返回值正确
-        self.assertEqual(result, ["/tmp/coverr-saved.mp4"])
+        self.assertEqual(result, [str(saved)])
+
+
+class TestMaterialProvenance(unittest.TestCase):
+    def setUp(self):
+        self.original_app_config = dict(config.app)
+        self.original_proxy_config = dict(config.proxy)
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.work = Path(self.temp_dir.name)
+        self.task_dir = self.work / "task"
+        self.task_dir.mkdir()
+
+    def tearDown(self):
+        config.app.clear()
+        config.app.update(self.original_app_config)
+        config.proxy.clear()
+        config.proxy.update(self.original_proxy_config)
+        self.temp_dir.cleanup()
+
+    @staticmethod
+    def item(asset_id, rendition_id, url, term, provider="pexels"):
+        item = material.MaterialInfo(
+            provider=provider,
+            url=url,
+            duration=5,
+        )
+        material._set_provenance(
+            item,
+            {
+                "search_term": term,
+                "provider": provider,
+                "asset_id": asset_id,
+                "canonical_page": f"https://example.com/assets/{asset_id}?ref=secret#x",
+                "creator": {"id": "creator", "name": "Creator", "profile_page": None},
+                "provider_response_sha256": "a" * 64,
+                "provider_result_index": 0,
+                "rendition": {
+                    "id": rendition_id,
+                    "kind": "video_file",
+                    "url": material._safe_public_url(url),
+                },
+                "rights": {
+                    "license_status": "not_evaluated",
+                    "attribution_status": "not_evaluated",
+                },
+                "warnings": [],
+            },
+        )
+        return item
+
+    def run_download(self, search_results, *, terms, save_side_effect, ordered=False):
+        def fake_search(search_term, minimum_duration, video_aspect):
+            return search_results[search_term]
+
+        with (
+            patch.dict(config.app, {"material_directory": ""}),
+            patch.object(material, "search_videos_pexels", side_effect=fake_search),
+            patch.object(material, "save_video", side_effect=save_side_effect),
+            patch.object(material.utils, "task_dir", return_value=str(self.task_dir)),
+            patch.object(
+                material.material_cache,
+                "load_material_search_cache",
+                return_value=None,
+            ),
+            patch.object(material.material_cache, "save_material_search_cache"),
+        ):
+            return material.download_videos(
+                task_id="provenance-task",
+                search_terms=terms,
+                source="pexels",
+                audio_duration=20,
+                max_clip_duration=5,
+                match_script_order=ordered,
+            )
+
+    def test_search_provider_fields_are_preserved_without_signed_urls(self):
+        config.app["pexels_api_keys"] = ["pexels-secret"]
+        response = {
+            "videos": [
+                {
+                    "id": 123,
+                    "url": "https://pexels.example/video/123?ref=x#frag",
+                    "duration": 8,
+                    "user": {
+                        "id": 7,
+                        "name": "Ada",
+                        "url": "https://pexels.example/@ada?utm=x",
+                    },
+                    "video_files": [
+                        {
+                            "id": 99,
+                            "quality": "hd",
+                            "file_type": "video/mp4",
+                            "width": 1080,
+                            "height": 1920,
+                            "fps": 30,
+                            "file_size": 42,
+                            "link": "https://cdn.example/v.mp4?token=do-not-store#frag",
+                        }
+                    ],
+                }
+            ]
+        }
+        with patch(
+            "app.services.material.requests.get",
+            return_value=SimpleNamespace(json=lambda: response),
+        ):
+            item = material.search_videos_pexels("agent team", 1)[0]
+
+        provenance = material._get_provenance(item)
+        self.assertEqual(provenance["asset_id"], "123")
+        self.assertEqual(provenance["creator"]["name"], "Ada")
+        self.assertEqual(provenance["rendition"]["id"], "99")
+        self.assertEqual(provenance["rendition"]["url"], "https://cdn.example/v.mp4")
+        self.assertNotIn("do-not-store", json.dumps(provenance))
+
+    def test_pixabay_preserves_selected_variant_and_redacts_key(self):
+        config.app["pixabay_api_keys"] = ["pixabay-secret-key"]
+        response = {
+            "hits": [
+                {
+                    "id": 321,
+                    "pageURL": "https://pixabay.example/videos/id-321/?ref=x#frag",
+                    "duration": 9,
+                    "user_id": 8,
+                    "user": "Grace",
+                    "videos": {
+                        "large": {
+                            "width": 1920,
+                            "height": 1080,
+                            "size": 99,
+                            "url": "https://cdn.example/p.mp4?token=secret-download",
+                        }
+                    },
+                }
+            ]
+        }
+        with patch(
+            "app.services.material.requests.get",
+            return_value=SimpleNamespace(json=lambda: response),
+        ) as get, patch("app.services.material.logger.info") as info:
+            item = material.search_videos_pixabay("workflow", 1)[0]
+
+        self.assertIn("key=pixabay-secret-key", get.call_args.args[0])
+        provenance = material._get_provenance(item)
+        self.assertEqual(provenance["asset_id"], "321")
+        self.assertEqual(provenance["creator"]["name"], "Grace")
+        self.assertEqual(provenance["rendition"]["id"], "large")
+        rendered = json.dumps(provenance)
+        logs = " ".join(str(call.args[0]) for call in info.call_args_list)
+        self.assertNotIn("pixabay-secret-key", rendered + logs)
+        self.assertNotIn("secret-download", rendered)
+
+    def test_sidecar_binds_ordered_local_bytes_and_strips_tokens(self):
+        first = self.item("1", "r1", "https://cdn.example/a.mp4?token=one#x", "one")
+        second = self.item("2", "r2", "https://cdn.example/b.mp4?jwt=two", "two")
+
+        def save(video_url, save_dir=""):
+            target = self.work / ("a.mp4" if "/a.mp4" in video_url else "b.mp4")
+            target.write_bytes(video_url.encode())
+            return str(target)
+
+        paths = self.run_download(
+            {"one": [first], "two": [second]},
+            terms=["one", "two"],
+            save_side_effect=save,
+            ordered=True,
+        )
+        raw = (self.task_dir / "materials-provenance.json").read_text()
+        sidecar = json.loads(raw)
+        self.assertEqual(sidecar["status"], "PASS")
+        self.assertEqual(
+            [entry["local"]["path"] for entry in sidecar["materials"]], paths
+        )
+        for entry, path in zip(sidecar["materials"], paths):
+            data = Path(path).read_bytes()
+            self.assertEqual(entry["local"]["bytes"], len(data))
+            self.assertEqual(
+                entry["local"]["sha256"], hashlib.sha256(data).hexdigest()
+            )
+        self.assertNotIn("token=one", raw)
+        self.assertNotIn("jwt=two", raw)
+        self.assertNotIn("ref=secret", raw)
+
+    def test_local_binding_failure_never_returns_an_unbound_path(self):
+        item = self.item("1", "r1", "https://cdn.example/a.mp4", "one")
+        saved = self.work / "saved.mp4"
+        saved.write_bytes(b"video")
+
+        for ordered in (False, True):
+            with self.subTest(ordered=ordered):
+                sidecar = self.task_dir / "materials-provenance.json"
+                sidecar.unlink(missing_ok=True)
+                with patch.object(
+                    material,
+                    "_local_artifact",
+                    side_effect=material.ProvenanceWriteError("binding failed"),
+                ), self.assertRaises(material.ProvenanceWriteError):
+                    self.run_download(
+                        {"one": [item]},
+                        terms=["one"],
+                        save_side_effect=lambda video_url, save_dir="": str(saved),
+                        ordered=ordered,
+                    )
+                self.assertFalse(sidecar.exists())
+
+    def test_signed_query_changes_do_not_defeat_asset_deduplication(self):
+        first = self.item("same", "same-r", "https://cdn.example/v.mp4?token=one", "one")
+        duplicate = self.item("same", "same-r", "https://cdn.example/v.mp4?token=two", "two")
+        saved = self.work / "saved.mp4"
+        saved.write_bytes(b"video")
+        calls = []
+
+        def save(video_url, save_dir=""):
+            calls.append(video_url)
+            return str(saved)
+
+        paths = self.run_download(
+            {"one": [first], "two": [duplicate]},
+            terms=["one", "two"],
+            save_side_effect=save,
+        )
+        sidecar = json.loads((self.task_dir / "materials-provenance.json").read_text())
+        self.assertEqual(paths, [str(saved)])
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(sidecar["materials"]), 1)
+        self.assertEqual(sidecar["attempts"][0]["status"], "DUPLICATE_SKIPPED")
+        self.assertEqual(sidecar["attempts"][0]["search_term"], "two")
+
+    def test_download_failure_is_only_recorded_in_attempts(self):
+        failed = self.item("bad", "r-bad", "https://cdn.example/bad.mp4?token=x", "term")
+        good = self.item("good", "r-good", "https://cdn.example/good.mp4?token=y", "term")
+        saved = self.work / "good.mp4"
+        saved.write_bytes(b"good")
+
+        def save(video_url, save_dir=""):
+            if "bad.mp4" in video_url:
+                raise requests.ConnectionError("secret-token-in-exception")
+            return str(saved)
+
+        paths = self.run_download(
+            {"term": [failed, good]}, terms=["term"], save_side_effect=save
+        )
+        raw = (self.task_dir / "materials-provenance.json").read_text()
+        sidecar = json.loads(raw)
+        self.assertEqual(paths, [str(saved)])
+        self.assertEqual([item["asset_id"] for item in sidecar["materials"]], ["good"])
+        self.assertEqual(sidecar["attempts"][0]["status"], "DOWNLOAD_FAILED")
+        self.assertNotIn("secret-token-in-exception", raw)
+        self.assertNotIn("token=x", raw)
+
+    def test_sidecar_collision_fails_closed_without_overwrite(self):
+        existing = self.task_dir / "materials-provenance.json"
+        existing.write_text("keep\n")
+        item = self.item("1", "r1", "https://cdn.example/a.mp4", "one")
+        saved = self.work / "saved.mp4"
+        saved.write_bytes(b"video")
+
+        with self.assertRaises(material.ProvenanceWriteError):
+            self.run_download(
+                {"one": [item]},
+                terms=["one"],
+                save_side_effect=lambda video_url, save_dir="": str(saved),
+            )
+
+        self.assertEqual(existing.read_text(), "keep\n")
+
+    def test_missing_key_error_does_not_dump_other_credentials(self):
+        config.app.clear()
+        config.app["unrelated_secret"] = "must-not-leak"
+        with self.assertRaises(ValueError) as raised:
+            material.get_api_key("pexels_api_keys")
+        self.assertNotIn("must-not-leak", str(raised.exception))
+
+    def test_unknown_provider_is_rejected_before_search(self):
+        with self.assertRaisesRegex(ValueError, "unsupported online material source"):
+            material.download_videos(
+                task_id="bad-provider",
+                search_terms=["one"],
+                source="not-a-provider",
+            )
+
+    def test_sidecar_publish_skips_directory_fsync_on_windows(self):
+        with patch.object(
+            material.os, "open", side_effect=AssertionError("must not open directory")
+        ):
+            material._fsync_parent_directory(self.task_dir, platform="nt")
 
 
 if __name__ == "__main__":

--- a/test/services/test_material_cache.py
+++ b/test/services/test_material_cache.py
@@ -7,6 +7,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+from app.config import config
 from app.models.schema import MaterialInfo, VideoAspect
 from app.services import material, material_cache
 
@@ -26,7 +27,21 @@ class TestMaterialSearchCache(unittest.TestCase):
 
     @staticmethod
     def _item(url: str = "https://example.com/video.mp4") -> MaterialInfo:
-        return MaterialInfo(provider="pixabay", url=url, duration=12)
+        item = MaterialInfo(provider="pixabay", url=url, duration=12)
+        material._set_provenance(
+            item,
+            {
+                "search_term": "nature",
+                "provider": "pixabay",
+                "asset_id": "123",
+                "provider_response_sha256": "a" * 64,
+                "rendition": {
+                    "id": "large",
+                    "url": "https://example.com/video.mp4",
+                },
+            },
+        )
+        return item
 
     def _cache_path(self) -> Path:
         return material_cache._cache_path(
@@ -60,6 +75,10 @@ class TestMaterialSearchCache(unittest.TestCase):
         self.assertEqual(loaded[0].provider, "pixabay")
         self.assertEqual(loaded[0].url, "https://example.com/video.mp4")
         self.assertEqual(loaded[0].duration, 12)
+        self.assertEqual(
+            material._get_provenance(loaded[0]),
+            material._get_provenance(self._item()),
+        )
 
     def test_expired_cache_is_removed_and_treated_as_miss(self):
         """
@@ -84,6 +103,64 @@ class TestMaterialSearchCache(unittest.TestCase):
             minimum_duration=5,
             video_aspect=VideoAspect.portrait,
             now=now,
+        )
+
+        self.assertIsNone(loaded)
+        self.assertFalse(cache_path.exists())
+
+    def test_version_one_cache_is_removed_and_treated_as_miss(self):
+        """升级后不能继续读取会丢失 provider provenance 的 v1 缓存。"""
+        cache_path = self._cache_path()
+        cache_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "items": [
+                        {
+                            "provider": "pixabay",
+                            "url": "https://example.com/video.mp4",
+                            "duration": 12,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        loaded = material_cache.load_material_search_cache(
+            provider="pixabay",
+            search_term="nature",
+            minimum_duration=5,
+            video_aspect=VideoAspect.portrait,
+        )
+
+        self.assertIsNone(loaded)
+        self.assertFalse(cache_path.exists())
+
+    def test_version_two_cache_without_provenance_is_invalid(self):
+        """v2 条目缺少 provenance 时必须远端重取，不能静默降级。"""
+        cache_path = self._cache_path()
+        cache_path.write_text(
+            json.dumps(
+                {
+                    "version": material_cache._CACHE_FORMAT_VERSION,
+                    "items": [
+                        {
+                            "provider": "pixabay",
+                            "url": "https://example.com/video.mp4",
+                            "duration": 12,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        loaded = material_cache.load_material_search_cache(
+            provider="pixabay",
+            search_term="nature",
+            minimum_duration=5,
+            video_aspect=VideoAspect.portrait,
         )
 
         self.assertIsNone(loaded)
@@ -166,8 +243,90 @@ class TestMaterialSearchCache(unittest.TestCase):
 
         self.assertEqual(len(cache_files), 1)
         self.assertNotIn("private search term", cache_files[0].name)
-        payload = json.loads(cache_files[0].read_text(encoding="utf-8"))
+        raw = cache_files[0].read_text(encoding="utf-8")
+        self.assertNotIn("private search term", raw)
+        payload = json.loads(raw)
         self.assertEqual(set(payload), {"version", "items"})
+
+        loaded = material_cache.load_material_search_cache(
+            provider="pixabay",
+            search_term="private search term",
+            minimum_duration=5,
+            video_aspect=VideoAspect.portrait,
+        )
+        self.assertEqual(
+            material._get_provenance(loaded[0])["search_term"],
+            "private search term",
+        )
+
+    def test_coverr_signed_urls_are_never_persisted(self):
+        """Coverr signed JWT 下载地址只能在当前请求内使用，不能进入磁盘缓存。"""
+        item = MaterialInfo(
+            provider="coverr",
+            url="https://storage.coverr.co/video/download?token=signed-jwt",
+            duration=12,
+        )
+        material._set_provenance(
+            item,
+            {
+                "search_term": "nature",
+                "provider": "coverr",
+                "asset_id": "coverr-123",
+                "provider_response_sha256": "c" * 64,
+                "rendition": {
+                    "id": "mp4_download",
+                    "url": "https://storage.coverr.co/video/download",
+                },
+            },
+        )
+
+        saved = material_cache.save_material_search_cache(
+            provider="coverr",
+            search_term="nature",
+            minimum_duration=5,
+            video_aspect=VideoAspect.portrait,
+            items=[item],
+        )
+
+        self.assertFalse(saved)
+        self.assertEqual(list(Path(self.temp_dir.name).glob("*.json")), [])
+
+    def test_coverr_cache_load_removes_legacy_signed_url(self):
+        """读取 Coverr 条件时应删除旧版本可能留下的 signed URL 缓存。"""
+        cache_path = material_cache._cache_path(
+            provider="coverr",
+            search_term="nature",
+            minimum_duration=5,
+            video_aspect=VideoAspect.portrait,
+        )
+        cache_path.write_text(
+            json.dumps(
+                {
+                    "version": material_cache._CACHE_FORMAT_VERSION,
+                    "items": [
+                        {
+                            "provider": "coverr",
+                            "url": "https://storage.coverr.co/video?token=signed-jwt",
+                            "duration": 12,
+                            "provider_provenance": {
+                                "asset_id": "coverr-123"
+                            },
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        loaded = material_cache.load_material_search_cache(
+            provider="coverr",
+            search_term="nature",
+            minimum_duration=5,
+            video_aspect=VideoAspect.portrait,
+        )
+
+        self.assertIsNone(loaded)
+        self.assertFalse(cache_path.exists())
 
     def test_cache_key_separates_provider_duration_and_aspect(self):
         """
@@ -228,6 +387,86 @@ class TestMaterialSearchCache(unittest.TestCase):
 
         self.assertEqual(remote_search.call_count, 1)
         self.assertEqual(first, second)
+        self.assertEqual(
+            material._get_provenance(second[0]),
+            material._get_provenance(first[0]),
+        )
+
+    def test_cache_hit_preserves_identity_deduplication_and_sidecar(self):
+        """缓存命中后仍须按 provider asset identity 去重并产出 PASS sidecar。"""
+
+        def cached_item(search_term: str, url: str) -> MaterialInfo:
+            item = MaterialInfo(provider="pexels", url=url, duration=12)
+            material._set_provenance(
+                item,
+                {
+                    "search_term": search_term,
+                    "provider": "pexels",
+                    "asset_id": "same-asset",
+                    "canonical_page": "https://example.com/assets/same-asset",
+                    "creator": None,
+                    "provider_response_sha256": "b" * 64,
+                    "provider_result_index": 0,
+                    "provider_duration_sec": 12,
+                    "rendition": {
+                        "id": "same-rendition",
+                        "kind": "video_file",
+                        "url": "https://cdn.example/video.mp4",
+                    },
+                    "rights": {
+                        "license_status": "not_evaluated",
+                        "attribution_status": "not_evaluated",
+                    },
+                    "warnings": [],
+                },
+            )
+            return item
+
+        for search_term, token in (("one", "first"), ("two", "second")):
+            self.assertTrue(
+                material_cache.save_material_search_cache(
+                    provider="pexels",
+                    search_term=search_term,
+                    minimum_duration=5,
+                    video_aspect=VideoAspect.portrait,
+                    items=[
+                        cached_item(
+                            search_term,
+                            f"https://cdn.example/video.mp4?token={token}",
+                        )
+                    ],
+                )
+            )
+
+        task_dir = Path(self.temp_dir.name) / "task"
+        task_dir.mkdir()
+        saved = Path(self.temp_dir.name) / "saved.mp4"
+        saved.write_bytes(b"video")
+
+        with (
+            patch.dict(config.app, {"material_directory": ""}),
+            patch.object(
+                material,
+                "search_videos_pexels",
+                side_effect=AssertionError("cache hit must not call provider"),
+            ),
+            patch.object(material, "save_video", return_value=str(saved)) as save,
+            patch.object(material.utils, "task_dir", return_value=str(task_dir)),
+        ):
+            result = material.download_videos(
+                task_id="cached-provenance",
+                search_terms=["one", "two"],
+                source="pexels",
+                audio_duration=20,
+                max_clip_duration=5,
+            )
+
+        sidecar = json.loads((task_dir / "materials-provenance.json").read_text())
+        self.assertEqual(result, [str(saved)])
+        self.assertEqual(save.call_count, 1)
+        self.assertEqual(sidecar["status"], "PASS")
+        self.assertEqual(len(sidecar["materials"]), 1)
+        self.assertEqual(sidecar["attempts"][0]["status"], "DUPLICATE_SKIPPED")
 
     def test_search_wrapper_retries_after_empty_result(self):
         """空结果不缓存，下一次调用仍应访问远端，以便临时故障恢复后自动重试。"""


### PR DESCRIPTION
## Summary

- preserve provider asset, creator, rendition, and response identity while downloading materials
- write an atomic no-overwrite `storage/tasks/<task_id>/materials-provenance.json` sidecar
- bind each returned local path to fresh SHA-256 and byte size in exact return order
- redact credentials, signed query parameters, raw responses, and unsafe exception text
- keep `download_videos(...) -> list[str]`, task intermediate results, and public `MaterialInfo` schema unchanged

## Safety and scope

The sidecar proves provider identity plus local byte binding only. It does not claim that provider rights or asset-specific third-party rights have been approved. Write failures and collisions fail closed.

## Tests

- full suite: 483 passed, 11 skipped, 4034 subtests passed
- Ruff: PASS
- py_compile: PASS
- git diff --check: PASS

This branch is based on current upstream `main`, including the merged Pixabay API-key log redaction from #1130.