### PR TITLE
fix(tasks): roll back state when scheduling fails

### DIFF
--- a/app/controllers/v1/video.py
+++ b/app/controllers/v1/video.py
@@ -206,11 +206,19 @@ def create_task(
             "params": body.model_dump(),
         }
         sm.state.update_task(task_id)
-        task_manager.add_task(tm.start, task_id=task_id, params=body, stop_at=stop_at)
+        try:
+            task_manager.add_task(
+                tm.start, task_id=task_id, params=body, stop_at=stop_at
+            )
+        except Exception:
+            # 状态记录在调度前创建，默认标记为 processing。如果调度器没能
+            # 接管任务（例如线程启动失败或 Redis 队列不可用），必须回滚该
+            # 记录，否则 API 和 WebUI 会永久展示一个实际从未运行的任务。
+            sm.state.delete_task(task_id)
+            raise
         logger.success(f"Task created: {utils.to_json(task)}")
         return utils.get_response(200, task)
     except TaskQueueFullError as e:
-        sm.state.delete_task(task_id)
         logger.warning(
             f"reject task because queue is full, request_id: {request_id}, task_id: {task_id}"
         )

--- a/test/services/test_controller_video.py
+++ b/test/services/test_controller_video.py
@@ -173,6 +173,30 @@ class TestVideoControllerTasks(unittest.TestCase):
         self.assertEqual(raised.exception.status_code, 429)
         delete_task.assert_called_once_with("task-123")
 
+    def test_create_task_removes_state_when_scheduler_fails(self):
+        """调度器未能接管任务时，不能留下永远处于 processing 的状态。"""
+        body = MagicMock()
+        body.model_dump.return_value = {"video_subject": "Coffee"}
+        scheduling_error = RuntimeError("can't start new thread")
+        state = sm.MemoryState()
+
+        with (
+            patch.object(video_controller.utils, "get_uuid", return_value="task-123"),
+            patch.object(video_controller.sm, "state", state),
+            patch.object(
+                video_controller.task_manager,
+                "add_task",
+                side_effect=scheduling_error,
+            ),
+        ):
+            with self.assertRaises(RuntimeError) as raised:
+                video_controller.create_task(
+                    self._request(), body, stop_at="video"
+                )
+
+        self.assertIs(raised.exception, scheduling_error)
+        self.assertIsNone(state.get_task("task-123"))
+
     def test_get_all_tasks_preserves_pagination(self):
         """任务列表响应必须包含状态层返回的总数和请求分页参数。"""
         with patch.object(


### PR DESCRIPTION
## Summary

- roll back the initial task state if `task_manager.add_task()` fails before accepting the task
- preserve the existing `TaskQueueFullError` to HTTP 429 mapping while sharing the same cleanup boundary
- add a regression test that uses a real `MemoryState` and preserves the original scheduling exception

## Problem

`create_task()` persisted a default `processing` state before calling the scheduler. The queue-full path removed that state, but other scheduler failures (for example, `threading.Thread.start()` raising `RuntimeError: can't start new thread`) propagated without cleanup. The task never ran, yet `/tasks` continued to expose it as `processing` with 0% progress.

I searched existing issues and open PRs for stuck/ghost task state and scheduling failures and found no matching report. Because the defect and fix are both localized and fully described here, I did not open a separate issue solely to close it immediately with this PR.

## TDD evidence

Before the implementation, the new regression test failed because the actual task state remained present after the injected scheduler error. After the implementation, it verifies both invariants:

1. the original `RuntimeError` is still propagated;
2. `MemoryState.get_task(task_id)` returns `None`.

The cleanup is intentionally scoped to `add_task()` only. A task that was successfully started or queued is not deleted if later logging or response serialization fails.

## Tests

- `uv run pytest -q test/services/test_controller_video.py test/services/test_task_manager.py` — 35 passed, 22 subtests passed
- `python -m compileall -q app cli.py main.py webui test`
- `ruff check app cli.py main.py webui test`
- `python -X utf8 -m coverage run -m pytest -q test` — 584 passed, 11 skipped, 4374 subtests passed
- `python -m coverage report` — 75% branch coverage (70% required)
- `git diff --check`

## Risk

Low. Success paths are unchanged, and the existing queue-full regression test continues to require exactly one state deletion and HTTP 429. If the state backend itself is unavailable, cleanup can still fail; this PR does not attempt to introduce a distributed transaction.