### PR TITLE
fix(schema): migrate to ConfigDict and add typed OpenAPI response models (#1219, #1218)

### DIFF
--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -1,6 +1,6 @@
 import warnings
 from enum import Enum
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, Literal
 
 import pydantic
 from pydantic import BaseModel, ConfigDict, Field
@@ -46,11 +46,9 @@ class VideoAspect(str, Enum):
         raise ValueError(f"unsupported video aspect: {self}")
 
 
-class _Config:
-    arbitrary_types_allowed = True
-
-
-@pydantic.dataclasses.dataclass(config=_Config)
+@pydantic.dataclasses.dataclass(
+    config=ConfigDict(arbitrary_types_allowed=True)
+)
 class MaterialInfo:
     provider: str = "pexels"
     url: str = ""
@@ -58,7 +56,7 @@ class MaterialInfo:
     # 在线素材搜索会附带经过筛选的公开来源信息，供搜索缓存和任务记录复用。
     # 本地上传素材不需要填写；写入任务文件前仍会按字段白名单重新构造，
     # 避免外部请求传入的签名 URL、凭据或无关字段进入持久化数据。
-    source_info: Optional[dict[str, Any]] = None
+    source_info: dict[str, Any] | None = None
 
 
 class VideoParams(BaseModel):
@@ -78,46 +76,46 @@ class VideoParams(BaseModel):
 
     video_subject: str
     video_script: str = ""  # Script used to generate the video
-    video_terms: Optional[str | list] = None  # Keywords used to generate the video
-    video_aspect: Optional[VideoAspect] = VideoAspect.portrait.value
-    video_concat_mode: Optional[VideoConcatMode] = VideoConcatMode.random.value
-    video_transition_mode: Optional[VideoTransitionMode] = None
+    video_terms: str | list | None = None  # Keywords used to generate the video
+    video_aspect: VideoAspect | None = VideoAspect.portrait.value
+    video_concat_mode: VideoConcatMode | None = VideoConcatMode.random.value
+    video_transition_mode: VideoTransitionMode | None = None
     video_clip_duration: int = Field(default=5, ge=1)
-    video_clip_speed: Optional[float] = 1.0
+    video_clip_speed: float | None = 1.0
     match_materials_to_script: bool = False
     video_count: int = Field(default=1, ge=1)
 
-    video_source: Optional[str] = "pexels"
-    video_materials: Optional[List[MaterialInfo]] = (
+    video_source: str | None = "pexels"
+    video_materials: list[MaterialInfo] | None = (
         None  # Materials used to generate the video
     )
     
-    custom_audio_file: Optional[str] = None  # Custom audio file path, will ignore TTS and can still use Whisper subtitles
-    video_language: Optional[str] = ""  # auto detect
+    custom_audio_file: str | None = None  # Custom audio file path, will ignore TTS and can still use Whisper subtitles
+    video_language: str | None = ""  # auto detect
 
-    voice_name: Optional[str] = ""
-    voice_volume: Optional[float] = 1.0
-    voice_rate: Optional[float] = 1.0
-    bgm_type: Optional[str] = "random"
-    bgm_file: Optional[str] = ""
-    bgm_volume: Optional[float] = 0.2
+    voice_name: str | None = ""
+    voice_volume: float | None = 1.0
+    voice_rate: float | None = 1.0
+    bgm_type: str | None = "random"
+    bgm_file: str | None = ""
+    bgm_volume: float | None = 0.2
     # 视频配乐供应商共用提示词，WebUI 新任务统一写入该字段。保留下面的
     # Sonilo 专用字段以兼容旧任务记录和现有 CLI 参数。
     video_music_prompt: str = Field(default="", max_length=2000)
     sonilo_bgm_prompt: str = Field(default="", max_length=2000)
 
-    subtitle_enabled: Optional[bool] = True
-    subtitle_position: Optional[str] = config.ui.get("subtitle_position", "bottom")  # top, bottom, center, custom
+    subtitle_enabled: bool | None = True
+    subtitle_position: str | None = config.ui.get("subtitle_position", "bottom")  # top, bottom, center, custom
     custom_position: float = config.ui.get("custom_position", 70.0)
-    font_name: Optional[str] = "STHeitiMedium.ttc"
-    text_fore_color: Optional[str] = "#FFFFFF"
-    text_background_color: Union[bool, str] = False
+    font_name: str | None = "STHeitiMedium.ttc"
+    text_fore_color: str | None = "#FFFFFF"
+    text_background_color: bool | str = False
     rounded_subtitle_background: bool = False
 
     font_size: int = 60
-    stroke_color: Optional[str] = "#000000"
+    stroke_color: str | None = "#000000"
     stroke_width: float = 1.5
-    n_threads: Optional[int] = 2
+    n_threads: int | None = 2
     paragraph_number: int = Field(default=1, ge=1, le=10)
     video_script_prompt: str = Field(default="", max_length=2000)
     custom_system_prompt: str = Field(default="", max_length=8000)
@@ -125,35 +123,35 @@ class VideoParams(BaseModel):
 
 class SubtitleRequest(BaseModel):
     video_script: str
-    video_language: Optional[str] = ""
-    voice_name: Optional[str] = "zh-CN-XiaoxiaoNeural-Female"
-    voice_volume: Optional[float] = 1.0
-    voice_rate: Optional[float] = 1.2
-    bgm_type: Optional[str] = "random"
-    bgm_file: Optional[str] = ""
-    bgm_volume: Optional[float] = 0.2
-    subtitle_position: Optional[str] = config.ui.get("subtitle_position", "bottom")
-    font_name: Optional[str] = "STHeitiMedium.ttc"
-    text_fore_color: Optional[str] = "#FFFFFF"
-    text_background_color: Union[bool, str] = False
+    video_language: str | None = ""
+    voice_name: str | None = "zh-CN-XiaoxiaoNeural-Female"
+    voice_volume: float | None = 1.0
+    voice_rate: float | None = 1.2
+    bgm_type: str | None = "random"
+    bgm_file: str | None = ""
+    bgm_volume: float | None = 0.2
+    subtitle_position: str | None = config.ui.get("subtitle_position", "bottom")
+    font_name: str | None = "STHeitiMedium.ttc"
+    text_fore_color: str | None = "#FFFFFF"
+    text_background_color: bool | str = False
     rounded_subtitle_background: bool = False
     font_size: int = 60
-    stroke_color: Optional[str] = "#000000"
+    stroke_color: str | None = "#000000"
     stroke_width: float = 1.5
-    video_source: Optional[str] = "local"
-    subtitle_enabled: Optional[str] = "true"
+    video_source: str | None = "local"
+    subtitle_enabled: str | None = "true"
 
 
 class AudioRequest(BaseModel):
     video_script: str
-    video_language: Optional[str] = ""
-    voice_name: Optional[str] = "zh-CN-XiaoxiaoNeural-Female"
-    voice_volume: Optional[float] = 1.0
-    voice_rate: Optional[float] = 1.2
-    bgm_type: Optional[str] = "random"
-    bgm_file: Optional[str] = ""
-    bgm_volume: Optional[float] = 0.2
-    video_source: Optional[str] = "local"
+    video_language: str | None = ""
+    voice_name: str | None = "zh-CN-XiaoxiaoNeural-Female"
+    voice_volume: float | None = 1.0
+    voice_rate: float | None = 1.2
+    bgm_type: str | None = "random"
+    bgm_file: str | None = ""
+    bgm_volume: float | None = 0.2
+    video_source: str | None = "local"
 
 
 class VideoScriptParams:
@@ -167,8 +165,8 @@ class VideoScriptParams:
     }
     """
 
-    video_subject: Optional[str] = "春天的花海"
-    video_language: Optional[str] = ""
+    video_subject: str | None = "春天的花海"
+    video_language: str | None = ""
     paragraph_number: int = Field(default=1, ge=1, le=10)
     video_script_prompt: str = Field(default="", max_length=2000)
     custom_system_prompt: str = Field(default="", max_length=8000)
@@ -184,11 +182,11 @@ class VideoTermsParams:
     }
     """
 
-    video_subject: Optional[str] = "春天的花海"
-    video_script: Optional[str] = (
+    video_subject: str | None = "春天的花海"
+    video_script: str | None = (
         "春天的花海，如诗如画般展现在眼前。万物复苏的季节里，大地披上了一袭绚丽多彩的盛装。金黄的迎春、粉嫩的樱花、洁白的梨花、艳丽的郁金香……"
     )
-    amount: Optional[int] = 5
+    amount: int | None = 5
     match_materials_to_script: bool = False
 
 
@@ -202,15 +200,15 @@ class VideoSocialMetadataParams:
     }
     """
 
-    video_subject: Optional[str] = Field(default="A day in Shanghai", max_length=500)
-    video_script: Optional[str] = Field(default="", max_length=8000)
-    language: Optional[str] = Field(default="auto", max_length=64)
-    platform: Optional[str] = Field(default="tiktok", max_length=64)
+    video_subject: str | None = Field(default="A day in Shanghai", max_length=500)
+    video_script: str | None = Field(default="", max_length=8000)
+    language: str | None = Field(default="auto", max_length=64)
+    platform: str | None = Field(default="tiktok", max_length=64)
 
 
 class BaseResponse(BaseModel):
     status: int = 200
-    message: Optional[str] = "success"
+    message: str | None = "success"
     data: Any = None
 
 
@@ -244,14 +242,18 @@ class TaskResponse(BaseResponse):
 
     data: TaskResponseData
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
                 "data": {"task_id": "6c85c8cc-a77a-42b9-bc30-947815aa0558"},
             },
         }
+    )
+
+
+TaskResponseData = TaskResponse.TaskResponseData
 
 
 class TaskStatusData(BaseModel):
@@ -262,21 +264,19 @@ class TaskStatusData(BaseModel):
     task_id: str
     state: int
     progress: int = 0
-    videos: Optional[List[str]] = None
-    combined_videos: Optional[List[str]] = None
-    failed_stage: Optional[str] = None
-    error: Optional[str] = None
-    cross_post_state: Optional[
-        Literal["pending", "processing", "complete", "failed"]
-    ] = None
-    cross_post_results: Optional[List[dict[str, Any]]] = None
-    cross_post_error: Optional[str] = None
+    videos: list[str] | None = None
+    combined_videos: list[str] | None = None
+    failed_stage: str | None = None
+    error: str | None = None
+    cross_post_state: Literal["pending", "processing", "complete", "failed"] | None = None
+    cross_post_results: list[dict[str, Any]] | None = None
+    cross_post_error: str | None = None
 
 
 class TaskListData(BaseModel):
     """分页任务列表结构。"""
 
-    tasks: List[TaskStatusData]
+    tasks: list[TaskStatusData]
     total: int
     page: int
     page_size: int
@@ -350,9 +350,20 @@ class TaskListResponse(BaseResponse):
     )
 
 
+class TaskDeletionData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    state: int
+    progress: int = 0
+    videos: list[str] | None = None
+    combined_videos: list[str] | None = None
+
+
 class TaskDeletionResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: TaskDeletionData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
@@ -368,11 +379,18 @@ class TaskDeletionResponse(BaseResponse):
                 },
             },
         }
+    )
+
+
+class VideoScriptData(BaseModel):
+    video_script: str
 
 
 class VideoScriptResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: VideoScriptData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
@@ -381,22 +399,38 @@ class VideoScriptResponse(BaseResponse):
                 },
             },
         }
+    )
+
+
+class VideoTermsData(BaseModel):
+    video_terms: list[str]
 
 
 class VideoTermsResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: VideoTermsData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
                 "data": {"video_terms": ["sky", "tree"]},
             },
         }
+    )
+
+
+class VideoSocialMetadataData(BaseModel):
+    title: str
+    caption: str
+    hashtags: list[str]
 
 
 class VideoSocialMetadataResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: VideoSocialMetadataData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
@@ -407,11 +441,24 @@ class VideoSocialMetadataResponse(BaseResponse):
                 },
             },
         }
+    )
+
+
+class BgmItemData(BaseModel):
+    name: str
+    size: int
+    file: str
+
+
+class BgmRetrieveData(BaseModel):
+    files: list[BgmItemData]
 
 
 class BgmRetrieveResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: BgmRetrieveData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
@@ -426,21 +473,42 @@ class BgmRetrieveResponse(BaseResponse):
                 },
             },
         }
+    )
+
+
+class BgmUploadData(BaseModel):
+    file: str
 
 
 class BgmUploadResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: BgmUploadData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
                 "data": {"file": "4fca18fce7344f3aa824777a40d45c8c.mp3"},
             },
         }
+    )
+
+
+class VideoMaterialItemData(BaseModel):
+    name: str
+    size: int
+    file: str
+
+
+class VideoMaterialRetrieveData(BaseModel):
+    files: list[VideoMaterialItemData]
+
 
 class VideoMaterialRetrieveResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: VideoMaterialRetrieveData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
@@ -455,10 +523,18 @@ class VideoMaterialRetrieveResponse(BaseResponse):
                 },
             },
         }
+    )
+
+
+class VideoMaterialUploadData(BaseModel):
+    file: str
+
 
 class VideoMaterialUploadResponse(BaseResponse):
-    class Config:
-        json_schema_extra = {
+    data: VideoMaterialUploadData
+
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": 200,
                 "message": "success",
@@ -467,3 +543,4 @@ class VideoMaterialUploadResponse(BaseResponse):
                 },
             },
         }
+    )

--- a/test/services/test_schema.py
+++ b/test/services/test_schema.py
@@ -6,7 +6,31 @@ from pydantic import ValidationError
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from app.models.schema import VideoAspect, VideoParams
+from app.models.schema import (
+    BgmItemData,
+    BgmRetrieveData,
+    BgmRetrieveResponse,
+    BgmUploadData,
+    BgmUploadResponse,
+    MaterialInfo,
+    TaskDeletionData,
+    TaskDeletionResponse,
+    TaskResponse,
+    TaskResponseData,
+    VideoAspect,
+    VideoMaterialItemData,
+    VideoMaterialRetrieveData,
+    VideoMaterialRetrieveResponse,
+    VideoMaterialUploadData,
+    VideoMaterialUploadResponse,
+    VideoParams,
+    VideoScriptData,
+    VideoScriptResponse,
+    VideoSocialMetadataData,
+    VideoSocialMetadataResponse,
+    VideoTermsData,
+    VideoTermsResponse,
+)
 
 
 class TestVideoAspect(unittest.TestCase):
@@ -24,9 +48,11 @@ class TestVideoParams(unittest.TestCase):
     def test_rejects_non_positive_generation_counts(self):
         for field_name in ("video_clip_duration", "video_count"):
             for value in (0, -1, None):
-                with self.subTest(field_name=field_name, value=value):
-                    with self.assertRaises(ValidationError):
-                        VideoParams(video_subject="Coffee", **{field_name: value})
+                with (
+                    self.subTest(field_name=field_name, value=value),
+                    self.assertRaises(ValidationError),
+                ):
+                    VideoParams(video_subject="Coffee", **{field_name: value})
 
     def test_accepts_positive_generation_counts(self):
         params = VideoParams(
@@ -35,6 +61,115 @@ class TestVideoParams(unittest.TestCase):
 
         self.assertEqual(params.video_clip_duration, 1)
         self.assertEqual(params.video_count, 1)
+
+
+class TestMaterialInfo(unittest.TestCase):
+    def test_material_info_dataclass_arbitrary_types(self):
+        class CustomObject:
+            pass
+
+        info = MaterialInfo(
+            provider="pexels",
+            url="https://example.com/video.mp4",
+            duration=10,
+            source_info={"custom": CustomObject()},
+        )
+        self.assertEqual(info.provider, "pexels")
+        self.assertEqual(info.duration, 10)
+        self.assertIsInstance(info.source_info["custom"], CustomObject)
+
+
+class TestResponseSchemas(unittest.TestCase):
+    def test_task_response_typed_data(self):
+        resp = TaskResponse(
+            status=200, message="success", data={"task_id": "test-123"}
+        )
+        self.assertIsInstance(resp.data, TaskResponseData)
+        self.assertEqual(resp.data.task_id, "test-123")
+        schema = TaskResponse.model_json_schema()
+        self.assertIn("data", schema["properties"])
+        self.assertIn("TaskResponseData", schema["$defs"])
+
+    def test_task_deletion_response_typed_data(self):
+        resp = TaskDeletionResponse(
+            status=200,
+            message="success",
+            data={"state": 1, "progress": 100, "videos": ["/path/v1.mp4"]},
+        )
+        self.assertIsInstance(resp.data, TaskDeletionData)
+        self.assertEqual(resp.data.state, 1)
+        self.assertEqual(resp.data.progress, 100)
+        schema = TaskDeletionResponse.model_json_schema()
+        self.assertIn("TaskDeletionData", schema["$defs"])
+
+    def test_video_script_response_typed_data(self):
+        resp = VideoScriptResponse(
+            status=200, message="success", data={"video_script": "test script"}
+        )
+        self.assertIsInstance(resp.data, VideoScriptData)
+        self.assertEqual(resp.data.video_script, "test script")
+        schema = VideoScriptResponse.model_json_schema()
+        self.assertIn("VideoScriptData", schema["$defs"])
+
+    def test_video_terms_response_typed_data(self):
+        resp = VideoTermsResponse(
+            status=200, message="success", data={"video_terms": ["apple", "banana"]}
+        )
+        self.assertIsInstance(resp.data, VideoTermsData)
+        self.assertEqual(resp.data.video_terms, ["apple", "banana"])
+        schema = VideoTermsResponse.model_json_schema()
+        self.assertIn("VideoTermsData", schema["$defs"])
+
+    def test_video_social_metadata_response_typed_data(self):
+        resp = VideoSocialMetadataResponse(
+            status=200,
+            message="success",
+            data={
+                "title": "Title",
+                "caption": "Caption",
+                "hashtags": ["#shorts"],
+            },
+        )
+        self.assertIsInstance(resp.data, VideoSocialMetadataData)
+        self.assertEqual(resp.data.title, "Title")
+        schema = VideoSocialMetadataResponse.model_json_schema()
+        self.assertIn("VideoSocialMetadataData", schema["$defs"])
+
+    def test_bgm_responses_typed_data(self):
+        retrieve_resp = BgmRetrieveResponse(
+            status=200,
+            message="success",
+            data={
+                "files": [{"name": "track1.mp3", "size": 1024, "file": "track1.mp3"}]
+            },
+        )
+        self.assertIsInstance(retrieve_resp.data, BgmRetrieveData)
+        self.assertEqual(len(retrieve_resp.data.files), 1)
+        self.assertIsInstance(retrieve_resp.data.files[0], BgmItemData)
+
+        upload_resp = BgmUploadResponse(
+            status=200, message="success", data={"file": "uploaded.mp3"}
+        )
+        self.assertIsInstance(upload_resp.data, BgmUploadData)
+        self.assertEqual(upload_resp.data.file, "uploaded.mp3")
+
+    def test_video_material_responses_typed_data(self):
+        retrieve_resp = VideoMaterialRetrieveResponse(
+            status=200,
+            message="success",
+            data={
+                "files": [{"name": "clip.mp4", "size": 2048, "file": "clip.mp4"}]
+            },
+        )
+        self.assertIsInstance(retrieve_resp.data, VideoMaterialRetrieveData)
+        self.assertEqual(len(retrieve_resp.data.files), 1)
+        self.assertIsInstance(retrieve_resp.data.files[0], VideoMaterialItemData)
+
+        upload_resp = VideoMaterialUploadResponse(
+            status=200, message="success", data={"file": "new_clip.mp4"}
+        )
+        self.assertIsInstance(upload_resp.data, VideoMaterialUploadData)
+        self.assertEqual(upload_resp.data.file, "new_clip.mp4")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary of Changes

Closes #1219
Closes #1218

1. **Pydantic v2 ConfigDict Migration:**
   - Migrated `@pydantic.dataclasses.dataclass` on `MaterialInfo` to use modern `config=ConfigDict(arbitrary_types_allowed=True)`.
   - Replaced all legacy `class Config:` inner classes with Pydantic v2 `model_config = ConfigDict(json_schema_extra={...})`.

2. **Typed OpenAPI / Swagger Response Schemas:**
   - Defined dedicated data models for all responses:
     - `TaskDeletionData` (`state`, `progress`, `videos`, `combined_videos`)
     - `VideoScriptData` (`video_script`)
     - `VideoTermsData` (`video_terms`)
     - `VideoSocialMetadataData` (`title`, `caption`, `hashtags`)
     - `BgmItemData` & `BgmRetrieveData` (`files`)
     - `BgmUploadData` (`file`)
     - `VideoMaterialItemData` & `VideoMaterialRetrieveData` (`files`)
     - `VideoMaterialUploadData` (`file`)
   - Bound each response model's `data:` field to its typed model instead of inheriting untyped `Any`, allowing OpenAPI / FastAPI docs to generate concrete schema definitions for client generators and SDKs.

3. **Tests & Quality Verification:**
   - Added unit test suite in `test/services/test_schema.py` verifying dataclass configuration, OpenAPI schema generation, and response model serialization.
   - All tests pass and `ruff check` passes with zero warnings.