### PR TITLE
feat(cli): add batch manifest mode

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -360,6 +360,29 @@ run:
 uv run python cli.py --help
 ```
 
+To run several tasks sequentially, pass a UTF-8 JSON array or JSONL manifest. CLI
+options act as defaults, and each object overrides fields from `VideoParams`:
+
+```json
+[
+  {"video_subject": "How solar panels work"},
+  {"video_subject": "How wind turbines work", "video_aspect": "16:9"}
+]
+```
+
+```shell
+uv run python cli.py --batch-file ./tasks.json --stop-at video
+```
+
+The manifest is resolved from the current working directory. Relative
+`custom_audio_file` and local `video_materials[].url` values inside it are resolved
+from the manifest's directory; file paths supplied as CLI defaults keep their normal
+current-working-directory semantics. A manifest is limited to 100 tasks and 1 MiB.
+All entries are validated before the first task starts, tasks continue after an
+individual runtime failure, and the command prints one JSON summary when finished.
+The summary contains `total`, `succeeded`, `failed`, and `tasks`; each task entry has
+`index`, `task_id`, `status`, `result`, `failed_stage`, and `error`.
+
 ## Voice Synthesis 🗣
 
 The default provider is the free **Edge TTS**, shown as **Azure TTS V1** in the WebUI. MoneyPrinterTurbo also supports **Azure TTS V2**, **SiliconFlow TTS**, **Google Gemini TTS**, **Xiaomi MiMo TTS**, **ElevenLabs TTS**, self-hosted **Chatterbox TTS**, **Fish Audio TTS**, and a no-voice mode.

--- a/README-ja.md
+++ b/README-ja.md
@@ -350,6 +350,19 @@ uv run python cli.py --video-subject "How AI is changing everyday life"
 uv run python cli.py --help
 ```
 
+複数のタスクを順番に実行するには、`--batch-file` で UTF-8 の JSON 配列または
+JSONL マニフェストを指定します。CLI オプションが共通の既定値となり、各オブジェクトで
+`VideoParams` フィールドを上書きできます。
+
+```shell
+uv run python cli.py --batch-file ./tasks.json --stop-at video
+```
+
+マニフェストは最大 100 タスク、1 MiB までです。最初のタスクを開始する前に全項目と
+ローカルファイルを検証し、個別タスクが失敗しても後続タスクを続行して最後に JSON
+サマリーを出力します。マニフェスト内の相対音声・ローカル素材パスはマニフェストの
+ディレクトリを基準に解決されます。
+
 ## 音声合成 🗣
 
 既定のプロバイダーは無料の **Edge TTS** で、WebUI 上では **Azure TTS V1** と表示されます。MoneyPrinterTurbo は **Azure TTS V2**、**SiliconFlow TTS**、**Google Gemini TTS**、**Xiaomi MiMo TTS**、**ElevenLabs TTS**、セルフホストの **Chatterbox TTS**、**Fish Audio TTS**、および音声なしモードにも対応しています。

--- a/README.md
+++ b/README.md
@@ -369,6 +369,17 @@ uv run python cli.py --video-subject "人工智能如何改变日常生活"
 uv run python cli.py --help
 ```
 
+如需顺序执行多个任务，可通过 `--batch-file` 提供 UTF-8 JSON 数组或 JSONL
+清单。CLI 参数作为全局默认值，每个对象可覆盖 `VideoParams` 字段：
+
+```shell
+uv run python cli.py --batch-file ./tasks.json --stop-at video
+```
+
+清单最多包含 100 个任务且不超过 1 MiB。所有条目会在第一个任务启动前完成
+参数与本地文件预检；单个任务运行失败不会阻止后续条目，结束后会输出统一的
+JSON 汇总。清单中的相对自定义音频与本地素材路径以清单目录为基准。
+
 ## 语音合成 🗣
 
 默认使用免费的 **Edge TTS**，在 WebUI 中显示为 **Azure TTS V1**。项目同时支持 **Azure TTS V2**、**SiliconFlow TTS**、**Google Gemini TTS**、**小米 MiMo TTS**、**ElevenLabs TTS**、自托管 **Chatterbox TTS**、**Fish Audio TTS**，以及无配音模式。

--- a/cli.py
+++ b/cli.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import math
 import os
 import re
 import shutil
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 from uuid import UUID, uuid4
 
 from loguru import logger
@@ -30,6 +31,8 @@ UI_VOICE_MODE_UPLOAD = "upload"
 UI_VOICE_MODES_WITHOUT_TTS = frozenset({UI_VOICE_MODE_NONE, UI_VOICE_MODE_UPLOAD})
 _PIPELINE_STAGES = ("script", "terms", "audio", "subtitle", "materials", "video")
 _CUSTOM_AUDIO_EXTENSIONS = {".mp3", ".wav", ".m4a", ".aac", ".flac", ".ogg"}
+_BATCH_FILE_MAX_BYTES = 1024 * 1024
+_BATCH_TASK_MAX_COUNT = 100
 
 
 class _CliHelpFormatter(
@@ -172,6 +175,10 @@ Examples:
   Stop after script generation:
     uv run python cli.py --video-subject "How AI is changing everyday life" --stop-at script
 
+  Run a JSON array or JSONL manifest. CLI options provide defaults and each object
+  overrides VideoParams fields for one task:
+    uv run python cli.py --batch-file ./tasks.jsonl --stop-at script
+
 Pipeline stages:
   script     Generate or return the script.
   terms      Generate material search terms; unavailable with local materials.
@@ -183,8 +190,21 @@ Pipeline stages:
 
 Output and exit status:
   Task files are written to storage/tasks/<task-id>/. A successful command prints one
-  JSON object to stdout and exits with 0. Task failures exit with 1; argument errors
-  exit with 2. Runtime logs are written to stderr.
+  JSON object to stdout and exits with 0. Batch mode prints one JSON summary after all
+  tasks finish. Task failures exit with 1; argument or manifest errors exit with 2
+  before any batch task starts. Runtime logs are written to stderr.
+
+Batch manifests:
+  --batch-file accepts a UTF-8 JSON array or JSONL file with one object per non-empty
+  line (up to 100 tasks and 1 MiB). Objects may override VideoParams fields; unknown
+  fields are rejected. Every merged task needs video_subject or video_script.
+  The manifest path is relative to the current working directory. Relative
+  custom_audio_file and local video_materials[].url values declared in a manifest are
+  relative to the manifest directory. Relative paths supplied by CLI options remain
+  relative to the current working directory. bgm_file and font_name keep their managed
+  storage/resource lookup rules. --stop-at is a batch-wide CLI option. The summary has
+  total, succeeded, failed, and tasks keys; every task entry has index, task_id,
+  status, result, failed_stage, and error.
 """,
         formatter_class=_CliHelpFormatter,
     )
@@ -485,18 +505,32 @@ Output and exit status:
     )
 
     execution_group = parser.add_argument_group("execution")
-    execution_group.add_argument(
+    execution_mode = execution_group.add_mutually_exclusive_group()
+    execution_mode.add_argument(
         "--task-id",
         type=_task_id,
         default=None,
         help="custom UUID used for storage/tasks/<task-id>; generated automatically when omitted",
     )
+    execution_mode.add_argument(
+        "--batch-file",
+        default=None,
+        metavar="PATH",
+        help=(
+            "UTF-8 JSON array or JSONL task manifest; conflicts with --task-id and "
+            "generates a UUID for every task"
+        ),
+    )
     args = parser.parse_args(argv)
 
-    if not args.video_subject.strip() and not args.video_script.strip():
+    if (
+        not args.batch_file
+        and not args.video_subject.strip()
+        and not args.video_script.strip()
+    ):
         parser.error("one of --video-subject or --video-script is required")
 
-    if args.video_source == "local" and args.stop_at == "terms":
+    if not args.batch_file and args.video_source == "local" and args.stop_at == "terms":
         parser.error(
             "--stop-at terms has no effect with --video-source local "
             "(search terms are not generated for local sources)"
@@ -504,35 +538,48 @@ Output and exit status:
 
     stage_requires_materials = args.stop_at in {"materials", "video"}
     has_video_materials = bool((args.video_materials or "").strip())
-    if args.video_source == "local" and stage_requires_materials and not has_video_materials:
+    if (
+        not args.batch_file
+        and args.video_source == "local"
+        and stage_requires_materials
+        and not has_video_materials
+    ):
         parser.error(
             "--video-materials is required with --video-source local when "
             "--stop-at is materials or video"
         )
-    if args.video_source != "local" and has_video_materials:
+    if not args.batch_file and args.video_source != "local" and has_video_materials:
         parser.error("--video-materials can only be used with --video-source local")
 
     if args.bgm_file:
         if args.bgm_type in (None, "custom"):
             args.bgm_type = "custom"
-        else:
+        elif not args.batch_file:
             parser.error("--bgm-file can only be combined with --bgm-type custom")
 
     if args.sonilo_bgm_prompt:
         if args.bgm_type in (None, "sonilo"):
             args.bgm_type = "sonilo"
-        else:
+        elif not args.batch_file:
             parser.error(
                 "--sonilo-bgm-prompt can only be combined with --bgm-type sonilo"
             )
 
-    if args.custom_position is not None and args.subtitle_position != "custom":
+    if (
+        not args.batch_file
+        and args.custom_position is not None
+        and args.subtitle_position != "custom"
+    ):
         parser.error("--custom-position requires --subtitle-position custom")
     # 只有显式的 --no-subtitle-enabled 才算冲突。默认值现在是 None，
     # 保存的关闭状态在 build_video_params 中处理，不应在这里报参数错误。
-    if args.stop_at == "subtitle" and args.subtitle_enabled is False:
+    if (
+        not args.batch_file
+        and args.stop_at == "subtitle"
+        and args.subtitle_enabled is False
+    ):
         parser.error("--stop-at subtitle cannot be combined with --no-subtitle-enabled")
-    if args.subtitle_background_enabled is False and (
+    if not args.batch_file and args.subtitle_background_enabled is False and (
         args.subtitle_background_color is not None
         or args.rounded_subtitle_background is True
     ):
@@ -750,6 +797,264 @@ def build_video_params(args: argparse.Namespace) -> VideoParams:
     return VideoParams(**params_kwargs)
 
 
+def _load_batch_manifest(raw_path: str) -> tuple[str, list[dict[str, Any]]]:
+    expanded_path = os.path.expanduser(raw_path.strip())
+    if not expanded_path:
+        raise ValueError("--batch-file path cannot be empty")
+
+    candidate = (
+        expanded_path
+        if os.path.isabs(expanded_path)
+        else os.path.join(os.getcwd(), expanded_path)
+    )
+    manifest_path = os.path.realpath(candidate)
+    if not os.path.isfile(manifest_path):
+        raise ValueError(f"batch manifest does not exist or is not a file: {raw_path}")
+
+    with open(manifest_path, "rb") as manifest_file:
+        payload = manifest_file.read(_BATCH_FILE_MAX_BYTES + 1)
+    if len(payload) > _BATCH_FILE_MAX_BYTES:
+        raise ValueError(
+            f"batch manifest exceeds the {_BATCH_FILE_MAX_BYTES}-byte limit"
+        )
+
+    try:
+        text = payload.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise ValueError("batch manifest must be UTF-8 encoded") from exc
+    if not text.strip():
+        raise ValueError("batch manifest must contain at least one task")
+
+    if text.lstrip().startswith("["):
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"invalid JSON array in batch manifest: {exc.msg}"
+            ) from exc
+        if not isinstance(parsed, list):
+            raise ValueError("batch manifest JSON must be an array")
+        entries = parsed
+    else:
+        entries = []
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"invalid JSONL in batch manifest at line {line_number}: {exc.msg}"
+                ) from exc
+
+    if not entries:
+        raise ValueError("batch manifest must contain at least one task")
+    if len(entries) > _BATCH_TASK_MAX_COUNT:
+        raise ValueError(
+            f"batch manifest contains {len(entries)} tasks; "
+            f"the limit is {_BATCH_TASK_MAX_COUNT}"
+        )
+
+    for index, entry in enumerate(entries, start=1):
+        if not isinstance(entry, dict):
+            raise ValueError(f"batch task {index} must be a JSON object")
+    return manifest_path, entries
+
+
+def _validate_batch_entry_fields(
+    entry: dict[str, Any],
+    *,
+    index: int,
+    allowed_fields: set[str],
+) -> None:
+    unknown_fields = sorted(set(entry) - allowed_fields)
+    if unknown_fields:
+        raise ValueError(
+            f"batch task {index} contains unknown VideoParams fields: "
+            f"{', '.join(unknown_fields)}"
+        )
+
+    materials = entry.get("video_materials")
+    if not isinstance(materials, list):
+        return
+    allowed_material_fields = {"provider", "url", "duration", "source_info"}
+    for material_index, material in enumerate(materials, start=1):
+        if not isinstance(material, dict):
+            continue
+        unknown_material_fields = sorted(set(material) - allowed_material_fields)
+        if unknown_material_fields:
+            raise ValueError(
+                f"batch task {index} material {material_index} contains unknown "
+                f"MaterialInfo fields: {', '.join(unknown_material_fields)}"
+            )
+
+
+def _manifest_relative_path(raw_path: str, manifest_directory: str) -> str:
+    expanded_path = os.path.expanduser(raw_path.strip())
+    if not expanded_path or os.path.isabs(expanded_path):
+        return expanded_path
+    return os.path.realpath(os.path.join(manifest_directory, expanded_path))
+
+
+def _resolve_batch_entry_paths(
+    params: VideoParams,
+    *,
+    override_fields: set[str],
+    manifest_directory: str,
+) -> None:
+    if "custom_audio_file" in override_fields and params.custom_audio_file:
+        params.custom_audio_file = _manifest_relative_path(
+            params.custom_audio_file,
+            manifest_directory,
+        )
+
+    if (
+        "video_materials" in override_fields
+        and params.video_source == "local"
+        and params.video_materials
+    ):
+        for material in params.video_materials:
+            material.url = _manifest_relative_path(
+                material.url,
+                manifest_directory,
+            )
+
+
+def _validate_batch_task_params(
+    params: VideoParams,
+    *,
+    stop_at: str,
+    custom_position_is_explicit: bool,
+) -> None:
+    if not params.video_subject.strip() and not params.video_script.strip():
+        raise ValueError("one of video_subject or video_script is required")
+
+    if params.video_source not in {"pexels", "pixabay", "coverr", "local"}:
+        raise ValueError(
+            "video_source must be one of: pexels, pixabay, coverr, local"
+        )
+    if params.video_source == "local" and stop_at == "terms":
+        raise ValueError(
+            "stop_at=terms has no effect with video_source=local"
+        )
+    if (
+        params.video_source == "local"
+        and stop_at in {"materials", "video"}
+        and not params.video_materials
+    ):
+        raise ValueError(
+            "video_materials is required with video_source=local when "
+            "stop_at is materials or video"
+        )
+    if params.video_source != "local" and params.video_materials:
+        raise ValueError("video_materials can only be used with video_source=local")
+
+    if stop_at == "subtitle" and not params.subtitle_enabled:
+        raise ValueError("stop_at=subtitle cannot be combined with disabled subtitles")
+    if params.subtitle_position not in {"top", "center", "bottom", "custom"}:
+        raise ValueError(
+            "subtitle_position must be one of: top, center, bottom, custom"
+        )
+    if custom_position_is_explicit and params.subtitle_position != "custom":
+        raise ValueError("custom_position requires subtitle_position=custom")
+    if not math.isfinite(params.custom_position) or not 0 <= params.custom_position <= 100:
+        raise ValueError("custom_position must be a finite number between 0 and 100")
+    if params.text_background_color is False and params.rounded_subtitle_background:
+        raise ValueError(
+            "rounded_subtitle_background requires an enabled subtitle background"
+        )
+
+    color_values = {
+        "text_fore_color": params.text_fore_color,
+        "stroke_color": params.stroke_color,
+        "text_background_color": (
+            params.text_background_color
+            if isinstance(params.text_background_color, str)
+            else None
+        ),
+    }
+    for name, value in color_values.items():
+        if value is not None and not re.fullmatch(r"#[0-9a-fA-F]{6}", value):
+            raise ValueError(f"{name} must use #RRGGBB format")
+
+    numeric_constraints = (
+        ("voice_volume", params.voice_volume, 0, False),
+        ("voice_rate", params.voice_rate, 0, True),
+        ("bgm_volume", params.bgm_volume, 0, False),
+        ("stroke_width", params.stroke_width, 0, False),
+    )
+    for name, value, minimum, exclusive in numeric_constraints:
+        if value is None:
+            continue
+        if not math.isfinite(value) or (
+            value <= minimum if exclusive else value < minimum
+        ):
+            comparison = ">" if exclusive else ">="
+            raise ValueError(f"{name} must be a finite number {comparison} {minimum}")
+
+    for name, value in (
+        ("n_threads", params.n_threads),
+        ("font_size", params.font_size),
+    ):
+        if value is not None and value < 1:
+            raise ValueError(f"{name} must be >= 1")
+
+    if params.bgm_type not in {"", "random", "custom", "sonilo"}:
+        raise ValueError("bgm_type must be one of: none, random, custom, sonilo")
+    if params.bgm_file and params.bgm_type != "custom":
+        raise ValueError("bgm_file requires bgm_type=custom")
+    if params.sonilo_bgm_prompt and params.bgm_type != "sonilo":
+        raise ValueError("sonilo_bgm_prompt requires bgm_type=sonilo")
+
+
+def _build_batch_tasks(args: argparse.Namespace) -> list[VideoParams]:
+    from app.models.schema import VideoParams
+
+    manifest_path, entries = _load_batch_manifest(args.batch_file)
+    manifest_directory = os.path.dirname(manifest_path)
+    base_params = build_video_params(args)
+    allowed_fields = set(VideoParams.model_fields)
+    base_values = {
+        field_name: getattr(base_params, field_name) for field_name in allowed_fields
+    }
+    tasks: list[VideoParams] = []
+
+    for index, entry in enumerate(entries, start=1):
+        _validate_batch_entry_fields(
+            entry,
+            index=index,
+            allowed_fields=allowed_fields,
+        )
+        try:
+            params = VideoParams.model_validate(
+                {**copy.deepcopy(base_values), **entry}
+            )
+            override_fields = set(entry)
+            _resolve_batch_entry_paths(
+                params,
+                override_fields=override_fields,
+                manifest_directory=manifest_directory,
+            )
+            _validate_batch_task_params(
+                params,
+                stop_at=args.stop_at,
+                custom_position_is_explicit=(
+                    args.custom_position is not None
+                    or "custom_position" in override_fields
+                ),
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"invalid batch task {index}: {exc}") from exc
+        tasks.append(params)
+
+    for index, params in enumerate(tasks, start=1):
+        try:
+            prepare_cli_files(params, stop_at=args.stop_at)
+        except (OSError, ValueError) as exc:
+            raise ValueError(f"invalid batch task {index}: {exc}") from exc
+    return tasks
+
+
 def _resolve_cli_file(
     raw_path: str,
     *,
@@ -939,8 +1244,88 @@ def prepare_cli_files(params: VideoParams, stop_at: str) -> None:
         material.url = prepared_path
 
 
+def _run_batch_tasks(args: argparse.Namespace, tasks: list[VideoParams]) -> int:
+    from app.services import task as tm
+    from app.utils import utils
+
+    task_summaries: list[dict[str, Any]] = []
+    used_task_ids: set[str] = set()
+    failed_count = 0
+
+    for index, params in enumerate(tasks, start=1):
+        task_id = utils.get_uuid()
+        if task_id in used_task_ids:
+            task_id = str(uuid4())
+        used_task_ids.add(task_id)
+        logger.info(
+            f"start CLI batch task: index={index}, task_id={task_id}, "
+            f"stop_at={args.stop_at}"
+        )
+
+        result = None
+        failed_stage = None
+        error = None
+        try:
+            result = tm.start(task_id=task_id, params=params, stop_at=args.stop_at)
+        except Exception as exc:
+            failed_stage = "runtime"
+            error = str(exc)
+            logger.exception(
+                "CLI batch task failed with an unexpected error: "
+                f"index={index}, task_id={task_id}, error={exc}"
+            )
+        else:
+            if not isinstance(result, dict) or not result:
+                failed_stage = "unknown"
+                error = "empty or invalid task result"
+            elif result.get("state") == tm.const.TASK_STATE_FAILED:
+                failed_stage = result.get("failed_stage") or "unknown"
+                error = result.get("error") or "unknown task error"
+
+            if error is not None:
+                logger.error(
+                    f"CLI batch task failed: index={index}, task_id={task_id}, "
+                    f"stop_at={args.stop_at}, stage={failed_stage}, error={error}"
+                )
+
+        status = "failed" if error is not None else "succeeded"
+        if status == "failed":
+            failed_count += 1
+        task_summaries.append(
+            {
+                "index": index,
+                "task_id": task_id,
+                "status": status,
+                "result": result,
+                "failed_stage": failed_stage,
+                "error": error,
+            }
+        )
+
+    print(
+        json.dumps(
+            {
+                "total": len(task_summaries),
+                "succeeded": len(task_summaries) - failed_count,
+                "failed": failed_count,
+                "tasks": task_summaries,
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 1 if failed_count else 0
+
+
 def run_cli(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
+    if args.batch_file:
+        try:
+            tasks = _build_batch_tasks(args)
+        except (ValueError, OSError) as exc:
+            logger.error(f"invalid CLI batch input: {exc}")
+            return 2
+        return _run_batch_tasks(args, tasks)
+
     try:
         params = build_video_params(args)
         prepare_cli_files(params, stop_at=args.stop_at)

--- a/cli.py
+++ b/cli.py
@@ -959,6 +959,11 @@ def _validate_batch_task_params(
         raise ValueError("custom_position requires subtitle_position=custom")
     if not math.isfinite(params.custom_position) or not 0 <= params.custom_position <= 100:
         raise ValueError("custom_position must be a finite number between 0 and 100")
+    if params.video_clip_speed is not None and (
+        not math.isfinite(params.video_clip_speed)
+        or not 0.5 <= params.video_clip_speed <= 2.0
+    ):
+        raise ValueError("video_clip_speed must be a finite number between 0.5 and 2.0")
     if params.text_background_color is False and params.rounded_subtitle_background:
         raise ValueError(
             "rounded_subtitle_background requires an enabled subtitle background"
@@ -1047,11 +1052,31 @@ def _build_batch_tasks(args: argparse.Namespace) -> list[VideoParams]:
             raise ValueError(f"invalid batch task {index}: {exc}") from exc
         tasks.append(params)
 
+    validation_plans = []
     for index, params in enumerate(tasks, start=1):
         try:
-            prepare_cli_files(params, stop_at=args.stop_at)
+            validation_plans.append(_validate_cli_files(params, stop_at=args.stop_at))
         except (OSError, ValueError) as exc:
             raise ValueError(f"invalid batch task {index}: {exc}") from exc
+
+    prepared_paths: dict[str, str] = {}
+    created_paths: list[str] = []
+    try:
+        for index, (local_videos_dir, resolved_materials) in enumerate(
+            validation_plans, start=1
+        ):
+            try:
+                _prepare_cli_materials(
+                    local_videos_dir,
+                    resolved_materials,
+                    prepared_paths=prepared_paths,
+                    created_paths=created_paths,
+                )
+            except OSError as exc:
+                raise ValueError(f"invalid batch task {index}: {exc}") from exc
+    except Exception:
+        _remove_cli_material_copies(created_paths)
+        raise
     return tasks
 
 
@@ -1126,13 +1151,15 @@ def _resolve_managed_resource_file(
     )
 
 
-def prepare_cli_files(params: VideoParams, stop_at: str) -> None:
+def _validate_cli_files(
+    params: VideoParams, stop_at: str
+) -> tuple[str, list[tuple[MaterialInfo, str, str]]]:
     """
-    在调用 LLM/TTS 前准备 CLI 文件，避免长流程运行到后期才报告路径错误。
+    无副作用地解析并校验 CLI 文件，避免批量预检留下素材副本。
 
-    服务层为了保护 API 请求，只允许读取 ``storage/local_videos`` 内的素材。
-    CLI 是本地入口，接受当前目录相对路径和绝对路径。目录外素材会
-    复制到受控目录，再把参数替换为服务层可安全使用的绝对路径。
+    自定义音频、BGM 和字体会被规范化为服务层可使用的路径或名称；本地素材
+    仅解析来源和扩展名，实际复制由 ``_prepare_cli_materials`` 在所有批量条目
+    校验通过后统一完成。
     """
     from app.models import const
     from app.services import bgm as bgm_service
@@ -1202,9 +1229,9 @@ def prepare_cli_files(params: VideoParams, stop_at: str) -> None:
         params.font_name = os.path.basename(font_path)
 
     if params.video_source != "local" or stop_at not in {"materials", "video"}:
-        return
+        return "", []
 
-    local_videos_dir = utils.storage_dir("local_videos", create=True)
+    local_videos_dir = utils.storage_dir("local_videos")
     resolved_materials: list[tuple[MaterialInfo, str, str]] = []
     for material in params.video_materials or []:
         source_path = _resolve_cli_file(
@@ -1221,9 +1248,39 @@ def prepare_cli_files(params: VideoParams, stop_at: str) -> None:
             )
         resolved_materials.append((material, source_path, extension))
 
-    # 所有输入检查通过后再复制，避免第二个文件无效时留下第一个文件的
-    # 孤儿副本。
-    prepared_paths: dict[str, str] = {}
+    return local_videos_dir, resolved_materials
+
+
+def _remove_cli_material_copies(created_paths: Sequence[str]) -> None:
+    """Best-effort cleanup for managed copies created by one CLI preparation."""
+    for file_path in reversed(created_paths):
+        try:
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+        except OSError as exc:
+            logger.warning(
+                f"failed to remove prepared CLI material: path={file_path}, "
+                f"error={exc}"
+            )
+
+
+def _prepare_cli_materials(
+    local_videos_dir: str,
+    resolved_materials: Sequence[tuple[MaterialInfo, str, str]],
+    *,
+    prepared_paths: dict[str, str] | None = None,
+    created_paths: list[str] | None = None,
+) -> None:
+    """Copy validated local materials once and update every matching reference."""
+    if not resolved_materials:
+        return
+
+    os.makedirs(local_videos_dir, exist_ok=True)
+    if prepared_paths is None:
+        prepared_paths = {}
+    if created_paths is None:
+        created_paths = []
+
     for material, source_path, extension in resolved_materials:
         prepared_path = prepared_paths.get(source_path)
         if prepared_path is None:
@@ -1234,7 +1291,16 @@ def prepare_cli_files(params: VideoParams, stop_at: str) -> None:
                     local_videos_dir,
                     f"cli-material-{uuid4().hex}{extension}",
                 )
-                shutil.copy2(source_path, prepared_path)
+                try:
+                    shutil.copy2(source_path, prepared_path)
+                except OSError:
+                    try:
+                        if os.path.exists(prepared_path):
+                            os.remove(prepared_path)
+                    except OSError:
+                        pass
+                    raise
+                created_paths.append(prepared_path)
                 logger.info(
                     "copied CLI local material into managed storage: "
                     f"source={source_path}, target={prepared_path}"
@@ -1242,6 +1308,21 @@ def prepare_cli_files(params: VideoParams, stop_at: str) -> None:
             prepared_paths[source_path] = prepared_path
 
         material.url = prepared_path
+
+
+def prepare_cli_files(params: VideoParams, stop_at: str) -> None:
+    """Validate and prepare files for one trusted local CLI task."""
+    local_videos_dir, resolved_materials = _validate_cli_files(params, stop_at)
+    created_paths: list[str] = []
+    try:
+        _prepare_cli_materials(
+            local_videos_dir,
+            resolved_materials,
+            created_paths=created_paths,
+        )
+    except Exception:
+        _remove_cli_material_copies(created_paths)
+        raise
 
 
 def _run_batch_tasks(args: argparse.Namespace, tasks: list[VideoParams]) -> int:
@@ -1266,7 +1347,12 @@ def _run_batch_tasks(args: argparse.Namespace, tasks: list[VideoParams]) -> int:
         failed_stage = None
         error = None
         try:
-            result = tm.start(task_id=task_id, params=params, stop_at=args.stop_at)
+            result = tm.start(
+                task_id=task_id,
+                params=params,
+                stop_at=args.stop_at,
+                allow_server_file_input=True,
+            )
         except Exception as exc:
             failed_stage = "runtime"
             error = str(exc)

--- a/cli.py
+++ b/cli.py
@@ -933,6 +933,15 @@ def _validate_batch_task_params(
         raise ValueError(
             "video_source must be one of: pexels, pixabay, coverr, local"
         )
+    for field_name, value in (
+        ("video_aspect", params.video_aspect),
+        ("video_concat_mode", params.video_concat_mode),
+    ):
+        # These schema fields remain Optional for compatibility with historical
+        # API payloads, but the video pipeline always dereferences their enum
+        # values. A manifest's explicit null must fail before any batch task starts.
+        if value is None:
+            raise ValueError(f"{field_name} cannot be null")
     if params.video_source == "local" and stop_at == "terms":
         raise ValueError(
             "stop_at=terms has no effect with video_source=local"

--- a/test/services/test_cli.py
+++ b/test/services/test_cli.py
@@ -645,6 +645,8 @@ class TestCli(unittest.TestCase):
         )
         self.assertEqual(first_call.kwargs["params"].voice_name, "global-voice")
         self.assertEqual(second_call.kwargs["params"].voice_name, "global-voice")
+        self.assertIs(first_call.kwargs["allow_server_file_input"], True)
+        self.assertIs(second_call.kwargs["allow_server_file_input"], True)
         summary = json.loads(output.getvalue())
         self.assertEqual(
             {key: summary[key] for key in ("total", "succeeded", "failed")},
@@ -733,27 +735,142 @@ class TestCli(unittest.TestCase):
         self.assertIn("unknown VideoParams fields", str(log_error.call_args))
 
     def test_missing_file_in_later_batch_task_prevents_every_task_from_starting(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            tempfile.TemporaryDirectory() as managed_dir,
+        ):
+            source_file = Path(temp_dir) / "valid.mp4"
+            source_file.write_bytes(b"valid video")
             manifest = Path(temp_dir) / "tasks.json"
             manifest.write_text(
                 json.dumps(
                     [
-                        {"video_subject": "valid"},
                         {
-                            "video_subject": "missing audio",
-                            "custom_audio_file": "missing.mp3",
+                            "video_subject": "valid local material",
+                            "video_source": "local",
+                            "video_materials": [
+                                {"provider": "local", "url": "valid.mp4"}
+                            ],
+                        },
+                        {
+                            "video_subject": "missing local material",
+                            "video_source": "local",
+                            "video_materials": [
+                                {"provider": "local", "url": "missing.mp4"}
+                            ],
                         },
                     ]
                 ),
                 encoding="utf-8",
             )
-            with patch("app.services.task.start") as start:
+            with (
+                patch("app.services.task.start") as start,
+                patch("app.utils.utils.storage_dir", return_value=managed_dir),
+            ):
                 code = cli.run_cli(
-                    ["--batch-file", str(manifest), "--stop-at", "audio"]
+                    ["--batch-file", str(manifest), "--stop-at", "materials"]
                 )
 
-        self.assertEqual(code, 2)
-        start.assert_not_called()
+            self.assertEqual(code, 2)
+            start.assert_not_called()
+            self.assertEqual(os.listdir(managed_dir), [])
+
+    def test_batch_reuses_one_managed_copy_for_repeated_local_material(self):
+        with (
+            tempfile.TemporaryDirectory() as manifest_dir,
+            tempfile.TemporaryDirectory() as managed_dir,
+        ):
+            source_file = Path(manifest_dir) / "shared.mp4"
+            source_file.write_bytes(b"shared video")
+            manifest = Path(manifest_dir) / "tasks.json"
+            manifest.write_text(
+                json.dumps(
+                    [
+                        {
+                            "video_subject": subject,
+                            "video_source": "local",
+                            "video_materials": [
+                                {"provider": "local", "url": "shared.mp4"}
+                            ],
+                        }
+                        for subject in ("first", "second")
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            with (
+                patch(
+                    "app.services.task.start",
+                    side_effect=[
+                        {"state": 1, "materials": ["first"]},
+                        {"state": 1, "materials": ["second"]},
+                    ],
+                ) as start,
+                patch(
+                    "app.utils.utils.get_uuid",
+                    side_effect=["task-one", "task-two"],
+                ),
+                patch("app.utils.utils.storage_dir", return_value=managed_dir),
+                redirect_stdout(io.StringIO()),
+            ):
+                code = cli.run_cli(
+                    ["--batch-file", str(manifest), "--stop-at", "materials"]
+                )
+
+            first_path = start.call_args_list[0].kwargs["params"].video_materials[0].url
+            second_path = start.call_args_list[1].kwargs["params"].video_materials[0].url
+            managed_files = os.listdir(managed_dir)
+
+        self.assertEqual(code, 0)
+        self.assertEqual(first_path, second_path)
+        self.assertEqual(len(managed_files), 1)
+        self.assertTrue(managed_files[0].startswith("cli-material-"))
+
+    def test_batch_copy_failure_removes_all_managed_materials(self):
+        with (
+            tempfile.TemporaryDirectory() as manifest_dir,
+            tempfile.TemporaryDirectory() as managed_dir,
+        ):
+            first_source = Path(manifest_dir) / "first.mp4"
+            second_source = Path(manifest_dir) / "second.mp4"
+            first_source.write_bytes(b"first video")
+            second_source.write_bytes(b"second video")
+            manifest = Path(manifest_dir) / "tasks.json"
+            manifest.write_text(
+                json.dumps(
+                    [
+                        {
+                            "video_subject": name,
+                            "video_source": "local",
+                            "video_materials": [
+                                {"provider": "local", "url": f"{name}.mp4"}
+                            ],
+                        }
+                        for name in ("first", "second")
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            real_copy = cli.shutil.copy2
+
+            def fail_second_copy(source, target):
+                if os.path.basename(source) == "second.mp4":
+                    Path(target).write_bytes(b"partial copy")
+                    raise OSError("simulated copy failure")
+                return real_copy(source, target)
+
+            with (
+                patch("app.services.task.start") as start,
+                patch("app.utils.utils.storage_dir", return_value=managed_dir),
+                patch.object(cli.shutil, "copy2", side_effect=fail_second_copy),
+            ):
+                code = cli.run_cli(
+                    ["--batch-file", str(manifest), "--stop-at", "materials"]
+                )
+
+            self.assertEqual(code, 2)
+            start.assert_not_called()
+            self.assertEqual(os.listdir(managed_dir), [])
 
     def test_batch_rejects_non_object_and_unknown_material_fields(self):
         invalid_manifests = (
@@ -804,6 +921,28 @@ class TestCli(unittest.TestCase):
                         {
                             "video_subject": "invalid color",
                             "text_fore_color": "white",
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            with patch("app.services.task.start") as start:
+                code = cli.run_cli(
+                    ["--batch-file", str(manifest), "--stop-at", "script"]
+                )
+
+        self.assertEqual(code, 2)
+        start.assert_not_called()
+
+    def test_batch_rejects_invalid_video_clip_speed_before_start(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = Path(temp_dir) / "tasks.json"
+            manifest.write_text(
+                json.dumps(
+                    [
+                        {
+                            "video_subject": "invalid speed",
+                            "video_clip_speed": -1,
                         }
                     ]
                 ),

--- a/test/services/test_cli.py
+++ b/test/services/test_cli.py
@@ -1,4 +1,5 @@
 import io
+import json
 import os
 import subprocess
 import sys
@@ -578,6 +579,411 @@ class TestCli(unittest.TestCase):
 
             self.assertEqual(params.custom_audio_file, str(audio_file.resolve()))
 
+    def test_batch_file_does_not_require_global_subject_and_conflicts_with_task_id(self):
+        args = cli.parse_args(["--batch-file", "tasks.jsonl"])
+        self.assertEqual(args.batch_file, "tasks.jsonl")
+
+        with self.assertRaises(SystemExit) as cm:
+            cli.parse_args(
+                [
+                    "--batch-file",
+                    "tasks.jsonl",
+                    "--task-id",
+                    str(uuid4()),
+                ]
+            )
+
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_batch_json_array_merges_cli_defaults_and_prints_summary(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = Path(temp_dir) / "tasks.json"
+            manifest.write_text(
+                json.dumps(
+                    [
+                        {"video_subject": "first subject"},
+                        {"video_script": "prepared second script"},
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            output = io.StringIO()
+            with (
+                patch(
+                    "app.services.task.start",
+                    side_effect=[
+                        {"state": 1, "script": "first"},
+                        {"state": 1, "script": "second"},
+                    ],
+                ) as start,
+                patch(
+                    "app.utils.utils.get_uuid",
+                    side_effect=["task-one", "task-two"],
+                ),
+                redirect_stdout(output),
+            ):
+                code = cli.run_cli(
+                    [
+                        "--batch-file",
+                        str(manifest),
+                        "--stop-at",
+                        "script",
+                        "--voice-name",
+                        "global-voice",
+                    ]
+                )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(start.call_count, 2)
+        first_call, second_call = start.call_args_list
+        self.assertEqual(first_call.kwargs["task_id"], "task-one")
+        self.assertEqual(second_call.kwargs["task_id"], "task-two")
+        self.assertEqual(first_call.kwargs["params"].video_subject, "first subject")
+        self.assertEqual(
+            second_call.kwargs["params"].video_script,
+            "prepared second script",
+        )
+        self.assertEqual(first_call.kwargs["params"].voice_name, "global-voice")
+        self.assertEqual(second_call.kwargs["params"].voice_name, "global-voice")
+        summary = json.loads(output.getvalue())
+        self.assertEqual(
+            {key: summary[key] for key in ("total", "succeeded", "failed")},
+            {"total": 2, "succeeded": 2, "failed": 0},
+        )
+        self.assertEqual(
+            [task["status"] for task in summary["tasks"]],
+            ["succeeded", "succeeded"],
+        )
+        self.assertEqual(
+            set(summary["tasks"][0]),
+            {"index", "task_id", "status", "result", "failed_stage", "error"},
+        )
+
+    def test_batch_jsonl_continues_after_runtime_and_structured_failures(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = Path(temp_dir) / "tasks.jsonl"
+            manifest.write_text(
+                "\n".join(
+                    json.dumps({"video_subject": subject})
+                    for subject in ("one", "two", "three")
+                ),
+                encoding="utf-8",
+            )
+            output = io.StringIO()
+            with (
+                patch(
+                    "app.services.task.start",
+                    side_effect=[
+                        {"state": 1, "script": "ok"},
+                        RuntimeError("provider unavailable"),
+                        {
+                            "state": -1,
+                            "failed_stage": "audio",
+                            "error": "TTS failed",
+                        },
+                    ],
+                ) as start,
+                patch(
+                    "app.utils.utils.get_uuid",
+                    side_effect=["task-one", "task-two", "task-three"],
+                ),
+                patch.object(cli.logger, "exception"),
+                patch.object(cli.logger, "error"),
+                redirect_stdout(output),
+            ):
+                code = cli.run_cli(
+                    ["--batch-file", str(manifest), "--stop-at", "script"]
+                )
+
+        self.assertEqual(code, 1)
+        self.assertEqual(start.call_count, 3)
+        summary = json.loads(output.getvalue())
+        self.assertEqual(summary["succeeded"], 1)
+        self.assertEqual(summary["failed"], 2)
+        self.assertEqual(
+            [task["status"] for task in summary["tasks"]],
+            ["succeeded", "failed", "failed"],
+        )
+        self.assertEqual(summary["tasks"][1]["failed_stage"], "runtime")
+        self.assertEqual(summary["tasks"][1]["error"], "provider unavailable")
+        self.assertEqual(summary["tasks"][2]["failed_stage"], "audio")
+
+    def test_invalid_later_batch_task_prevents_every_task_from_starting(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = Path(temp_dir) / "tasks.json"
+            manifest.write_text(
+                json.dumps(
+                    [
+                        {"video_subject": "valid"},
+                        {"video_subject": "invalid", "unknown_option": True},
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            with (
+                patch("app.services.task.start") as start,
+                patch.object(cli.logger, "error") as log_error,
+            ):
+                code = cli.run_cli(
+                    ["--batch-file", str(manifest), "--stop-at", "script"]
+                )
+
+        self.assertEqual(code, 2)
+        start.assert_not_called()
+        self.assertIn("unknown VideoParams fields", str(log_error.call_args))
+
+    def test_missing_file_in_later_batch_task_prevents_every_task_from_starting(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = Path(temp_dir) / "tasks.json"
+            manifest.write_text(
+                json.dumps(
+                    [
+                        {"video_subject": "valid"},
+                        {
+                            "video_subject": "missing audio",
+                            "custom_audio_file": "missing.mp3",
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            with patch("app.services.task.start") as start:
+                code = cli.run_cli(
+                    ["--batch-file", str(manifest), "--stop-at", "audio"]
+                )
+
+        self.assertEqual(code, 2)
+        start.assert_not_called()
+
+    def test_batch_rejects_non_object_and_unknown_material_fields(self):
+        invalid_manifests = (
+            ["not an object"],
+            [
+                {
+                    "video_subject": "invalid material",
+                    "video_source": "local",
+                    "video_materials": [
+                        {"provider": "local", "url": "clip.mp4", "secret": "x"}
+                    ],
+                }
+            ],
+        )
+        for payload in invalid_manifests:
+            with self.subTest(payload=payload), tempfile.TemporaryDirectory() as temp_dir:
+                manifest = Path(temp_dir) / "tasks.json"
+                manifest.write_text(json.dumps(payload), encoding="utf-8")
+                with patch("app.services.task.start") as start:
+                    code = cli.run_cli(
+                        ["--batch-file", str(manifest), "--stop-at", "script"]
+                    )
+
+                self.assertEqual(code, 2)
+                start.assert_not_called()
+
+    def test_batch_validates_every_task_has_subject_or_script_before_start(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = Path(temp_dir) / "tasks.json"
+            manifest.write_text(
+                json.dumps([{"video_subject": "valid"}, {}]),
+                encoding="utf-8",
+            )
+            with patch("app.services.task.start") as start:
+                code = cli.run_cli(
+                    ["--batch-file", str(manifest), "--stop-at", "script"]
+                )
+
+        self.assertEqual(code, 2)
+        start.assert_not_called()
+
+    def test_batch_rejects_invalid_subtitle_color_before_start(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = Path(temp_dir) / "tasks.json"
+            manifest.write_text(
+                json.dumps(
+                    [
+                        {
+                            "video_subject": "invalid color",
+                            "text_fore_color": "white",
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            with patch("app.services.task.start") as start:
+                code = cli.run_cli(
+                    ["--batch-file", str(manifest), "--stop-at", "script"]
+                )
+
+        self.assertEqual(code, 2)
+        start.assert_not_called()
+
+    def test_batch_manifest_limits_size_and_task_count(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            oversized = Path(temp_dir) / "oversized.jsonl"
+            oversized.write_bytes(b"x" * (cli._BATCH_FILE_MAX_BYTES + 1))
+            with self.assertRaisesRegex(ValueError, "byte limit"):
+                cli._load_batch_manifest(str(oversized))
+
+            too_many = Path(temp_dir) / "too-many.json"
+            too_many.write_text(
+                json.dumps(
+                    [
+                        {"video_subject": f"task {index}"}
+                        for index in range(cli._BATCH_TASK_MAX_COUNT + 1)
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "the limit is"):
+                cli._load_batch_manifest(str(too_many))
+
+    def test_batch_jsonl_error_reports_source_line(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = Path(temp_dir) / "invalid.jsonl"
+            manifest.write_text(
+                '{"video_subject": "valid"}\n{invalid json}\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "line 2"):
+                cli._load_batch_manifest(str(manifest))
+
+    def test_manifest_relative_custom_audio_uses_manifest_directory(self):
+        with (
+            tempfile.TemporaryDirectory() as manifest_dir,
+            tempfile.TemporaryDirectory() as working_dir,
+        ):
+            audio_file = Path(manifest_dir) / "voice.mp3"
+            audio_file.write_bytes(b"audio")
+            manifest = Path(manifest_dir) / "tasks.json"
+            manifest.write_text(
+                json.dumps(
+                    [
+                        {
+                            "video_subject": "manifest audio",
+                            "custom_audio_file": "voice.mp3",
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(working_dir)
+                with (
+                    patch(
+                        "app.services.task.start",
+                        return_value={"state": 1, "audio_file": "ok"},
+                    ) as start,
+                    patch("app.utils.utils.get_uuid", return_value="task-one"),
+                    redirect_stdout(io.StringIO()),
+                ):
+                    code = cli.run_cli(
+                        ["--batch-file", str(manifest), "--stop-at", "audio"]
+                    )
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(code, 0)
+        self.assertEqual(
+            start.call_args.kwargs["params"].custom_audio_file,
+            str(audio_file.resolve()),
+        )
+
+    def test_manifest_relative_local_material_uses_manifest_directory(self):
+        with (
+            tempfile.TemporaryDirectory() as manifest_dir,
+            tempfile.TemporaryDirectory() as working_dir,
+            tempfile.TemporaryDirectory() as managed_dir,
+        ):
+            source_file = Path(manifest_dir) / "clip.mp4"
+            source_file.write_bytes(b"manifest video")
+            manifest = Path(manifest_dir) / "tasks.json"
+            manifest.write_text(
+                json.dumps(
+                    [
+                        {
+                            "video_subject": "manifest material",
+                            "video_source": "local",
+                            "video_materials": [
+                                {
+                                    "provider": "local",
+                                    "url": "clip.mp4",
+                                    "duration": 0,
+                                }
+                            ],
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(working_dir)
+                with (
+                    patch(
+                        "app.services.task.start",
+                        return_value={"state": 1, "materials": ["ok"]},
+                    ) as start,
+                    patch("app.utils.utils.get_uuid", return_value="task-one"),
+                    patch("app.utils.utils.storage_dir", return_value=managed_dir),
+                    redirect_stdout(io.StringIO()),
+                ):
+                    code = cli.run_cli(
+                        ["--batch-file", str(manifest), "--stop-at", "materials"]
+                    )
+            finally:
+                os.chdir(old_cwd)
+
+            prepared_file = Path(
+                start.call_args.kwargs["params"].video_materials[0].url
+            )
+            self.assertEqual(code, 0)
+            self.assertEqual(prepared_file.parent, Path(managed_dir))
+            self.assertEqual(prepared_file.read_bytes(), b"manifest video")
+
+    def test_global_relative_custom_audio_keeps_current_working_directory(self):
+        with (
+            tempfile.TemporaryDirectory() as manifest_dir,
+            tempfile.TemporaryDirectory() as working_dir,
+        ):
+            audio_file = Path(working_dir) / "voice.mp3"
+            audio_file.write_bytes(b"audio")
+            manifest = Path(manifest_dir) / "tasks.json"
+            manifest.write_text(
+                json.dumps([{"video_subject": "global audio"}]),
+                encoding="utf-8",
+            )
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(working_dir)
+                with (
+                    patch(
+                        "app.services.task.start",
+                        return_value={"state": 1, "audio_file": "ok"},
+                    ) as start,
+                    patch("app.utils.utils.get_uuid", return_value="task-one"),
+                    redirect_stdout(io.StringIO()),
+                ):
+                    code = cli.run_cli(
+                        [
+                            "--batch-file",
+                            str(manifest),
+                            "--custom-audio-file",
+                            "voice.mp3",
+                            "--stop-at",
+                            "audio",
+                        ]
+                    )
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(code, 0)
+        self.assertEqual(
+            start.call_args.kwargs["params"].custom_audio_file,
+            str(audio_file.resolve()),
+        )
+
     def test_help_documents_defaults_paths_stages_and_exit_codes(self):
         output = io.StringIO()
         with redirect_stdout(output), self.assertRaises(SystemExit) as cm:
@@ -588,6 +994,8 @@ class TestCli(unittest.TestCase):
         self.assertIn("zh-CN-XiaoxiaoNeural-Female", help_text)
         self.assertIn("current working directory", help_text)
         self.assertIn("Pipeline stages:", help_text)
+        self.assertIn("Batch manifests:", help_text)
+        self.assertIn("JSONL", help_text)
         self.assertIn("exit with 2", help_text)
 
     def test_help_does_not_initialize_application_or_write_logs(self):

--- a/test/services/test_cli.py
+++ b/test/services/test_cli.py
@@ -956,6 +956,36 @@ class TestCli(unittest.TestCase):
         self.assertEqual(code, 2)
         start.assert_not_called()
 
+    def test_later_null_runtime_field_prevents_every_batch_task_from_starting(self):
+        for field_name in ("video_aspect", "video_concat_mode"):
+            with self.subTest(field_name=field_name), tempfile.TemporaryDirectory() as temp_dir:
+                manifest = Path(temp_dir) / "tasks.json"
+                manifest.write_text(
+                    json.dumps(
+                        [
+                            {"video_subject": "valid first task"},
+                            {
+                                "video_subject": "invalid later task",
+                                field_name: None,
+                            },
+                        ]
+                    ),
+                    encoding="utf-8",
+                )
+                with patch("app.services.task.start") as start:
+                    code = cli.run_cli(
+                        [
+                            "--batch-file",
+                            str(manifest),
+                            "--stop-at",
+                            "video",
+                            "--no-subtitle-enabled",
+                        ]
+                    )
+
+                self.assertEqual(code, 2)
+                start.assert_not_called()
+
     def test_batch_manifest_limits_size_and_task_count(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             oversized = Path(temp_dir) / "oversized.jsonl"


### PR DESCRIPTION
## Summary

- add `--batch-file` for UTF-8 JSON arrays and JSONL manifests
- use normal CLI options as global defaults and let each manifest object override validated `VideoParams` fields
- reject unknown task/material fields, malformed entries, invalid cross-field combinations, unsupported colors, and missing local files before the first task starts
- limit manifests to 1 MiB and 100 tasks
- generate a separate UUID per task, execute sequentially, and continue after individual runtime failures
- print one stable JSON summary with totals and per-task result/error metadata
- resolve manifest-owned custom audio and local material paths relative to the manifest while preserving existing CLI path semantics
- document the workflow in English, Chinese, and Japanese

## Compatibility

The existing single-task path is unchanged unless `--batch-file` is supplied. `--task-id` remains available for single tasks and is mutually exclusive with batch mode.

Closes #1155.

## Tests

- batch/manifest/path/help tests: `14 passed` plus 2 subtests
- additional CLI regression run: `43 passed` plus 18 subtests; four existing default-video tests require font assets omitted by the local sparse checkout
- Ruff, compileall, and `git diff --check` pass