### PR TITLE
fix(api): validate positive video generation limits

### DIFF
--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -82,10 +82,10 @@ class VideoParams(BaseModel):
     video_aspect: Optional[VideoAspect] = VideoAspect.portrait.value
     video_concat_mode: Optional[VideoConcatMode] = VideoConcatMode.random.value
     video_transition_mode: Optional[VideoTransitionMode] = None
-    video_clip_duration: Optional[int] = 5
+    video_clip_duration: int = Field(default=5, ge=1)
     video_clip_speed: Optional[float] = 1.0
     match_materials_to_script: bool = False
-    video_count: Optional[int] = 1
+    video_count: int = Field(default=1, ge=1)
 
     video_source: Optional[str] = "pexels"
     video_materials: Optional[List[MaterialInfo]] = (

--- a/test/services/test_schema.py
+++ b/test/services/test_schema.py
@@ -2,9 +2,11 @@ import sys
 import unittest
 from pathlib import Path
 
+from pydantic import ValidationError
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from app.models.schema import VideoAspect
+from app.models.schema import VideoAspect, VideoParams
 
 
 class TestVideoAspect(unittest.TestCase):
@@ -16,6 +18,23 @@ class TestVideoAspect(unittest.TestCase):
     def test_to_resolution_rejects_unsupported_value(self):
         with self.assertRaises(ValueError):
             VideoAspect.to_resolution("4:5")
+
+
+class TestVideoParams(unittest.TestCase):
+    def test_rejects_non_positive_generation_counts(self):
+        for field_name in ("video_clip_duration", "video_count"):
+            for value in (0, -1, None):
+                with self.subTest(field_name=field_name, value=value):
+                    with self.assertRaises(ValidationError):
+                        VideoParams(video_subject="Coffee", **{field_name: value})
+
+    def test_accepts_positive_generation_counts(self):
+        params = VideoParams(
+            video_subject="Coffee", video_clip_duration=1, video_count=1
+        )
+
+        self.assertEqual(params.video_clip_duration, 1)
+        self.assertEqual(params.video_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Reject non-positive clip durations before they reach the media pipeline.
- Reject non-positive video counts before a task can spend provider resources and fail late.

## Root cause

The API model allowed zero, negative, and null values even though the WebUI and CLI require positive integers. A zero clip duration made the material-splitting loop stop advancing, while a non-positive video count could fail only after earlier generation stages completed.

## Validation

- `python3 -m compileall -q app/models/schema.py test/services/test_schema.py`
- `git diff --check`
