### PR TITLE
fix(elevenlabs): stop wiping the saved API key on every restart

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -252,6 +252,18 @@ def is_elevenlabs_voice(voice_name: str) -> bool:
     return (voice_name or "").startswith("elevenlabs:")
 
 
+def get_elevenlabs_api_key() -> str:
+    """
+    读取 ElevenLabs TTS 使用的 API Key。
+
+    与 elevenlabs_music.get_api_key 保持一致：环境变量仅作为本机配置未填写时的
+    后备来源。缺少该回退时，只设置 ELEVENLABS_API_KEY 的部署会在界面上看起来
+    正常，却在生成阶段失败并提示 API Key 未设置。
+    """
+    configured_key = str(config.elevenlabs.get("api_key", "") or "").strip()
+    return configured_key or os.getenv("ELEVENLABS_API_KEY", "").strip()
+
+
 def is_chatterbox_voice(voice_name: str) -> bool:
     return (voice_name or "").startswith("chatterbox:")
 
@@ -1288,7 +1300,7 @@ def elevenlabs_tts(
         logger.error("ElevenLabs TTS text is empty")
         return None
 
-    api_key = config.elevenlabs.get("api_key", "")
+    api_key = get_elevenlabs_api_key()
     if not api_key:
         logger.error("ElevenLabs API key is not set")
         return None

--- a/test/services/test_voice.py
+++ b/test/services/test_voice.py
@@ -1024,7 +1024,10 @@ class TestElevenLabsVoice(unittest.TestCase):
     @patch("app.services.voice.config")
     def test_elevenlabs_tts_no_api_key(self, mock_config):
         mock_config.elevenlabs.get.return_value = ""
-        result = vs.elevenlabs_tts("Hello", "abc123", "/tmp/test.mp3")
+        # Key 解析包含环境变量回退，宿主机上导出的 ELEVENLABS_API_KEY 会让
+        # "未配置 Key" 这个前提不再成立，因此显式清空。
+        with patch.dict(os.environ, {}, clear=True):
+            result = vs.elevenlabs_tts("Hello", "abc123", "/tmp/test.mp3")
         self.assertIsNone(result)
 
     @patch("app.services.voice.config")
@@ -1032,6 +1035,58 @@ class TestElevenLabsVoice(unittest.TestCase):
         mock_config.elevenlabs.get.return_value = "fake-key"
         result = vs.elevenlabs_tts("  ", "abc123", "/tmp/test.mp3")
         self.assertIsNone(result)
+
+    def test_api_key_prefers_config_over_environment(self):
+        with (
+            patch.object(vs.config, "elevenlabs", {"api_key": "config-key"}),
+            patch.dict(os.environ, {"ELEVENLABS_API_KEY": "env-key"}),
+        ):
+            self.assertEqual(vs.get_elevenlabs_api_key(), "config-key")
+
+    def test_api_key_falls_back_to_environment(self):
+        """
+        只设置 ELEVENLABS_API_KEY 的部署此前会在界面上看起来正常，却在生成阶段
+        以 "API key is not set" 失败，因为 TTS 只读取 config.toml。
+        """
+        with (
+            patch.object(vs.config, "elevenlabs", {"api_key": ""}),
+            patch.dict(os.environ, {"ELEVENLABS_API_KEY": "env-key"}),
+        ):
+            self.assertEqual(vs.get_elevenlabs_api_key(), "env-key")
+
+    def test_api_key_ignores_surrounding_whitespace(self):
+        with (
+            patch.object(vs.config, "elevenlabs", {"api_key": "   "}),
+            patch.dict(os.environ, {"ELEVENLABS_API_KEY": "  env-key  "}),
+        ):
+            self.assertEqual(vs.get_elevenlabs_api_key(), "env-key")
+
+    def test_api_key_missing_everywhere_is_empty(self):
+        with (
+            patch.object(vs.config, "elevenlabs", {}),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            self.assertEqual(vs.get_elevenlabs_api_key(), "")
+
+    def test_api_key_resolution_matches_music_service(self):
+        """TTS 与配乐共用同一个账号配置，两者的解析结果必须一致。"""
+        from app.services import elevenlabs_music
+
+        for config_key, env_key in (("config-key", "env-key"), ("", "env-key")):
+            with self.subTest(config_key=config_key, env_key=env_key):
+                with (
+                    patch.object(vs.config, "elevenlabs", {"api_key": config_key}),
+                    patch.object(
+                        elevenlabs_music.config,
+                        "elevenlabs",
+                        {"api_key": config_key},
+                    ),
+                    patch.dict(os.environ, {"ELEVENLABS_API_KEY": env_key}),
+                ):
+                    self.assertEqual(
+                        vs.get_elevenlabs_api_key(),
+                        elevenlabs_music.get_api_key(),
+                    )
 
 
 if __name__ == "__main__":

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -2784,8 +2784,9 @@ def _render_elevenlabs_api_key_input(label_key):
     后渲染的输入框还会覆盖共享配置。这里统一使用一个 key，并集中处理环境变量
     回填、配置更新和音色缓存失效，确保界面显示与后台任务始终读取同一个值。
     """
+    env_key = os.getenv("ELEVENLABS_API_KEY", "").strip()
     configured_key = str(config.elevenlabs.get("api_key", "") or "").strip()
-    effective_key = configured_key or os.getenv("ELEVENLABS_API_KEY", "").strip()
+    effective_key = configured_key or env_key
     entered_key = st.text_input(
         tr(label_key),
         value=effective_key,
@@ -2799,8 +2800,15 @@ def _render_elevenlabs_api_key_input(label_key):
                 del st.session_state[cache_key]
 
     # 环境变量仅用于当前进程，不在用户未修改时自动复制到 config.toml。
-    # 已有配置或用户主动修改输入时才更新本机配置，与 Sonilo 行为保持一致。
-    if configured_key or entered_key != effective_key:
+    #
+    # An empty widget value must never clobber a stored key. Streamlit password
+    # inputs report an empty value whenever a session is replayed — for example
+    # when a still-open browser tab reconnects after a server restart — and the
+    # previous condition wrote that empty string straight back into config.toml,
+    # wiping the saved key on every restart. A replayed empty value cannot be
+    # told apart from a deliberate clear by value alone, so the stored key wins;
+    # remove it by editing config.toml.
+    if entered_key and entered_key != env_key:
         config.elevenlabs["api_key"] = entered_key
     return entered_key
 
@@ -3126,7 +3134,14 @@ def _render_audio_settings(panel, params):
                     "elevenlabs_api_key_input",
                     config.elevenlabs.get("api_key", ""),
                 )
-                if saved_elevenlabs_api_key:
+                # A key that only came from ELEVENLABS_API_KEY must not be copied
+                # into config.toml, which `save_config` rewrites on nearly every
+                # interaction. Both TTS and background music fall back to the
+                # environment variable themselves, so leaving it out costs
+                # nothing and keeps the secret in .env where it was put.
+                if saved_elevenlabs_api_key and saved_elevenlabs_api_key != os.getenv(
+                    "ELEVENLABS_API_KEY", ""
+                ).strip():
                     config.elevenlabs["api_key"] = saved_elevenlabs_api_key
                 cache_key = f"elevenlabs_voices_{saved_elevenlabs_api_key}"
                 if cache_key not in st.session_state:


### PR DESCRIPTION
## Problem

The ElevenLabs API key has to be re-entered on virtually every app load. It is saved, it works for the session, and then it is gone.

`_render_elevenlabs_api_key_input` in `webui/Main.py` persisted the widget value whenever a key was already stored:

```python
if configured_key or entered_key != effective_key:
    config.elevenlabs["api_key"] = entered_key
```

Once a key was saved, `configured_key` was truthy, so the assignment ran **unconditionally** — including when `entered_key` came back empty. Streamlit password inputs report an empty value when a session is replayed (for instance a still-open browser tab reconnecting after a server restart), so the empty string was written straight back over the stored key, and `save_config()` persisted the wipe.

### Reproduction

1. Put a valid key in `config.toml` under `[elevenlabs] api_key`, with the WebUI open in a browser tab.
2. Restart the containers.
3. Within seconds, `[elevenlabs] api_key` is `""`.

## Fix

An empty widget value can no longer overwrite a stored key. A replayed empty value cannot be distinguished from a deliberate clear by value alone, so the stored key wins — clearing it is done by editing `config.toml`.

Two related fixes are included:

- **`app/services/voice.py`** gained the `ELEVENLABS_API_KEY` fallback that `elevenlabs_music.get_api_key` already had, extracted as `get_elevenlabs_api_key()` to mirror that function. Without it, a deployment that set only the environment variable looked correctly configured in the WebUI but failed at generation time with `ElevenLabs API key is not set`.

- **The TTS branch** that primes the key for the Play Voice button no longer copies an environment-derived key into `config.toml`, so a secret kept in the environment stays out of the file the WebUI rewrites.

## Tests

Adds regression tests for key resolution, including one asserting that TTS and background music resolve identically.

Also pins the existing `test_elevenlabs_tts_no_api_key` to an empty environment: that test asserts behaviour when no key is configured, and with the new fallback its premise no longer holds on a host that exports `ELEVENLABS_API_KEY`. Verified it now passes both with and without that variable set.

Full suite: **509 passed, 11 skipped, 4035 subtests passed**.