### PR TITLE
fix(subtitle): unify create() return value and check result in caller

### DIFF
--- a/app/services/subtitle.py
+++ b/app/services/subtitle.py
@@ -19,7 +19,7 @@ initial_prompt = config.whisper.get("initial_prompt", "") or None
 model = None
 
 
-def create(audio_file, subtitle_file: str = ""):
+def create(audio_file, subtitle_file: str = "") -> str:
     global model
     if WhisperModel is None:
         logger.warning("faster_whisper not available, skipping whisper subtitle generation")
@@ -46,7 +46,7 @@ def create(audio_file, subtitle_file: str = ""):
                 f"see [README.md FAQ](https://github.com/harry0703/MoneyPrinterTurbo) for more details.\n"
                 f"********************************************\n\n"
             )
-            return None
+            return ""
 
     logger.info(f"start, output file: {subtitle_file}")
     if not subtitle_file:
@@ -142,6 +142,7 @@ def create(audio_file, subtitle_file: str = ""):
     with open(subtitle_file, "w", encoding="utf-8") as f:
         f.write(sub)
     logger.info(f"subtitle file created: {subtitle_file}")
+    return subtitle_file
 
 
 def file_to_subtitles(filename):

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -565,7 +565,10 @@ def generate_subtitle(task_id, params, video_script, sub_maker, audio_file):
             return ""
 
     if subtitle_provider == "whisper":
-        subtitle.create(audio_file=audio_file, subtitle_file=subtitle_path)
+        created_path = subtitle.create(audio_file=audio_file, subtitle_file=subtitle_path)
+        if not created_path:
+            logger.warning("whisper subtitle generation failed, skipping subtitle correction")
+            return ""
         logger.info("\n\n## correcting subtitle")
         subtitle.correct(subtitle_file=subtitle_path, video_script=video_script)
 


### PR DESCRIPTION
- Add return type annotation -> str to subtitle.create()
- Return empty string instead of None when model loading fails, consistent with import failure
- Return subtitle_file path on success so callers can verify generation
- Check create() return value in task.py before calling correct(), skip correction and return early on failure