### PR TITLE
fix(schema): improve response schemas and migrate to Pydantic v2 ConfigDict

### DIFF
--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -398,6 +398,8 @@ class TaskListResponse(BaseResponse):
 
 
 class TaskDeletionResponse(BaseResponse):
+    data: None = None
+
     model_config = ConfigDict(
         json_schema_extra={
             "example": {

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -46,8 +46,10 @@ class VideoAspect(str, Enum):
         raise ValueError(f"unsupported video aspect: {self}")
 
 
-class _Config:
-    arbitrary_types_allowed = True
+_Config = ConfigDict(
+    arbitrary_types_allowed=True,
+    # Note: ensure your key names match renamed V2 parameters if needed
+)
 
 
 @pydantic.dataclasses.dataclass(config=_Config)
@@ -91,8 +93,10 @@ class VideoParams(BaseModel):
     video_materials: Optional[List[MaterialInfo]] = (
         None  # Materials used to generate the video
     )
-    
-    custom_audio_file: Optional[str] = None  # Custom audio file path, will ignore TTS and can still use Whisper subtitles
+
+    custom_audio_file: Optional[str] = (
+        None  # Custom audio file path, will ignore TTS and can still use Whisper subtitles
+    )
     video_language: Optional[str] = ""  # auto detect
 
     voice_name: Optional[str] = ""
@@ -107,7 +111,9 @@ class VideoParams(BaseModel):
     sonilo_bgm_prompt: str = Field(default="", max_length=2000)
 
     subtitle_enabled: Optional[bool] = True
-    subtitle_position: Optional[str] = config.ui.get("subtitle_position", "bottom")  # top, bottom, center, custom
+    subtitle_position: Optional[str] = config.ui.get(
+        "subtitle_position", "bottom"
+    )  # top, bottom, center, custom
     custom_position: float = config.ui.get("custom_position", 70.0)
     font_name: Optional[str] = "STHeitiMedium.ttc"
     text_fore_color: Optional[str] = "#FFFFFF"
@@ -208,12 +214,6 @@ class VideoSocialMetadataParams:
     platform: Optional[str] = Field(default="tiktok", max_length=64)
 
 
-class BaseResponse(BaseModel):
-    status: int = 200
-    message: Optional[str] = "success"
-    data: Any = None
-
-
 class TaskVideoRequest(VideoParams, BaseModel):
     pass
 
@@ -234,24 +234,25 @@ class VideoSocialMetadataRequest(VideoSocialMetadataParams, BaseModel):
     pass
 
 
-######################################################################################################
-######################################################################################################
-######################################################################################################
-######################################################################################################
-class TaskResponse(BaseResponse):
-    class TaskResponseData(BaseModel):
-        task_id: str
+# ---------------------------
+# ----- RESPONSE MODELS -----
+# ---------------------------
+class BaseResponse(BaseModel):
+    status: int = 200
+    message: Optional[str] = "success"
+    data: Any = None
 
-    data: TaskResponseData
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "status": 200,
-                "message": "success",
-                "data": {"task_id": "6c85c8cc-a77a-42b9-bc30-947815aa0558"},
-            },
-        }
+# ---- DATA MODELS ----
+class TaskResponseData(BaseModel):
+    task_id: str
+
+
+class TaskDeletionData(BaseModel):
+    state: int
+    progress: int
+    videos: Optional[List[str]]
+    combined_videos: Optional[List[str]]
 
 
 class TaskStatusData(BaseModel):
@@ -280,6 +281,59 @@ class TaskListData(BaseModel):
     total: int
     page: int
     page_size: int
+
+
+class VideoScriptData(BaseModel):
+    video_script: str
+
+
+class VideoTermsData(BaseModel):
+    video_terms: List[str]
+
+
+class VideoSocialMetadataData(BaseModel):
+    title: str
+    caption: str
+    hashtags: List[str]
+
+
+class FileData(BaseModel):
+    name: str
+    size: int
+    file: str
+
+
+class BgmRetrieveData(BaseModel):
+    files: List[FileData]
+
+
+class BgmUploadData(BaseModel):
+    file: str
+
+
+class VideoMaterialRetrieveData(BaseModel):
+    files: List[FileData]
+
+
+class VideoMaterialUploadData(BaseModel):
+    file: str
+
+
+# ---- RESPONSE MODELS ----
+class TaskResponse(BaseResponse):
+    data: TaskResponseData
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "status": 200,
+                "message": "success",
+                "data": {
+                    "task_id": "6c85c8cc-a77a-42b9-bc30-947815aa0558",
+                },
+            },
+        }
+    )
 
 
 class TaskQueryResponse(BaseResponse):
@@ -351,8 +405,10 @@ class TaskListResponse(BaseResponse):
 
 
 class TaskDeletionResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: TaskDeletionData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
@@ -368,11 +424,14 @@ class TaskDeletionResponse(BaseResponse):
                 },
             },
         }
+    )
 
 
 class VideoScriptResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: VideoScriptData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
@@ -381,22 +440,28 @@ class VideoScriptResponse(BaseResponse):
                 },
             },
         }
+    )
 
 
 class VideoTermsResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: VideoTermsData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
                 "data": {"video_terms": ["sky", "tree"]},
             },
         }
+    )
 
 
 class VideoSocialMetadataResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: VideoSocialMetadataData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
@@ -407,11 +472,14 @@ class VideoSocialMetadataResponse(BaseResponse):
                 },
             },
         }
+    )
 
 
 class BgmRetrieveResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: BgmRetrieveData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
@@ -426,21 +494,28 @@ class BgmRetrieveResponse(BaseResponse):
                 },
             },
         }
+    )
 
 
 class BgmUploadResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: BgmUploadData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
                 "data": {"file": "4fca18fce7344f3aa824777a40d45c8c.mp3"},
             },
         }
+    )
+
 
 class VideoMaterialRetrieveResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: VideoMaterialRetrieveData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
@@ -455,10 +530,14 @@ class VideoMaterialRetrieveResponse(BaseResponse):
                 },
             },
         }
+    )
+
 
 class VideoMaterialUploadResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: VideoMaterialUploadData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
@@ -467,3 +546,4 @@ class VideoMaterialUploadResponse(BaseResponse):
                 },
             },
         }
+    )

--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -248,13 +248,6 @@ class TaskResponseData(BaseModel):
     task_id: str
 
 
-class TaskDeletionData(BaseModel):
-    state: int
-    progress: int
-    videos: Optional[List[str]]
-    combined_videos: Optional[List[str]]
-
-
 class TaskStatusData(BaseModel):
     """任务查询对外保证的稳定字段；历史和扩展字段继续原样透传。"""
 
@@ -405,23 +398,12 @@ class TaskListResponse(BaseResponse):
 
 
 class TaskDeletionResponse(BaseResponse):
-    data: TaskDeletionData
-
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
-                "data": {
-                    "state": 1,
-                    "progress": 100,
-                    "videos": [
-                        "http://127.0.0.1:8080/tasks/6c85c8cc-a77a-42b9-bc30-947815aa0558/final-1.mp4"
-                    ],
-                    "combined_videos": [
-                        "http://127.0.0.1:8080/tasks/6c85c8cc-a77a-42b9-bc30-947815aa0558/combined-1.mp4"
-                    ],
-                },
+                "data": None,
             },
         }
     )

--- a/test/services/test_controller_video.py
+++ b/test/services/test_controller_video.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from fastapi.testclient import TestClient
+
+from app import asgi
 from app.config import config
 from app.controllers.manager.base_manager import TaskQueueFullError
 from app.controllers.v1 import video as video_controller
@@ -34,20 +37,16 @@ class TestVideoControllerHelpers(unittest.TestCase):
         ):
             with self.subTest(filename=filename):
                 self.assertEqual(
-                    video_controller._sanitize_upload_filename(
-                        filename, "request-123"
-                    ),
+                    video_controller._sanitize_upload_filename(filename, "request-123"),
                     expected,
                 )
 
     def test_fastapi_startup_recovers_interrupted_cross_posts(self):
         """API 进程启动时必须执行一次发布遗留状态恢复。"""
-        from app import asgi
         from app.services import task as task_service
 
-        with patch.object(
-            task_service, "recover_interrupted_cross_posts"
-        ) as recover:
+        with patch.object(task_service, "recover_interrupted_cross_posts") as recover:
+
             async def run_lifespan():
                 async with asgi.application_lifespan(asgi.app):
                     pass
@@ -61,9 +60,7 @@ class TestVideoControllerHelpers(unittest.TestCase):
         for filename in ("", ".", "..", "/"):
             with self.subTest(filename=filename):
                 with self.assertRaises(HttpException) as raised:
-                    video_controller._sanitize_upload_filename(
-                        filename, "request-123"
-                    )
+                    video_controller._sanitize_upload_filename(filename, "request-123")
                 self.assertEqual(raised.exception.status_code, 400)
 
     def test_resolve_path_maps_missing_and_unsafe_files(self):
@@ -96,9 +93,7 @@ class TestVideoControllerHelpers(unittest.TestCase):
         for header, expected in cases:
             with self.subTest(header=header):
                 self.assertEqual(
-                    video_controller._parse_byte_range(
-                        header, 10, "request-123"
-                    ),
+                    video_controller._parse_byte_range(header, 10, "request-123"),
                     expected,
                 )
 
@@ -114,9 +109,7 @@ class TestVideoControllerHelpers(unittest.TestCase):
         for header in invalid_headers:
             with self.subTest(header=header):
                 with self.assertRaises(HttpException) as raised:
-                    video_controller._parse_byte_range(
-                        header, 10, "request-123"
-                    )
+                    video_controller._parse_byte_range(header, 10, "request-123")
                 self.assertEqual(raised.exception.status_code, 416)
 
 
@@ -166,9 +159,7 @@ class TestVideoControllerTasks(unittest.TestCase):
             patch.object(video_controller.sm.state, "delete_task") as delete_task,
         ):
             with self.assertRaises(HttpException) as raised:
-                video_controller.create_task(
-                    self._request(), body, stop_at="video"
-                )
+                video_controller.create_task(self._request(), body, stop_at="video")
 
         self.assertEqual(raised.exception.status_code, 429)
         delete_task.assert_called_once_with("task-123")
@@ -190,9 +181,7 @@ class TestVideoControllerTasks(unittest.TestCase):
             ),
         ):
             with self.assertRaises(RuntimeError) as raised:
-                video_controller.create_task(
-                    self._request(), body, stop_at="video"
-                )
+                video_controller.create_task(self._request(), body, stop_at="video")
 
         self.assertIs(raised.exception, scheduling_error)
         self.assertIsNone(state.get_task("task-123"))
@@ -309,11 +298,15 @@ class TestVideoControllerTasks(unittest.TestCase):
         )
 
         for task in busy_tasks:
-            with self.subTest(task_id=task["task_id"]), patch.object(
-                video_controller.sm.state,
-                "get_task",
-                return_value=task,
-            ), patch.object(video_controller.sm.state, "delete_task") as delete_task:
+            with (
+                self.subTest(task_id=task["task_id"]),
+                patch.object(
+                    video_controller.sm.state,
+                    "get_task",
+                    return_value=task,
+                ),
+                patch.object(video_controller.sm.state, "delete_task") as delete_task,
+            ):
                 with self.assertRaises(HttpException) as raised:
                     video_controller.delete_video(
                         self._request(), task_id=task["task_id"]
@@ -331,17 +324,20 @@ class TestVideoControllerTasks(unittest.TestCase):
             "cross_post_state": const.CROSS_POST_STATE_COMPLETE,
         }
 
-        with patch.object(
-            video_controller.sm.state,
-            "get_task",
-            return_value=completed_task,
-        ), patch.object(
-            video_controller.utils,
-            "task_dir",
-            return_value="/tmp/mpt-completed-task-test",
-        ), patch.object(
-            video_controller.os.path, "exists", return_value=False
-        ), patch.object(video_controller.sm.state, "delete_task") as delete_task:
+        with (
+            patch.object(
+                video_controller.sm.state,
+                "get_task",
+                return_value=completed_task,
+            ),
+            patch.object(
+                video_controller.utils,
+                "task_dir",
+                return_value="/tmp/mpt-completed-task-test",
+            ),
+            patch.object(video_controller.os.path, "exists", return_value=False),
+            patch.object(video_controller.sm.state, "delete_task") as delete_task,
+        ):
             response = video_controller.delete_video(
                 self._request(), task_id="completed-task"
             )
@@ -364,6 +360,65 @@ class TestVideoControllerTasks(unittest.TestCase):
                     with self.assertRaises(HttpException) as raised:
                         operation()
                     self.assertEqual(raised.exception.status_code, 404)
+
+
+class TestVideoControllerDeleteHTTP(unittest.TestCase):
+    """DELETE /api/v1/tasks/{task_id} 的真实 HTTP 级回归测试。"""
+
+    def setUp(self):
+        self.client = TestClient(asgi.app)
+
+    def _seed_completed_task(self, task_id: str) -> str:
+        """创建一个已完成的任务，返回其存储目录路径。"""
+
+        task_dir = utils.task_dir(task_id)
+        video_path = os.path.join(task_dir, "final-1.mp4")
+        Path(video_path).write_bytes(b"fake-video")
+        sm.state.update_task(
+            task_id,
+            state=const.TASK_STATE_COMPLETE,
+            progress=100,
+            videos=[video_path],
+            combined_videos=[video_path],
+            cross_post_state=const.CROSS_POST_STATE_COMPLETE,
+        )
+        return task_dir
+
+    def test_delete_completed_task_returns_success_response(self):
+        """成功删除应返回 200, 且响应体必须是控制器的真实输出 (status/message/data)"""
+
+        task_id = "http-delete-success-task"
+        task_dir = self._seed_completed_task(task_id)
+
+        try:
+            response = self.client.delete(f"/api/v1/tasks/{task_id}")
+        finally:
+            shutil.rmtree(task_dir, ignore_errors=True)
+            sm.state.delete_task(task_id)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"status": 200, "message": "success", "data": None},
+        )
+
+    def test_deleted_task_lookup_returns_404(self):
+        """删除后再次查询必须返回 404，确认任务确实从状态存储中移除，
+        而不只是删除接口本身的响应格式正确。"""
+
+        task_id = "http-delete-lookup-task"
+        task_dir = self._seed_completed_task(task_id)
+
+        try:
+            delete_response = self.client.delete(f"/api/v1/tasks/{task_id}")
+            self.assertEqual(delete_response.status_code, 200)
+
+            lookup_response = self.client.get(f"/api/v1/tasks/{task_id}")
+        finally:
+            # 任务此时应已被删除；只清理可能残留的目录。
+            shutil.rmtree(task_dir, ignore_errors=True)
+
+        self.assertEqual(lookup_response.status_code, 404)
 
 
 class TestVideoControllerFiles(unittest.TestCase):
@@ -439,9 +494,7 @@ class TestVideoControllerFiles(unittest.TestCase):
                 return_value=temp_dir,
             ):
                 response = asyncio.run(
-                    video_controller.download_video(
-                        self._request(), "final-1.mp4"
-                    )
+                    video_controller.download_video(self._request(), "final-1.mp4")
                 )
 
         # macOS 的 /var 是 /private/var 符号链接，安全解析会返回真实路径。

--- a/test/services/test_controller_video.py
+++ b/test/services/test_controller_video.py
@@ -16,7 +16,7 @@ from app.controllers.manager.base_manager import TaskQueueFullError
 from app.controllers.v1 import video as video_controller
 from app.models import const
 from app.models.exception import HttpException
-from app.models.schema import TaskListResponse, TaskQueryResponse
+from app.models.schema import TaskDeletionResponse, TaskListResponse, TaskQueryResponse
 from app.services import state as sm
 from app.utils import utils
 
@@ -280,6 +280,14 @@ class TestVideoControllerTasks(unittest.TestCase):
         list_schema = TaskListResponse.model_json_schema()
         self.assertIn("TaskListData", list_schema["$defs"])
         self.assertIn("TaskStatusData", list_schema["$defs"])
+
+    def test_task_deletion_schema_defines_null_data_contract(self):
+        """TaskDeletionResponse 的 OpenAPI 架构必须将 data 显式声明为 null 类型。"""
+        schema = TaskDeletionResponse.model_json_schema()
+        data_property = schema["properties"]["data"]
+
+        self.assertEqual(data_property.get("type"), "null")
+        self.assertIsNone(data_property.get("default"))
 
     def test_delete_rejects_generation_and_cross_posting_tasks(self):
         """生成中和发布中的任务都在读取目录，删除接口必须返回 409。"""


### PR DESCRIPTION
This PR addresses two issues in `app/models/schema.py`:

#1218  — Response models expose data as any in the generated OpenAPI schema.

#1219  — Remaining class-based Pydantic Config definitions produce deprecation warnings under Pydantic v2.

The changes make response schemas more explicit and migrate the affected models to Pydantic v2's recommended configuration syntax.

## Changes

* Added dedicated response data models:

  * `TaskResponseData`
  * `TaskDeletionData`
  * `VideoScriptData`
  * `VideoTermsData`
  * `VideoSocialMetadataData`
  * `FileData`
  * `BgmRetrieveData`
  * `BgmUploadData`
  * `VideoMaterialRetrieveData`
  * `VideoMaterialUploadData`

* Updated response models to explicitly declare their `data` type instead of inheriting `data: Any` from `BaseResponse`.

* Migrated class-based Pydantic configuration to Pydantic v2's `ConfigDict`.

* Updated `MaterialInfo` to use `ConfigDict` with `arbitrary_types_allowed=True`.

## OpenAPI Schema Before & After

### Before

Response models such as `TaskDeletionResponse` exposed `data` as `any` in the generated OpenAPI schema, even though the example contained a concrete object structure.

<img width="363" height="168" alt="Screenshot 2026-08-20 233243" src="https://github.com/user-attachments/assets/a542dfa7-d390-4c10-898a-ed3543ce0f37" />

### After

The response now exposes the actual structure of `data`, including its fields and types.

<img width="467" height="268" alt="Screenshot 2026-08-20 233401" src="https://github.com/user-attachments/assets/4e1e98a9-8680-4486-88d6-7fe408211adb" />

This makes the generated API documentation more accurate and useful for API consumers.

## Why

Previously, several response models only documented their `data` structure through `json_schema_extra["example"]`.

As a result, the generated OpenAPI schema could show:

```text
data: any
```

even though the example contained a specific object structure.

The new dedicated data models allow FastAPI/Pydantic to generate an accurate schema for the actual response payload.

This change also removes the Pydantic v2 deprecation warning:

```text
PydanticDeprecatedSince20: Support for class-based `config` is deprecated,
use ConfigDict instead.
```

## Compatibility

The API response structure remains unchanged.

This change primarily:

* improves the generated OpenAPI documentation
* makes response contracts explicit
* removes deprecated Pydantic configuration usage
* improves type safety in the response models

## Testing

* Ran the existing test suite.
* Verified that the updated response models can be imported and constructed successfully.
* Verified the generated OpenAPI schemas for the updated response models.
* Confirmed that the affected class-based `Config` definitions have been migrated to `ConfigDict`.

Closes #1218 
Closes #1219   
