### PR TITLE
feat(subtitle): make whisper initial_prompt configurable

### DIFF
--- a/app/services/subtitle.py
+++ b/app/services/subtitle.py
@@ -15,6 +15,7 @@ from app.utils import utils
 model_size = config.whisper.get("model_size", "large-v3")
 device = config.whisper.get("device", "cpu")
 compute_type = config.whisper.get("compute_type", "int8")
+initial_prompt = config.whisper.get("initial_prompt", "") or None
 model = None
 
 
@@ -57,6 +58,7 @@ def create(audio_file, subtitle_file: str = ""):
         word_timestamps=True,
         vad_filter=True,
         vad_parameters=dict(min_silence_duration_ms=500),
+        **({"initial_prompt": initial_prompt} if initial_prompt else {}),
     )
 
     logger.info(

--- a/config.example.toml
+++ b/config.example.toml
@@ -284,6 +284,10 @@ model_size = "large-v3"
 # "float16" or "int8_float16" for CUDA.
 device = "cpu"
 compute_type = "int8"
+# Optional prompt that biases Whisper's decoder toward specific vocabulary
+# (brand names, technical terms). Passed as initial_prompt to transcribe().
+# Leave empty to disable.
+# initial_prompt = ""
 
 # =============================================================================
 # Material Request Proxy / 素材请求代理


### PR DESCRIPTION
## Summary

Allow biasing Whisper's decoder with a vocabulary prompt (brand names, technical terms) via a new `[whisper] initial_prompt` config key, passed as `initial_prompt` to `transcribe()`.

## Motivation

Whisper sometimes mis-transcribes brand names and technical terms. The existing `correct()` pass matches subtitles against the script, but the transcription itself benefits from a decoder bias prompt.

## Changes

- `app/services/subtitle.py`: read `config.whisper initial_prompt` at module load; pass it to `model.transcribe()` only when set (no behavior change when empty).
- `config.example.toml`: document the new key under `[whisper]`.