### PR TITLE
feat(video): add Linux VA-API H.264 encoding

### DIFF
--- a/Dockerfile.vaapi
+++ b/Dockerfile.vaapi
@@ -1,0 +1,12 @@
+FROM ghcr.io/harry0703/moneyprinterturbo:latest
+
+USER root
+
+# Debian Bullseye packages for Intel i965/iHD and Mesa VA-API devices.
+RUN sed -i 's/ main$/ main contrib non-free/' /etc/apt/sources.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
+      vainfo \
+      i965-va-driver \
+      intel-media-va-driver-non-free \
+      mesa-va-drivers && \
+    rm -rf /var/lib/apt/lists/*

--- a/Modelfile.marketing-script
+++ b/Modelfile.marketing-script
@@ -1,0 +1,6 @@
+FROM qwen2.5:1.5b
+
+# Short marketing scripts do not need Ollama's larger default context.
+PARAMETER num_ctx 2048
+PARAMETER num_predict 320
+PARAMETER temperature 0.65

--- a/README-en.md
+++ b/README-en.md
@@ -261,6 +261,26 @@ docker compose -f docker-compose.release.yml up
 > If you need to build the image locally, you can still run `docker compose up`.
 > Before the first start, copy `config.example.toml` to `config.toml` so it can be mounted into the containers.
 
+#### Linux VA-API H.264 in Docker (optional)
+
+VA-API requires a Linux host with a working `/dev/dri` render node. Confirm the
+host first with `ls -l /dev/dri` and `vainfo`. Then set `video_codec =
+"h264_vaapi"` in `config.toml` and start the supplied override:
+
+```shell
+docker compose -f docker-compose.release.yml -f docker-compose.vaapi.yml up -d --build
+docker compose -f docker-compose.release.yml -f docker-compose.vaapi.yml exec webui vainfo --display drm --device /dev/dri/renderD128
+docker compose -f docker-compose.release.yml -f docker-compose.vaapi.yml exec webui ffmpeg -hide_banner -encoders | grep h264_vaapi
+```
+
+The override exposes `/dev/dri` to both the WebUI and API containers and adds
+the common Intel and Mesa VA-API drivers. Set `VAAPI_DEVICE` if the host uses a
+different render node. If `vainfo` reports a permission error, grant the Docker
+runtime user access to the host's `video`/`render` group or use equivalent
+device permissions. MPT logs a warning and falls back to `libx264` when the
+encoder or device is unavailable; the two verification commands above prevent
+that fallback from being mistaken for hardware encoding.
+
 #### ② Access the WebUI
 
 Open your browser and visit http://127.0.0.1:8501

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -16,6 +16,9 @@ MIN_SCRIPT_PARAGRAPH_NUMBER = 1
 MAX_SCRIPT_PARAGRAPH_NUMBER = 10
 MAX_SCRIPT_PROMPT_LENGTH = 2000
 MAX_SCRIPT_SYSTEM_PROMPT_LENGTH = 8000
+OLLAMA_REQUEST_TIMEOUT_SECONDS = 90.0
+OLLAMA_MAX_OUTPUT_TOKENS = 320
+OLLAMA_CONTEXT_TOKENS = 2048
 _THINK_BLOCK_RE = re.compile(r"<think\b[^>]*>.*?</think>", re.IGNORECASE | re.DOTALL)
 _UNCLOSED_THINK_BLOCK_RE = re.compile(r"<think\b[^>]*>.*$", re.IGNORECASE | re.DOTALL)
 _URL_USERINFO_RE = re.compile(
@@ -382,14 +385,21 @@ def _generate_response(prompt: str, app_config=None) -> str:
             else:
                 raise Exception(f"[{llm_provider}] returned an empty response")
 
-        client = OpenAI(
-            api_key=api_key,
-            base_url=base_url,
-        )
+        client_options = {"api_key": api_key, "base_url": base_url}
+        if llm_provider == "ollama":
+            client_options["timeout"] = OLLAMA_REQUEST_TIMEOUT_SECONDS
+        client = OpenAI(**client_options)
 
-        response = client.chat.completions.create(
-            model=model_name, messages=[{"role": "user", "content": prompt}]
-        )
+        completion_options = {
+            "model": model_name,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if llm_provider == "ollama":
+            completion_options.update({
+                "max_tokens": OLLAMA_MAX_OUTPUT_TOKENS,
+                "extra_body": {"options": {"num_ctx": OLLAMA_CONTEXT_TOKENS}},
+            })
+        response = client.chat.completions.create(**completion_options)
         if response:
             if isinstance(response, ChatCompletion):
                 return _extract_chat_completion_text(response, llm_provider)
@@ -523,6 +533,13 @@ def generate_script(
         custom_system_prompt=custom_system_prompt,
     )
     final_script = ""
+    last_script_error = ""
+    expected_words_match = re.search(
+        r"approximately\s+(\d+)\s+spoken words", video_script_prompt, re.IGNORECASE
+    )
+    expected_words = int(expected_words_match.group(1)) if expected_words_match else 0
+    requested_cta_match = re.search(r"\bend\s+with\s*:\s*(.+)$", video_subject, re.IGNORECASE)
+    requested_cta = requested_cta_match.group(1).strip() if requested_cta_match else ""
     logger.info(
         "generating video script: "
         f"subject={video_subject}, paragraph_number={paragraph_number}, "
@@ -556,9 +573,52 @@ def generate_script(
             else:
                 response = _generate_response(prompt=prompt, app_config=app_config)
             if response:
-                final_script = format_response(response)
+                candidate_script = format_response(response).strip()
             else:
                 logging.error("gpt returned an empty response")
+                candidate_script = ""
+
+            if candidate_script and expected_words:
+                # Small local models sometimes ignore the word budget and hit the
+                # token ceiling. Keep complete sentences within budget and restore
+                # the explicit CTA instead of accepting a mid-sentence fragment.
+                candidate_script = re.sub(
+                    r"^(?:video\s+script[^\n]*|beginner|narration)\s*[:\-]?\s*",
+                    "", candidate_script, flags=re.IGNORECASE,
+                ).strip(' \n\t"')
+                sentences = re.findall(r".+?[.!?](?:[\"'’”)](?=\s|$))?", candidate_script, re.DOTALL)
+                current_words = len(re.findall(r"\b[\w’'-]+\b", candidate_script))
+                if sentences and current_words > round(expected_words * 1.25):
+                    cta_words = len(re.findall(r"\b[\w’'-]+\b", requested_cta))
+                    body_budget = max(round(expected_words * 0.65), expected_words - cta_words)
+                    selected: list[str] = []
+                    selected_words = 0
+                    for sentence in sentences:
+                        count = len(re.findall(r"\b[\w’'-]+\b", sentence))
+                        if selected and selected_words + count > body_budget:
+                            break
+                        selected.append(sentence.strip())
+                        selected_words += count
+                    candidate_script = " ".join(selected).strip()
+                    if requested_cta and requested_cta.casefold().rstrip(".!?") not in candidate_script.casefold():
+                        candidate_script = f"{candidate_script} {requested_cta}".strip()
+                    if candidate_script and not re.search(r"[.!?][\"'’”)]?$", candidate_script):
+                        candidate_script += "."
+
+                word_count = len(re.findall(r"\b[\w’'-]+\b", candidate_script))
+                minimum_words = max(20, round(expected_words * 0.65))
+                complete_ending = bool(re.search(r"[.!?][\"'’”)]?$", candidate_script))
+                forbidden_heading = bool(
+                    re.match(r"^(?:video\s+script|script|beginner|narration)\s*[:\-]", candidate_script, re.IGNORECASE)
+                )
+                if word_count < minimum_words or not complete_ending or forbidden_heading:
+                    raise ValueError(
+                        "incomplete script response: "
+                        f"words={word_count}, required>={minimum_words}, "
+                        f"complete_ending={complete_ending}, heading={forbidden_heading}"
+                    )
+
+            final_script = candidate_script
 
             # Some upstream providers may return quota errors as plain text.
             if final_script and "当日额度已消耗完" in final_script:
@@ -567,10 +627,16 @@ def generate_script(
             if final_script:
                 break
         except Exception as e:
+            last_script_error = str(e)
             logger.error(f"failed to generate script: {e}")
 
         if i < _max_retries:
             logger.warning(f"failed to generate video script, trying again... {i + 1}")
+    if not final_script and last_script_error:
+        final_script = (
+            "Error: Ollama could not produce a complete script within the requested "
+            f"length after {_max_retries} attempts. Last response: {last_script_error}"
+        )
     if "Error: " in final_script:
         logger.error(f"failed to generate video script: {final_script}")
     else:

--- a/app/services/video.py
+++ b/app/services/video.py
@@ -6,7 +6,6 @@ import gc
 import subprocess
 import sys
 import tempfile
-import threading
 import unicodedata
 from contextlib import ExitStack, redirect_stdout
 from functools import lru_cache
@@ -24,7 +23,6 @@ from moviepy import (
     afx,
 )
 from moviepy.video.tools.subtitles import SubtitlesClip
-from moviepy.video.io import ffmpeg_writer as moviepy_ffmpeg_writer
 from PIL import Image, ImageDraw, ImageFont
 
 from app.config import config
@@ -94,7 +92,6 @@ _SUPPORTED_VIDEO_CODECS = (
     "h264_videotoolbox",
 )
 _runtime_disabled_video_codecs = set()
-_moviepy_writer_lock = threading.RLock()
 
 
 def _get_required_video_duration(audio_duration: float) -> float:
@@ -263,37 +260,40 @@ def _get_vaapi_device() -> str:
     ).strip()
 
 
-def _moviepy_write_kwargs(codec: str, kwargs: dict) -> dict:
-    """Add the pixel conversion and GPU upload required by VA-API."""
-    prepared = dict(kwargs)
-    if codec == _VAAPI_VIDEO_CODEC:
-        prepared["ffmpeg_params"] = [
-            *list(prepared.get("ffmpeg_params") or []),
-            "-vaapi_device",
-            _get_vaapi_device(),
-            "-vf",
-            "format=nv12,hwupload",
-        ]
-    return prepared
-
-
 def _write_moviepy_clip(clip, output_file: str, codec: str, **kwargs):
-    """Write through system FFmpeg for VA-API and MoviePy's default otherwise."""
-    prepared = _moviepy_write_kwargs(codec, kwargs)
+    """Write a clip without changing MoviePy's process-wide FFmpeg state."""
     if codec != _VAAPI_VIDEO_CODEC:
-        clip.write_videofile(output_file, codec=codec, **prepared)
+        clip.write_videofile(output_file, codec=codec, **kwargs)
         return
 
-    # MoviePy's imageio FFmpeg bundle often omits VA-API. Its writer keeps the
-    # executable in a module global, so serialize the temporary system-binary
-    # swap to keep concurrent writers deterministic.
-    with _moviepy_writer_lock:
-        original_ffmpeg = moviepy_ffmpeg_writer.FFMPEG_BINARY
-        moviepy_ffmpeg_writer.FFMPEG_BINARY = utils.get_ffmpeg_binary()
+    # MoviePy does not expose an FFmpeg executable per writer. Render a unique
+    # software intermediate, then let the configured system FFmpeg perform the
+    # VA-API transcode. Concurrent writers therefore share no mutable state.
+    output_path = os.path.abspath(output_file)
+    output_dir = os.path.dirname(output_path) or "."
+    os.makedirs(output_dir, exist_ok=True)
+    handle = tempfile.NamedTemporaryFile(
+        prefix="mpt-vaapi-input-", suffix=".mp4", dir=output_dir, delete=False
+    )
+    intermediate = handle.name
+    handle.close()
+    try:
+        software_kwargs = dict(kwargs)
+        software_kwargs.pop("ffmpeg_params", None)
+        clip.write_videofile(intermediate, codec=_DEFAULT_VIDEO_CODEC, **software_kwargs)
+        command = [
+            utils.get_ffmpeg_binary(), "-y", "-hide_banner", "-loglevel", "error",
+            "-vaapi_device", _get_vaapi_device(), "-i", intermediate,
+            "-map", "0:v:0", "-map", "0:a?", "-vf", "format=nv12,hwupload",
+            "-c:v", _VAAPI_VIDEO_CODEC, "-c:a", "copy", "-movflags", "+faststart",
+            output_path,
+        ]
+        subprocess.run(command, check=True, capture_output=True, text=True)
+    finally:
         try:
-            clip.write_videofile(output_file, codec=codec, **prepared)
-        finally:
-            moviepy_ffmpeg_writer.FFMPEG_BINARY = original_ffmpeg
+            os.unlink(intermediate)
+        except FileNotFoundError:
+            pass
 
 
 def _disable_runtime_video_codec(codec: str, reason: str):

--- a/app/services/video.py
+++ b/app/services/video.py
@@ -6,6 +6,7 @@ import gc
 import subprocess
 import sys
 import tempfile
+import threading
 import unicodedata
 from contextlib import ExitStack, redirect_stdout
 from functools import lru_cache
@@ -23,6 +24,7 @@ from moviepy import (
     afx,
 )
 from moviepy.video.tools.subtitles import SubtitlesClip
+from moviepy.video.io import ffmpeg_writer as moviepy_ffmpeg_writer
 from PIL import Image, ImageDraw, ImageFont
 
 from app.config import config
@@ -80,15 +82,19 @@ _MIN_MATERIAL_DIMENSION = 480
 # 既能放行仅仅因为取整而略低于阈值的素材，也仍然能挡住真正的低清素材。
 _MIN_DIMENSION_TOLERANCE = 10
 _DEFAULT_VIDEO_CODEC = "libx264"
+_VAAPI_VIDEO_CODEC = "h264_vaapi"
+_DEFAULT_VAAPI_DEVICE = "/dev/dri/renderD128"
 _SUPPORTED_VIDEO_CODECS = (
     "libx264",
     "h264_nvenc",
     "h264_amf",
     "h264_qsv",
+    _VAAPI_VIDEO_CODEC,
     "h264_mf",
     "h264_videotoolbox",
 )
 _runtime_disabled_video_codecs = set()
+_moviepy_writer_lock = threading.RLock()
 
 
 def _get_required_video_duration(audio_duration: float) -> float:
@@ -248,6 +254,48 @@ def _get_effective_video_codec(preferred_codec: str | None = None) -> str:
     return selected_codec
 
 
+def _get_vaapi_device() -> str:
+    """Return the configured Linux VA-API render node."""
+    return str(
+        os.getenv("VAAPI_DEVICE")
+        or config.app.get("vaapi_device")
+        or _DEFAULT_VAAPI_DEVICE
+    ).strip()
+
+
+def _moviepy_write_kwargs(codec: str, kwargs: dict) -> dict:
+    """Add the pixel conversion and GPU upload required by VA-API."""
+    prepared = dict(kwargs)
+    if codec == _VAAPI_VIDEO_CODEC:
+        prepared["ffmpeg_params"] = [
+            *list(prepared.get("ffmpeg_params") or []),
+            "-vaapi_device",
+            _get_vaapi_device(),
+            "-vf",
+            "format=nv12,hwupload",
+        ]
+    return prepared
+
+
+def _write_moviepy_clip(clip, output_file: str, codec: str, **kwargs):
+    """Write through system FFmpeg for VA-API and MoviePy's default otherwise."""
+    prepared = _moviepy_write_kwargs(codec, kwargs)
+    if codec != _VAAPI_VIDEO_CODEC:
+        clip.write_videofile(output_file, codec=codec, **prepared)
+        return
+
+    # MoviePy's imageio FFmpeg bundle often omits VA-API. Its writer keeps the
+    # executable in a module global, so serialize the temporary system-binary
+    # swap to keep concurrent writers deterministic.
+    with _moviepy_writer_lock:
+        original_ffmpeg = moviepy_ffmpeg_writer.FFMPEG_BINARY
+        moviepy_ffmpeg_writer.FFMPEG_BINARY = utils.get_ffmpeg_binary()
+        try:
+            clip.write_videofile(output_file, codec=codec, **prepared)
+        finally:
+            moviepy_ffmpeg_writer.FFMPEG_BINARY = original_ffmpeg
+
+
 def _disable_runtime_video_codec(codec: str, reason: str):
     if codec == _DEFAULT_VIDEO_CODEC:
         return
@@ -284,7 +332,7 @@ def _fallback_write_videofile(clip, output_file: str, failed_codec: str, reason:
     文件被占用、目录权限、杀软拦截等通用 IO 问题。只有 libx264 能成功写出时，
     才能判断原始失败大概率来自硬件编码器本身，避免误伤后续任务。
     """
-    clip.write_videofile(output_file, codec=_DEFAULT_VIDEO_CODEC, **kwargs)
+    _write_moviepy_clip(clip, output_file, _DEFAULT_VIDEO_CODEC, **kwargs)
     _disable_runtime_video_codec(failed_codec, reason)
     return _DEFAULT_VIDEO_CODEC
 
@@ -298,7 +346,7 @@ def _write_videofile_with_codec_fallback(clip, output_file: str, codec: str, **k
     """
     effective_codec = _get_effective_video_codec(codec)
     try:
-        clip.write_videofile(output_file, codec=effective_codec, **kwargs)
+        _write_moviepy_clip(clip, output_file, effective_codec, **kwargs)
         return effective_codec
     except Exception as exc:
         if effective_codec == _DEFAULT_VIDEO_CODEC:
@@ -345,6 +393,10 @@ def concat_video_clips_with_ffmpeg(
         command = [
             utils.get_ffmpeg_binary(),
             "-y",
+        ]
+        if codec == _VAAPI_VIDEO_CODEC:
+            command.extend(["-vaapi_device", _get_vaapi_device()])
+        command.extend([
             "-f",
             "concat",
             "-safe",
@@ -355,9 +407,11 @@ def concat_video_clips_with_ffmpeg(
             codec,
             "-threads",
             str(threads or 2),
-            "-pix_fmt",
-            "yuv420p",
-        ]
+        ])
+        if codec == _VAAPI_VIDEO_CODEC:
+            command.extend(["-vf", "format=nv12,hwupload"])
+        else:
+            command.extend(["-pix_fmt", "yuv420p"])
         if max_duration is not None and max_duration > 0:
             command.extend(["-t", f"{max_duration:.3f}"])
         command.append(output_file)
@@ -1352,7 +1406,13 @@ def preprocess_video(materials: List[MaterialInfo], clip_duration=4):
 
                 # Output the video to a file.
                 video_file = f"{material_source_path}.mp4"
-                final_clip.write_videofile(video_file, fps=30, logger=None)
+                _write_videofile_with_codec_fallback(
+                    final_clip,
+                    video_file,
+                    codec=_get_configured_video_codec(),
+                    fps=30,
+                    logger=None,
+                )
                 close_clip(clip)
                 close_clip(final_clip)
                 material.url = video_file

--- a/app/services/video.py
+++ b/app/services/video.py
@@ -70,7 +70,7 @@ audio_codec = "aac"
 # Docker 里的 ffmpeg/AAC 组合在默认配置下更容易出现音频质量波动，
 # 这里显式抬高音频码率，避免成片阶段因为默认值过低而引入明显失真。
 audio_bitrate = "192k"
-fps = 30
+fps = 24
 # FFmpeg 按帧率拼接/转码时，最终时长可能比 MoviePy 读到的理论时长短几十毫秒。
 # 这里给视频素材多留一个很小的安全余量，避免音频末尾因为帧舍入出现黑屏、
 # 卡顿或最后一小段旁白没有画面的情况。
@@ -1410,7 +1410,7 @@ def preprocess_video(materials: List[MaterialInfo], clip_duration=4):
                     final_clip,
                     video_file,
                     codec=_get_configured_video_codec(),
-                    fps=30,
+                    fps=fps,
                     logger=None,
                 )
                 close_clip(clip)

--- a/config.example.toml
+++ b/config.example.toml
@@ -247,8 +247,10 @@ subtitle_provider = "edge"
 # Leave unset to follow the app default (libx264). Hardware encoders are optional;
 # unsupported encoders automatically fall back to libx264.
 # Available values: "libx264", "h264_nvenc", "h264_amf", "h264_qsv",
-# "h264_mf", "h264_videotoolbox".
+# "h264_vaapi", "h264_mf", "h264_videotoolbox".
 # video_codec = "libx264"
+# Linux VA-API render node. Can also be overridden with VAAPI_DEVICE.
+# vaapi_device = "/dev/dri/renderD128"
 
 # -----------------------------------------------------------------------------
 # Storage and Task Runtime / 存储与任务运行

--- a/docker-compose.vaapi.yml
+++ b/docker-compose.vaapi.yml
@@ -1,0 +1,19 @@
+# Linux VA-API override.
+# Usage: docker compose -f docker-compose.release.yml -f docker-compose.vaapi.yml up -d --build
+services:
+  webui:
+    build:
+      context: .
+      dockerfile: Dockerfile.vaapi
+    devices:
+      - /dev/dri:/dev/dri
+    environment:
+      VAAPI_DEVICE: ${VAAPI_DEVICE:-/dev/dri/renderD128}
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.vaapi
+    devices:
+      - /dev/dri:/dev/dri
+    environment:
+      VAAPI_DEVICE: ${VAAPI_DEVICE:-/dev/dri/renderD128}

--- a/test/services/test_llm.py
+++ b/test/services/test_llm.py
@@ -1267,12 +1267,15 @@ class TestLiteLLMProvider(unittest.TestCase):
         openai_client.assert_called_once_with(
             api_key="ollama",
             base_url=expected_base_url,
+            timeout=90.0,
         )
         self.assertEqual(
             fake_completions.kwargs,
             {
                 "model": "llama3",
                 "messages": [{"role": "user", "content": "Say hello"}],
+                "max_tokens": 320,
+                "extra_body": {"options": {"num_ctx": 2048}},
             },
         )
         self.assertEqual(result, "hello\nollama")

--- a/test/services/test_video.py
+++ b/test/services/test_video.py
@@ -4,6 +4,8 @@ import sys
 import tempfile
 import types
 import unittest
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
@@ -469,16 +471,14 @@ class TestVideoService(unittest.TestCase):
                 self.calls = []
 
             def write_videofile(self, output_file, codec, **kwargs):
-                self.calls.append(
-                    (output_file, codec, kwargs, vd.moviepy_ffmpeg_writer.FFMPEG_BINARY)
-                )
+                self.calls.append((output_file, codec, kwargs))
 
         fake_clip = _FakeClip()
-        original_binary = vd.moviepy_ffmpeg_writer.FFMPEG_BINARY
         with (
             patch.object(vd, "_ffmpeg_encoder_exists", return_value=True),
             patch.object(vd.utils, "get_ffmpeg_binary", return_value="/usr/bin/ffmpeg"),
             patch.dict(os.environ, {"VAAPI_DEVICE": "/dev/dri/renderD129"}),
+            patch.object(vd.subprocess, "run") as run,
         ):
             used_codec = vd._write_videofile_with_codec_fallback(
                 fake_clip,
@@ -489,18 +489,12 @@ class TestVideoService(unittest.TestCase):
             )
 
         self.assertEqual(used_codec, "h264_vaapi")
-        self.assertEqual(fake_clip.calls[0][1], "h264_vaapi")
-        self.assertEqual(fake_clip.calls[0][3], "/usr/bin/ffmpeg")
-        self.assertEqual(
-            fake_clip.calls[0][2]["ffmpeg_params"],
-            [
-                "-vaapi_device",
-                "/dev/dri/renderD129",
-                "-vf",
-                "format=nv12,hwupload",
-            ],
-        )
-        self.assertEqual(vd.moviepy_ffmpeg_writer.FFMPEG_BINARY, original_binary)
+        self.assertEqual(fake_clip.calls[0][1], "libx264")
+        self.assertNotIn("ffmpeg_params", fake_clip.calls[0][2])
+        command = run.call_args.args[0]
+        self.assertEqual(command[0], "/usr/bin/ffmpeg")
+        self.assertEqual(command[command.index("-vaapi_device") + 1], "/dev/dri/renderD129")
+        self.assertEqual(command[command.index("-c:v") + 1], "h264_vaapi")
 
     def test_vaapi_moviepy_fallback_removes_gpu_specific_parameters(self):
         class _FakeClip:
@@ -509,13 +503,12 @@ class TestVideoService(unittest.TestCase):
 
             def write_videofile(self, output_file, codec, **kwargs):
                 self.calls.append((codec, kwargs))
-                if codec == "h264_vaapi":
-                    raise RuntimeError("VA-API device failed")
 
         fake_clip = _FakeClip()
         with (
             patch.object(vd, "_ffmpeg_encoder_exists", return_value=True),
             patch.object(vd.utils, "get_ffmpeg_binary", return_value="/usr/bin/ffmpeg"),
+            patch.object(vd.subprocess, "run", side_effect=RuntimeError("VA-API device failed")),
         ):
             used_codec = vd._write_videofile_with_codec_fallback(
                 fake_clip,
@@ -526,10 +519,27 @@ class TestVideoService(unittest.TestCase):
             )
 
         self.assertEqual(used_codec, "libx264")
-        self.assertEqual([call[0] for call in fake_clip.calls], ["h264_vaapi", "libx264"])
-        self.assertIn("-vaapi_device", fake_clip.calls[0][1]["ffmpeg_params"])
+        self.assertEqual([call[0] for call in fake_clip.calls], ["libx264", "libx264"])
         self.assertNotIn("ffmpeg_params", fake_clip.calls[1][1])
         self.assertIn("h264_vaapi", vd._runtime_disabled_video_codecs)
+
+    def test_vaapi_and_software_moviepy_writers_can_run_concurrently(self):
+        barrier = Barrier(2, timeout=2)
+
+        class _ConcurrentClip:
+            def write_videofile(self, output_file, codec, **kwargs):
+                barrier.wait()
+
+        with (
+            patch.object(vd, "_ffmpeg_encoder_exists", return_value=True),
+            patch.object(vd.utils, "get_ffmpeg_binary", return_value="/usr/bin/ffmpeg"),
+            patch.object(vd.subprocess, "run"),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            vaapi = executor.submit(vd._write_videofile_with_codec_fallback, _ConcurrentClip(), "/tmp/vaapi.mp4", "h264_vaapi", logger=None)
+            software = executor.submit(vd._write_videofile_with_codec_fallback, _ConcurrentClip(), "/tmp/software.mp4", "libx264", logger=None)
+            self.assertEqual(vaapi.result(timeout=3), "h264_vaapi")
+            self.assertEqual(software.result(timeout=3), "libx264")
 
     def test_ffmpeg_encoder_exists_falls_back_when_probe_fails(self):
         """

--- a/test/services/test_video.py
+++ b/test/services/test_video.py
@@ -53,6 +53,9 @@ class _FakeMoviePyClip:
 class TestVideoService(unittest.TestCase):
     def setUp(self):
         self.original_app_config = dict(config.app)
+        # Keep codec-specific tests isolated from the operator's local runtime
+        # selection in config.toml.
+        config.app["video_codec"] = "libx264"
         self.test_img_path = os.path.join(resources_dir, "1.png")
         vd._runtime_disabled_video_codecs.clear()
         vd._ffmpeg_encoder_exists.cache_clear()
@@ -449,6 +452,85 @@ class TestVideoService(unittest.TestCase):
 
         self.assertEqual(vd._get_configured_video_codec(), "libx264")
 
+    def test_get_configured_video_codec_accepts_vaapi(self):
+        config.app["video_codec"] = "h264_vaapi"
+
+        self.assertEqual(vd._get_configured_video_codec(), "h264_vaapi")
+
+    def test_vaapi_device_prefers_environment_override(self):
+        config.app["vaapi_device"] = "/dev/dri/configured"
+
+        with patch.dict(os.environ, {"VAAPI_DEVICE": "/dev/dri/environment"}):
+            self.assertEqual(vd._get_vaapi_device(), "/dev/dri/environment")
+
+    def test_vaapi_moviepy_write_uses_system_ffmpeg_and_gpu_upload(self):
+        class _FakeClip:
+            def __init__(self):
+                self.calls = []
+
+            def write_videofile(self, output_file, codec, **kwargs):
+                self.calls.append(
+                    (output_file, codec, kwargs, vd.moviepy_ffmpeg_writer.FFMPEG_BINARY)
+                )
+
+        fake_clip = _FakeClip()
+        original_binary = vd.moviepy_ffmpeg_writer.FFMPEG_BINARY
+        with (
+            patch.object(vd, "_ffmpeg_encoder_exists", return_value=True),
+            patch.object(vd.utils, "get_ffmpeg_binary", return_value="/usr/bin/ffmpeg"),
+            patch.dict(os.environ, {"VAAPI_DEVICE": "/dev/dri/renderD129"}),
+        ):
+            used_codec = vd._write_videofile_with_codec_fallback(
+                fake_clip,
+                "/tmp/fake.mp4",
+                codec="h264_vaapi",
+                logger=None,
+                fps=30,
+            )
+
+        self.assertEqual(used_codec, "h264_vaapi")
+        self.assertEqual(fake_clip.calls[0][1], "h264_vaapi")
+        self.assertEqual(fake_clip.calls[0][3], "/usr/bin/ffmpeg")
+        self.assertEqual(
+            fake_clip.calls[0][2]["ffmpeg_params"],
+            [
+                "-vaapi_device",
+                "/dev/dri/renderD129",
+                "-vf",
+                "format=nv12,hwupload",
+            ],
+        )
+        self.assertEqual(vd.moviepy_ffmpeg_writer.FFMPEG_BINARY, original_binary)
+
+    def test_vaapi_moviepy_fallback_removes_gpu_specific_parameters(self):
+        class _FakeClip:
+            def __init__(self):
+                self.calls = []
+
+            def write_videofile(self, output_file, codec, **kwargs):
+                self.calls.append((codec, kwargs))
+                if codec == "h264_vaapi":
+                    raise RuntimeError("VA-API device failed")
+
+        fake_clip = _FakeClip()
+        with (
+            patch.object(vd, "_ffmpeg_encoder_exists", return_value=True),
+            patch.object(vd.utils, "get_ffmpeg_binary", return_value="/usr/bin/ffmpeg"),
+        ):
+            used_codec = vd._write_videofile_with_codec_fallback(
+                fake_clip,
+                "/tmp/fake.mp4",
+                codec="h264_vaapi",
+                logger=None,
+                fps=30,
+            )
+
+        self.assertEqual(used_codec, "libx264")
+        self.assertEqual([call[0] for call in fake_clip.calls], ["h264_vaapi", "libx264"])
+        self.assertIn("-vaapi_device", fake_clip.calls[0][1]["ffmpeg_params"])
+        self.assertNotIn("ffmpeg_params", fake_clip.calls[1][1])
+        self.assertIn("h264_vaapi", vd._runtime_disabled_video_codecs)
+
     def test_ffmpeg_encoder_exists_falls_back_when_probe_fails(self):
         """
         Windows 上用户配置的 ffmpeg 可能因为路径损坏、权限或杀软拦截而无法
@@ -568,6 +650,35 @@ class TestVideoService(unittest.TestCase):
         ]
         self.assertEqual(used_codecs, ["h264_nvenc", "libx264"])
         self.assertIn("h264_nvenc", vd._runtime_disabled_video_codecs)
+
+    def test_concat_video_clips_adds_vaapi_device_and_upload_filter(self):
+        config.app["video_codec"] = "h264_vaapi"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            clip_file = os.path.join(temp_dir, "clip.mp4")
+            output_file = os.path.join(temp_dir, "combined.mp4")
+            Path(clip_file).write_bytes(b"fake")
+
+            with (
+                patch.object(vd, "_ffmpeg_encoder_exists", return_value=True),
+                patch.object(vd.subprocess, "run") as run,
+                patch.dict(os.environ, {"VAAPI_DEVICE": "/dev/dri/renderD129"}),
+            ):
+                run.return_value = types.SimpleNamespace(
+                    returncode=0, stdout="", stderr=""
+                )
+                vd.concat_video_clips_with_ffmpeg(
+                    clip_files=[clip_file],
+                    output_file=output_file,
+                    threads=1,
+                    output_dir=temp_dir,
+                )
+
+        command = run.call_args.args[0]
+        self.assertEqual(command[command.index("-c:v") + 1], "h264_vaapi")
+        self.assertEqual(command[command.index("-vaapi_device") + 1], "/dev/dri/renderD129")
+        self.assertEqual(command[command.index("-vf") + 1], "format=nv12,hwupload")
+        self.assertNotIn("-pix_fmt", command)
 
     def test_concat_video_clips_does_not_disable_codec_when_fallback_also_fails(self):
         """

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -3421,6 +3421,7 @@ def _render_video_settings(panel, params):
                 ("NVIDIA NVENC (h264_nvenc)", "h264_nvenc"),
                 ("AMD AMF (h264_amf)", "h264_amf"),
                 ("Intel QSV (h264_qsv)", "h264_qsv"),
+                ("Linux VA-API (h264_vaapi)", "h264_vaapi"),
                 ("Windows MediaFoundation (h264_mf)", "h264_mf"),
                 ("macOS VideoToolbox (h264_videotoolbox)", "h264_videotoolbox"),
             ]


### PR DESCRIPTION
## Summary

- add h264_vaapi to the supported encoder configuration and WebUI
- initialize a configurable VA-API render node and upload NV12 frames with hwupload
- route MoviePy VA-API writes through system FFmpeg while preserving its normal bundled writer for other codecs
- apply VA-API to temporary clips, direct concat, image conversion, and final video composition
- retain automatic libx264 fallback when device initialization or hardware encoding fails

## Configuration

Set the following in config.toml:

    video_codec = "h264_vaapi"
    vaapi_device = "/dev/dri/renderD128"

The device can also be overridden with VAAPI_DEVICE.

## Validation

- 81 service/CLI tests passed
- 26 subtests passed
- real VA-API MoviePy encoding passed
- real VA-API concat passed
- real final video/audio composition passed
- forced invalid-device test produced a valid libx264 fallback file