### PR TITLE
feat(webui): autoplay voice preview

### DIFF
--- a/test/services/test_webui_voice_preview.py
+++ b/test/services/test_webui_voice_preview.py
@@ -156,6 +156,46 @@ def test_script_shows_estimate_and_enables_full_voiceover_preview():
     assert [str(item.value) for item in app.exception] == []
 
 
+def test_short_preview_autoplays_only_after_explicit_click_and_reuses_cache():
+    """短试听应立即播放；普通 rerun 不重播，重复点击也不重复调用 TTS。"""
+    test_ui = dict(
+        config.ui,
+        voice_mode="tts",
+        tts_server="azure-tts-v1",
+        voice_name="zh-CN-XiaoxiaoNeural-Female",
+    )
+
+    def fake_tts(**kwargs):
+        Path(kwargs["voice_file"]).write_bytes(
+            b"RIFF\x24\x00\x00\x00WAVEfmt " + b"\x00" * 32
+        )
+        return object()
+
+    with (
+        patch.object(config, "ui", test_ui),
+        patch.object(config, "save_config"),
+        patch.object(voice, "tts", side_effect=fake_tts) as synthesize,
+        patch.object(voice, "get_audio_duration", return_value=3.0),
+    ):
+        app = AppTest.from_file(str(WEBUI_MAIN), default_timeout=30)
+        app.session_state["ui_language"] = "zh"
+        app.run()
+
+        _button_by_key(app, "play_voice_button").click().run()
+        assert len(app.get("audio")) == 1
+        assert app.get("audio")[0].proto.autoplay
+
+        app.run()
+        assert len(app.get("audio")) == 1
+        assert not app.get("audio")[0].proto.autoplay
+
+        _button_by_key(app, "play_voice_button").click().run()
+
+    synthesize.assert_called_once()
+    assert app.get("audio")[0].proto.autoplay
+    assert [str(item.value) for item in app.exception] == []
+
+
 def test_full_preview_uses_script_and_reuses_identical_cached_audio():
     """完整试听使用当前文案，相同参数重复点击时不得再次调用 TTS。"""
     script = "这是一段用于验证完整配音预览缓存的测试文案。"
@@ -197,6 +237,7 @@ def test_full_preview_uses_script_and_reuses_identical_cached_audio():
     synthesize.assert_called_once()
     assert synthesize.call_args.kwargs["text"] == script
     assert len(app.get("audio")) == 1
+    assert not app.get("audio")[0].proto.autoplay
     assert any("实际配音时长：12.3 秒" in item.value for item in app.caption)
     assert [str(item.value) for item in app.exception] == []
 

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -2875,9 +2875,19 @@ def _render_voice_preview(params, friendly_names, selected_tts_server, voice_nam
         and cached_preview.get("fingerprint") in valid_fingerprints
         and cached_preview.get("audio_bytes")
     ):
+        # 只在用户本次明确点击“试听音色”时自动播放。Streamlit 的其它控件
+        # 也会触发页面 rerun；如果对缓存音频永久开启 autoplay，修改任意设置
+        # 都可能让旧试听从头播放。完整试听继续保留手动播放，避免较长音频在
+        # 生成完成后意外打断用户。
+        should_autoplay = bool(
+            short_preview_requested
+            and cached_preview.get("preview_type") == "sample"
+            and cached_preview.get("fingerprint") == sample_fingerprint
+        )
         st.audio(
             cached_preview["audio_bytes"],
             format=cached_preview.get("mime_type", "audio/mp3"),
+            autoplay=should_autoplay,
         )
         if cached_preview.get("preview_type") == "full":
             duration = cached_preview.get("duration")


### PR DESCRIPTION
• ## Summary

  This PR improves the WebUI voice preview experience by automatically playing the generated short voice sample after the user clicks **Play Voice**.
  Previously, the preview audio was generated and displayed successfully, but users had to click the audio player again to hear it.
  ## Changes
  - Automatically play short voice samples after an explicit **Play Voice** click
  - Reuse cached preview audio without making another TTS request
  - Allow repeated clicks to replay the cached sample
  - Prevent cached audio from replaying during unrelated Streamlit reruns
  - Keep full voiceover previews in manual-play mode
  - Add tests covering autoplay, cache reuse, reruns, and full-preview behavior

  ## Implementation Details
  Autoplay is enabled only when:
  - the user explicitly requests a short voice sample
  - the cached preview is a short sample
  - the cached preview fingerprint matches the current voice settings

  This prevents unexpected playback when users change other WebUI settings.

  ## Testing

  ```bash
  .venv/bin/python -m pytest -q test/services/test_webui_voice_preview.py
  .venv/bin/ruff check webui/Main.py test/services/test_webui_voice_preview.py
```
  Results:
  - 13 tests passed
  - Ruff checks passed

  ## 说明
  本 PR 优化了 WebUI 的音色试听体验。用户点击 试听音色 后，系统生成的短试听音频会立即自动播放。
  此前试听音频能够正常生成并显示在播放器中，但用户还需要再次点击播放器才能听到声音。
  ## 主要改动

  - 点击 试听音色 后自动播放生成的短试听音频
  - 相同配置下复用缓存，不重复调用 TTS 服务
  - 再次点击试听按钮时直接重播缓存音频
  - 修改其他 WebUI 设置导致页面重新运行时，不自动重播旧音频
  - “完整试听”继续保持手动播放，避免长音频意外播放
  - 增加自动播放、缓存复用、页面重新运行和完整试听相关测试

  ## 实现细节
  仅在满足以下条件时启用自动播放：
  - 用户本次明确点击了“试听音色”
  - 当前缓存内容属于短音色试听
  - 缓存指纹与当前音色、语速、音量和服务配置一致
  这样可以避免用户调整其他设置时，缓存中的试听音频意外从头播放。
  ## 测试结果

  - 13 项相关测试全部通过
  - Ruff 静态检查通过