### PR TITLE
feat(ui): add id-ID to support_locales

### DIFF
--- a/webui/Main.py
+++ b/webui/Main.py
@@ -1408,6 +1408,7 @@ support_locales = [
     "en-US",
     "es-ES",
     "fr-FR",
+    "id-ID",
     "ru-RU",
     "vi-VN",
     "th-TH",


### PR DESCRIPTION
Added Indonesian (`id-ID`) to the list of supported locales/languages in the WebUI.
This ensures the pipeline correctly routes Indonesian prompts for script generation and selects the appropriate TTS voices for voiceovers.

This PR has been split from the original submission to only include the language addition, per reviewer feedback.