### PR TITLE
fix(video): measure subtitle line height from font metrics

### DIFF
--- a/app/services/video.py
+++ b/app/services/video.py
@@ -776,9 +776,14 @@ def wrap_text(text, max_width, font="Arial", fontsize=60):
         left, top, right, bottom = font.getbbox(inner_text)
         return right - left, bottom - top
 
-    width, height = get_text_size(text)
+    # Line height must come from the font's own metrics, not from the ink extent
+    # of whichever glyphs this particular phrase happens to contain. getbbox()
+    # returns cap-height only for text with no descenders (g/j/p/q/y), which
+    # under-measures every line by ~30px at fontsize 60 and clips the last line.
+    line_height = sum(font.getmetrics())  # ascent + descent
+    width, _ = get_text_size(text)
     if width <= max_width:
-        return text, height
+        return text, line_height
 
     def split_long_token(token):
         # 当一个 token 本身就超宽时（常见于中文无空格长句，或英文超长单词），
@@ -839,7 +844,7 @@ def wrap_text(text, max_width, font="Arial", fontsize=60):
             lines[index - 1] = lines[index - 1][:-1]
 
     result = "\n".join(line.strip() for line in lines if line.strip()).strip()
-    height = len(lines) * height
+    height = len(lines) * line_height
     return result, height
 
 

--- a/test/services/test_video.py
+++ b/test/services/test_video.py
@@ -13,6 +13,7 @@ from moviepy import (
     ImageClip,
     VideoFileClip,
 )
+from PIL import ImageFont
 
 # add project root to python path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -985,6 +986,97 @@ class TestVideoService(unittest.TestCase):
             self.assertIn("\n", wrapped_text_zh)
         except Exception as e:
             self.fail(f"test wrap_text failed: {str(e)}")
+
+    def test_wrap_text_line_height_does_not_depend_on_descenders(self):
+        """
+        Line height must come from the font metrics, not from the ink extent of
+        the glyphs a phrase happens to contain. A Latin phrase without
+        descenders (g/j/p/q/y) is measured to the baseline only, so the height
+        returned here used to be cap-height per line and the last subtitle line
+        was clipped. Two phrases wrapping to the same number of lines must
+        report the same height.
+        """
+        font_path = os.path.join(utils.font_dir(), "STHeitiMedium.ttc")
+        font_size = 30
+        expected_line_height = sum(
+            ImageFont.truetype(font_path, font_size).getmetrics()
+        )
+
+        without_descenders = "A man survived the Hiroshima atomic bomb blast"
+        with_descenders = "A laser beam shoots across the black stripes"
+        self.assertFalse(set("gjpqy") & set(without_descenders))
+        self.assertTrue(set("gjpqy") & set(with_descenders))
+
+        wrapped_plain, height_plain = vd.wrap_text(
+            text=without_descenders,
+            max_width=300,
+            font=font_path,
+            fontsize=font_size,
+        )
+        wrapped_descenders, height_descenders = vd.wrap_text(
+            text=with_descenders,
+            max_width=300,
+            font=font_path,
+            fontsize=font_size,
+        )
+
+        line_count = wrapped_plain.count("\n") + 1
+        self.assertGreater(line_count, 1)
+        self.assertEqual(line_count, wrapped_descenders.count("\n") + 1)
+
+        self.assertEqual(height_plain, line_count * expected_line_height)
+        self.assertEqual(height_plain, height_descenders)
+
+    def test_wrap_text_single_line_uses_font_metrics(self):
+        """
+        Text short enough to need no wrapping takes the early return, and must
+        be measured against the font line height there as well.
+        """
+        font_path = os.path.join(utils.font_dir(), "STHeitiMedium.ttc")
+        font_size = 30
+        expected_line_height = sum(
+            ImageFont.truetype(font_path, font_size).getmetrics()
+        )
+
+        wrapped, height = vd.wrap_text(
+            text="Bottom line",
+            max_width=3000,
+            font=font_path,
+            fontsize=font_size,
+        )
+
+        self.assertNotIn("\n", wrapped)
+        self.assertEqual(height, expected_line_height)
+
+    def test_wrap_text_cjk_wrapping_is_unchanged_and_not_clipped(self):
+        """
+        CJK glyphs have a uniform vertical extent, so they never showed the
+        clipping. Wrapping output must stay identical after moving to font
+        metrics, and the height must only grow, never shrink, so existing CJK
+        subtitle layout is left alone.
+        """
+        font_path = os.path.join(utils.font_dir(), "STHeitiMedium.ttc")
+        font_size = 30
+        font = ImageFont.truetype(font_path, font_size)
+        text = "这是一段用来测试中文长句换行的文本内容，应该会根据宽度限制进行换行处理"
+
+        wrapped, height = vd.wrap_text(
+            text=text,
+            max_width=300,
+            font=font_path,
+            fontsize=font_size,
+        )
+
+        self.assertEqual(
+            wrapped,
+            "这是一段用来测试中文\n长句换行的文本内容，\n应该会根据宽度限制进\n行换行处理",
+        )
+        line_count = wrapped.count("\n") + 1
+        self.assertEqual(height, line_count * sum(font.getmetrics()))
+
+        bbox = font.getbbox(text)
+        ink_height_per_line = bbox[3] - bbox[1]
+        self.assertGreaterEqual(height, line_count * ink_height_per_line)
 
     def test_rounded_subtitle_background_clip_has_transparent_corners(self):
         """


### PR DESCRIPTION
Fixes #1232

### What was wrong

`wrap_text()` measured line height with `font.getbbox()`, which returns the ink extent of
whichever glyphs a phrase happens to contain. A Latin phrase with no descenders (`g/j/p/q/y`)
stops at the baseline, so each line measured cap-height only — 31px short per line at
`font_size=60` with `MicrosoftYaHeiBold.ttc`. That height becomes `clip_h` in `create_subtitle()`,
so the explicit box height added in #747 was computed from an already-undersized number: the box
stopped shrinking, but it was never the right size, and the bottom of the last line was cut off.

Every font in `resource/fonts/` under-measures the descender-free phrase, by 12–39px per line at
`font_size=60`. The error is present for phrases *with* descenders too, just small enough
(1–4px) to go unnoticed.

| | |
|---|---|
| before | <img src="https://github.com/user-attachments/assets/4e02f716-537e-454f-94bb-7ad8ec3bbdbb" width="420"> |
| after | <img src="https://github.com/user-attachments/assets/e26efe83-b707-47e3-9e5e-19fd7dba64e4" width="420"> |

### The fix

Take the line height from the font's own metrics — `sum(font.getmetrics())`, ascent + descent —
which is glyph-independent. Width measurement is unchanged. This also covers the single-line early
return, which had the same problem.

### Tests

Three cases added to `test/services/test_video.py`, all failing on `main` and passing here:

- `test_wrap_text_line_height_does_not_depend_on_descenders` — multiline Latin with and without
  descenders wrap to the same line count and must report the same height, equal to
  `lines * sum(font.getmetrics())`. This is the reported bug.
- `test_wrap_text_single_line_uses_font_metrics` — the early-return path.
- `test_wrap_text_cjk_wrapping_is_unchanged_and_not_clipped` — CJK wrapping output is asserted
  verbatim and the height is asserted to be no smaller than the previous ink measurement.

CJK glyphs have a uniform vertical extent, so they never showed the clipping. Wrapping output for
them is unchanged; the returned height rises slightly (metrics rather than ink), which only makes
the box taller.

Subtitle backgrounds are unaffected: both background paths size themselves with
`max(clip_h, text_clip.h)`, so a larger measured height grows the panel to match the text instead
of changing how it is drawn.

`ruff check app cli.py main.py webui test` and the full `pytest -q test` suite pass
(641 passed, 11 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165tE6dBki6C7e8BCsHcGv3
