### PR TITLE
fix(llm): preserve internal newlines in _normalize_text_response

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -64,7 +64,7 @@ def _normalize_text_response(content, llm_provider: str) -> str:
     if not content:
         raise ValueError(f"[{llm_provider}] returned empty text content")
 
-    return content.replace("\n", "")
+    return content.strip("\n")
 
 
 def _sanitize_error_message(error: object) -> str:


### PR DESCRIPTION
## 问题

`app/services/llm.py` 中的 `_normalize_text_response()` 使用 `content.replace("\n", "")` 处理 LLM 返回文本，这会删除内容中**所有**换行符，而不只是首尾多余的空白。

这带来两个实际影响：

1. `generate_script()` 依赖 `response.split("\n\n")` 按段落切分脚本，一旦换行全部被去掉，无论用户要求生成几段，脚本都会被压成一整段。
2. 依赖 `splitlines()` 做字幕行对齐的逻辑也会因此失效。

这是一个每次多段脚本生成都会触发的功能性回归。

## 修复

将 `content.replace("\n", "")` 改为 `content.strip("\n")`，只去除首尾换行/空白，保留内部段落结构，不影响后续 `.strip()` 之类的调用。

## 测试

- 手动验证：多段落 LLM 返回文本经过 `_normalize_text_response` 后，段落分隔符 `\n\n` 得以保留，`response.split("\n\n")` 能正确切分出多段。
- 单行/无换行文本行为不变。
