### PR TITLE
fix(security): prevent task symlink traversal

### DIFF
--- a/app/asgi.py
+++ b/app/asgi.py
@@ -82,9 +82,7 @@ app.add_middleware(
 )
 
 task_dir = utils.task_dir()
-app.mount(
-    "/tasks", StaticFiles(directory=task_dir, html=True, follow_symlink=True), name=""
-)
+app.mount("/tasks", StaticFiles(directory=task_dir, html=True), name="")
 
 public_dir = utils.public_dir()
 app.mount("/", StaticFiles(directory=public_dir, html=True), name="")

--- a/test/services/test_asgi_static_files.py
+++ b/test/services/test_asgi_static_files.py
@@ -1,0 +1,56 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app import asgi
+from app.utils import utils
+
+
+class TestTaskStaticFiles(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(asgi.app)
+
+    def test_serves_regular_task_file(self):
+        with tempfile.TemporaryDirectory(
+            prefix="static-task-", dir=utils.task_dir()
+        ) as task_directory:
+            task_path = Path(task_directory)
+            artifact = task_path / "artifact.txt"
+            artifact.write_text("task artifact", encoding="utf-8")
+
+            response = self.client.get(f"/tasks/{task_path.name}/{artifact.name}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "task artifact")
+
+    def test_does_not_serve_symlink_to_file_outside_tasks(self):
+        with (
+            tempfile.TemporaryDirectory(
+                prefix="static-task-", dir=utils.task_dir()
+            ) as task_directory,
+            tempfile.TemporaryDirectory(
+                prefix="static-secret-", dir=utils.storage_dir(create=True)
+            ) as external_directory,
+        ):
+            task_path = Path(task_directory)
+            secret = Path(external_directory) / "secret.txt"
+            secret.write_text("must not be served", encoding="utf-8")
+            exposed_link = task_path / "secret.txt"
+
+            try:
+                exposed_link.symlink_to(secret)
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"symbolic links are unavailable: {error}")
+
+            response = self.client.get(
+                f"/tasks/{task_path.name}/{exposed_link.name}"
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertNotIn(b"must not be served", response.content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- stop the `/tasks` static mount from following symbolic links
- preserve normal task artifact downloads
- add an HTTP regression test proving an in-tree symlink cannot expose a file outside `storage/tasks`

## Security impact

The task artifact mount now uses Starlette's secure default (`follow_symlink=False`). This removes a defense-in-depth path that could expose host files if a symbolic link ever appeared inside a task directory.

Related to the defense-in-depth findings in #1233.

## Tests

- `python -X utf8 -m pytest -q test/services/test_asgi_static_files.py test/services/test_controller_video.py` (`24 passed`)
- `ruff check app/asgi.py test/services/test_asgi_static_files.py`
- `python -X utf8 -m compileall -q app/asgi.py test/services/test_asgi_static_files.py`