### PR TITLE
use llm social captions for every cross-post platform, not just youtube

### DIFF
--- a/app/services/task.py
+++ b/app/services/task.py
@@ -58,6 +58,12 @@ _LOOMLOOM_STATE_RETRY_DELAY_SECONDS = 0.1
 _INTERRUPTED_CROSS_POST_ERROR = (
     "cross-posting was interrupted before the process completed"
 )
+# Map upload-post platform ids to the social platform names llm.py accepts.
+_CROSS_POST_SOCIAL_PLATFORMS = {
+    "tiktok": "tiktok",
+    "instagram": "instagram_reels",
+    "facebook": "facebook_reels",
+}
 # 视频配乐服务只需实现 ``is_enabled`` 和 ``generate_bgm``。供应商差异集中在
 # 文件扩展名、领域异常和 WebUI 警告代码；任务编排、0 音量短路及失败降级
 # 全部复用同一路径，避免后续新增供应商时维护多份相似流程。
@@ -986,25 +992,39 @@ def _run_cross_post(
             f"cross-post started, task_id: {task_id}, platforms: {', '.join(platforms)}"
         )
         youtube_extra = None
-        if any(platform.startswith("youtube") for platform in platforms):
+        post_title = video_subject or "Check out this video! #shorts #viral"
+        if platforms:
+            has_youtube = any(platform.startswith("youtube") for platform in platforms)
+            social_platform = "youtube_shorts"
+            if not has_youtube:
+                first = (platforms[0] or "").strip().lower()
+                # llm.py resolves unknown ids to its default platform.
+                social_platform = _CROSS_POST_SOCIAL_PLATFORMS.get(first, first)
             metadata = llm.generate_social_metadata(
                 video_subject=video_subject,
                 video_script=video_script,
                 language=video_language or "",
-                platform="youtube_shorts",
+                platform=social_platform,
             )
-            youtube_extra = {
-                "youtube_title": metadata.get("title", video_subject),
-                "youtube_description": metadata.get("caption", ""),
-                "tags": metadata.get("hashtags", []),
-                "privacyStatus": youtube_privacy_status,
-                "containsSyntheticMedia": True,
-            }
+            if has_youtube:
+                youtube_extra = {
+                    "youtube_title": metadata.get("title", video_subject),
+                    "youtube_description": metadata.get("caption", ""),
+                    "tags": metadata.get("hashtags", []),
+                    "privacyStatus": youtube_privacy_status,
+                    "containsSyntheticMedia": True,
+                }
+            post_title = (
+                metadata.get("caption")
+                or metadata.get("title")
+                or video_subject
+                or "Check out this video! #shorts #viral"
+            )
 
         for video_path in video_paths:
             result = upload_post.cross_post_video(
                 video_path=video_path,
-                title=video_subject or "Check out this video! #shorts #viral",
+                title=post_title,
                 platforms=list(platforms),
                 youtube_extra=youtube_extra,
             )

--- a/test/services/test_task.py
+++ b/test/services/test_task.py
@@ -1423,6 +1423,177 @@ class TestTaskService(unittest.TestCase):
         self.assertEqual(task["cross_post_state"], tm.const.CROSS_POST_STATE_COMPLETE)
         self.assertIsNone(task["cross_post_error"])
 
+    def test_cross_post_generates_caption_for_non_youtube_platforms(self):
+        """
+        TikTok/Instagram 发布同样要生成一次社交文案，并把 caption 作为所有
+        成片共享的发布标题，而不是直接发送原始主题。
+        """
+        metadata = {
+            "title": "Coffee Hook",
+            "caption": "Watch this coffee ritual.",
+            "hashtags": ["#coffee"],
+        }
+        state = MemoryState()
+        cases = {
+            "tiktok-first": (("tiktok", "instagram"), "tiktok"),
+            "instagram-first": (("instagram", "tiktok"), "instagram_reels"),
+        }
+
+        for case_name, (platforms, expected_platform) in cases.items():
+            with self.subTest(case=case_name):
+                task_id = f"caption-{case_name}"
+                state.update_task(
+                    task_id,
+                    state=tm.const.TASK_STATE_COMPLETE,
+                    progress=100,
+                    videos=["final.mp4"],
+                    cross_post_state=tm.const.CROSS_POST_STATE_PENDING,
+                )
+                with (
+                    patch.object(tm.sm, "state", state),
+                    patch.object(
+                        tm.llm,
+                        "generate_social_metadata",
+                        return_value=metadata,
+                    ) as generate_metadata,
+                    patch.object(
+                        tm.upload_post,
+                        "cross_post_video",
+                        return_value={"success": True},
+                    ) as cross_post,
+                ):
+                    tm._run_cross_post(
+                        task_id,
+                        ("final.mp4",),
+                        "Coffee",
+                        "A short coffee story.",
+                        "en",
+                        platforms,
+                        "private",
+                    )
+
+                generate_metadata.assert_called_once_with(
+                    video_subject="Coffee",
+                    video_script="A short coffee story.",
+                    language="en",
+                    platform=expected_platform,
+                )
+                cross_post.assert_called_once()
+                call = cross_post.call_args
+                self.assertEqual(call.kwargs["title"], "Watch this coffee ritual.")
+                self.assertEqual(call.kwargs["platforms"], list(platforms))
+                self.assertIsNone(call.kwargs["youtube_extra"])
+                task = state.get_task(task_id)
+                self.assertEqual(
+                    task["cross_post_state"], tm.const.CROSS_POST_STATE_COMPLETE
+                )
+
+    def test_cross_post_shares_metadata_between_youtube_fields_and_title(self):
+        """YouTube 专属字段与共享发布标题必须来自同一次元数据调用。"""
+        metadata = {
+            "title": "Morning Coffee",
+            "caption": "A better morning.",
+            "hashtags": ["#coffee", "#shorts"],
+        }
+        state = MemoryState()
+        state.update_task(
+            "shared-youtube-metadata",
+            state=tm.const.TASK_STATE_COMPLETE,
+            progress=100,
+            videos=["final-1.mp4", "final-2.mp4"],
+            cross_post_state=tm.const.CROSS_POST_STATE_PENDING,
+        )
+
+        with (
+            patch.object(tm.sm, "state", state),
+            patch.object(
+                tm.llm,
+                "generate_social_metadata",
+                return_value=metadata,
+            ) as generate_metadata,
+            patch.object(
+                tm.upload_post,
+                "cross_post_video",
+                return_value={"success": True},
+            ) as cross_post,
+        ):
+            tm._run_cross_post(
+                "shared-youtube-metadata",
+                ("final-1.mp4", "final-2.mp4"),
+                "Coffee",
+                "A short coffee story.",
+                "en",
+                ("youtube",),
+                "unlisted",
+            )
+
+        generate_metadata.assert_called_once_with(
+            video_subject="Coffee",
+            video_script="A short coffee story.",
+            language="en",
+            platform="youtube_shorts",
+        )
+        expected_extra = {
+            "youtube_title": "Morning Coffee",
+            "youtube_description": "A better morning.",
+            "tags": ["#coffee", "#shorts"],
+            "privacyStatus": "unlisted",
+            "containsSyntheticMedia": True,
+        }
+        self.assertEqual(cross_post.call_count, 2)
+        for call in cross_post.call_args_list:
+            self.assertEqual(call.kwargs["title"], "A better morning.")
+            self.assertEqual(call.kwargs["youtube_extra"], expected_extra)
+
+    def test_cross_post_empty_metadata_degrades_to_fallback_title(self):
+        """元数据缺失或为空时逐级退回，最终保留旧的通用兜底标题。"""
+        state = MemoryState()
+        cases = {
+            "legacy-string": ({}, "", "Check out this video! #shorts #viral"),
+            "title-over-subject": (
+                {"title": "Fallback Title", "caption": ""},
+                "Coffee",
+                "Fallback Title",
+            ),
+        }
+
+        for case_name, (metadata, subject, expected_title) in cases.items():
+            with self.subTest(case=case_name):
+                task_id = f"fallback-title-{case_name}"
+                state.update_task(
+                    task_id,
+                    state=tm.const.TASK_STATE_COMPLETE,
+                    progress=100,
+                    videos=["final.mp4"],
+                    cross_post_state=tm.const.CROSS_POST_STATE_PENDING,
+                )
+                with (
+                    patch.object(tm.sm, "state", state),
+                    patch.object(
+                        tm.llm,
+                        "generate_social_metadata",
+                        return_value=metadata,
+                    ) as generate_metadata,
+                    patch.object(
+                        tm.upload_post,
+                        "cross_post_video",
+                        return_value={"success": True},
+                    ) as cross_post,
+                ):
+                    tm._run_cross_post(
+                        task_id,
+                        ("final.mp4",),
+                        subject,
+                        "",
+                        "",
+                        ("tiktok",),
+                        "private",
+                    )
+
+                generate_metadata.assert_called_once()
+                cross_post.assert_called_once()
+                self.assertEqual(cross_post.call_args.kwargs["title"], expected_title)
+
     def test_recover_interrupted_cross_posts_preserves_active_future(self):
         """启动恢复只处理遗留状态，当前进程仍持有的发布任务不能被误伤。"""
         state = MemoryState()


### PR DESCRIPTION
right now `_run_cross_post` only generates llm metadata when youtube is in the platform list, so tiktok and instagram end up posting the raw video subject as their caption

this makes a single metadata call serve every platform:

- any non-empty platform list triggers exactly one `generate_social_metadata` call — youtube still gets its dedicated `youtube_title` / `youtube_description` / tags built from the same result, so youtube-only setups keep paying the same one call as before
- the shared caption (`caption or title or subject or the old fallback string`) goes out as the post text for tiktok / instagram instead of the bare subject
- config ids like `instagram` / `facebook` get mapped to the platform names llm.py actually understands (`instagram_reels`, `facebook_reels`); unknown ids pass through and hit llm.py's existing default, same as before

no new dependencies, no schema/api changes

tests: 3 new cases in `test/services/test_task.py` (caption reaches a tiktok-only post, youtube extras built from the same single call, empty metadata degrades to the old fallback) — `test_task.py` + `test_controller_video.py` green (70 passed / 3 skipped), ruff clean
