### PR TITLE
fix(controllers): register ping health check router

### DIFF
--- a/app/router.py
+++ b/app/router.py
@@ -1,4 +1,4 @@
-"""Application configuration - root APIRouter.
+"""Application configuration - root APIRouter
 
 Defines all FastAPI application endpoints.
 
@@ -9,9 +9,12 @@ Resources:
 
 from fastapi import APIRouter
 
+from app.controllers import ping
 from app.controllers.v1 import llm, video
 
 root_api_router = APIRouter()
+root_api_router.include_router(ping.router)
+
 # v1
 root_api_router.include_router(video.router)
 root_api_router.include_router(llm.router)

--- a/test/services/test_controller_ping.py
+++ b/test/services/test_controller_ping.py
@@ -1,0 +1,14 @@
+import unittest
+
+from app.controllers import ping as ping_controller
+
+
+class TestPingController(unittest.TestCase):
+    def test_ping(self):
+        response = ping_controller.ping(None)
+
+        self.assertEqual(response, "pong")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR registers the existing `ping` health-check router with the root API router so the FastAPI application properly exposes the endpoint.

The test follows the repository's existing controller unit-test style, directly testing the controller function and verifying that it returns the expected `"pong"` response.

### Changes

* Register `ping.router` in `root_api_router`
* Add a unit test for the ping controller
* Follow the existing controller testing pattern used by other endpoints
