### PR TITLE
feat: add Atlas Cloud LLM provider

### DIFF
--- a/app/models/llm_provider.py
+++ b/app/models/llm_provider.py
@@ -159,6 +159,12 @@ LLM_PROVIDER_REGISTRY = (
     ),
     # 聚合与统一接入平台
     LLMProviderSpec(
+        "atlascloud",
+        "Atlas Cloud",
+        default_model="deepseek-ai/deepseek-v4-pro",
+        default_base_url="https://api.atlascloud.ai/v1",
+    ),
+    LLMProviderSpec(
         "cloudflare",
         "Cloudflare AI Gateway",
         adapter="cloudflare_ai_gateway",

--- a/config.example.toml
+++ b/config.example.toml
@@ -141,6 +141,11 @@ mimo_api_key = ""
 mimo_base_url = ""
 mimo_model_name = ""
 
+# Atlas Cloud, using the OpenAI-compatible Chat Completions API.
+atlascloud_api_key = ""
+atlascloud_base_url = ""
+atlascloud_model_name = ""
+
 # Cloudflare AI Gateway. The token requires AI Gateway Read/Edit and Workers AI
 # Read permissions. Leave gateway_id empty to use the Registry default.
 # Dashboard: https://dash.cloudflare.com/

--- a/test/services/test_llm.py
+++ b/test/services/test_llm.py
@@ -227,6 +227,16 @@ class TestLiteLLMProvider(unittest.TestCase):
         self.assertEqual(get_llm_provider("openai").default_model, "gpt-5.5")
         self.assertEqual(get_llm_provider("aimlapi").default_model, "openai/gpt-5-5")
         self.assertEqual(get_llm_provider("deepseek").default_model, "deepseek-v4-pro")
+        atlascloud = get_llm_provider("atlascloud")
+        self.assertEqual(
+            atlascloud.default_model,
+            "deepseek-ai/deepseek-v4-pro",
+        )
+        self.assertEqual(
+            atlascloud.default_base_url,
+            "https://api.atlascloud.ai/v1",
+        )
+        self.assertEqual(atlascloud.adapter, "openai_compatible")
         self.assertEqual(
             get_llm_provider("modelscope").default_model, "ZhipuAI/GLM-5.2"
         )
@@ -280,6 +290,7 @@ class TestLiteLLMProvider(unittest.TestCase):
                 "grok",
                 "minimax",
                 "mimo",
+                "atlascloud",
                 "cloudflare",
                 "modelscope",
                 "aihubmix",


### PR DESCRIPTION
## Summary
- add Atlas Cloud to the centralized LLM provider registry
- use the existing OpenAI-compatible adapter with Atlas Cloud defaults
- expose the provider configuration keys in `config.example.toml` and cover registry defaults/order

## Validation
- project-pinned Ruff check and format check
- registry/config contracts on Python 3.11 and 3.12
- Python 3.12 compileall
- live OpenAI SDK chat completion using the registry defaults

No README or documentation changes.