### PR TITLE
fix: prevent clipped subtitle lines without descenders

### DIFF
--- a/app/services/video.py
+++ b/app/services/video.py
@@ -702,13 +702,14 @@ def wrap_text(text, max_width, font="Arial", fontsize=60):
     # 控制在视频可用宽度内，避免大字号或中文长句直接溢出画面。
     font = ImageFont.truetype(font, fontsize)
     max_width = int(max_width)
+    line_height = sum(font.getmetrics())
 
     def get_text_size(inner_text):
         inner_text = inner_text.strip()
         if not inner_text:
-            return 0, fontsize
-        left, top, right, bottom = font.getbbox(inner_text)
-        return right - left, bottom - top
+            return 0, line_height
+        left, _, right, _ = font.getbbox(inner_text)
+        return right - left, line_height
 
     width, height = get_text_size(text)
     if width <= max_width:

--- a/test/services/test_video.py
+++ b/test/services/test_video.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 from moviepy import (
     VideoFileClip,
 )
+from PIL import ImageFont
 # add project root to python path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from app.config import config
@@ -523,6 +524,11 @@ class TestVideoService(unittest.TestCase):
             print(wrapped_text_en, text_height_en)
             # verify text is wrapped
             self.assertIn("\n", wrapped_text_en)
+            line_height = sum(ImageFont.truetype(font_path, 30).getmetrics())
+            self.assertEqual(
+                text_height_en,
+                (wrapped_text_en.count("\n") + 1) * line_height,
+            )
             
             # test chinese text wrapping
             test_text_zh = "这是一段用来测试中文长句换行的文本内容，应该会根据宽度限制进行换行处理"
@@ -535,6 +541,10 @@ class TestVideoService(unittest.TestCase):
             print(wrapped_text_zh, text_height_zh)
             # verify chinese text is wrapped
             self.assertIn("\n", wrapped_text_zh)
+            self.assertEqual(
+                text_height_zh,
+                (wrapped_text_zh.count("\n") + 1) * line_height,
+            )
         except Exception as e:
             self.fail(f"test wrap_text failed: {str(e)}")
 


### PR DESCRIPTION
## Summary
- calculate subtitle line height from font ascent and descent instead of glyph-specific ink bounds
- keep width measurement based on each rendered string
- add regression assertions for wrapped English and Chinese subtitle heights

## Verification
- python -m py_compile app/services/video.py test/services/test_video.py
- targeted unit test was attempted but could not import because MoviePy is not installed in the local environment

Closes #1232