### PR TITLE
docs(readme): add Fish Audio to EN/JA TTS provider lists

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -127,7 +127,7 @@ Thanks to [Kimi](https://platform.kimi.ai?track_id=track-f6b0a640d35c41deb03b247
       satisfactory one
 - [x] Supports setting the **duration of video clips**, facilitating adjustments to material switching frequency
 - [x] Supports **multilingual video script** generation
-- [x] Supports **Edge TTS**, **Azure Speech**, **SiliconFlow**, **Google Gemini**, **Xiaomi MiMo**, **ElevenLabs**, and **Chatterbox** speech synthesis with real-time previews
+- [x] Supports **Edge TTS**, **Azure Speech**, **SiliconFlow**, **Google Gemini**, **Xiaomi MiMo**, **ElevenLabs**, **Chatterbox**, and **Fish Audio** speech synthesis with real-time previews
 - [x] Supports **subtitle generation** with configurable fonts, position, color, size, outline, and background styles
 - [x] Supports random or custom **background music** with adjustable volume
 - [x] Supports your own **local assets** and free-to-use HD footage from **Pexels**, **Pixabay**, and **Coverr**
@@ -356,7 +356,7 @@ uv run python cli.py --help
 
 ## Voice Synthesis 🗣
 
-The default provider is the free **Edge TTS**, shown as **Azure TTS V1** in the WebUI. MoneyPrinterTurbo also supports **Azure TTS V2**, **SiliconFlow TTS**, **Google Gemini TTS**, **Xiaomi MiMo TTS**, **ElevenLabs TTS**, self-hosted **Chatterbox TTS**, and a no-voice mode.
+The default provider is the free **Edge TTS**, shown as **Azure TTS V1** in the WebUI. MoneyPrinterTurbo also supports **Azure TTS V2**, **SiliconFlow TTS**, **Google Gemini TTS**, **Xiaomi MiMo TTS**, **ElevenLabs TTS**, self-hosted **Chatterbox TTS**, **Fish Audio TTS**, and a no-voice mode.
 
 Select a provider and voice in the WebUI, then follow the on-screen instructions for any required credentials. Edge TTS does not require an API key; [Azure TTS V2](https://portal.azure.com/) and other cloud providers require credentials from their respective platforms. See the available Edge TTS voices in the [voice list](./docs/voice-list.txt).
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -126,7 +126,7 @@
 - [x] **動画の一括生成**に対応。一度に複数の動画を作成し、最も満足のいくものを選べます
 - [x] **動画クリップの長さ**の設定に対応。素材の切り替え頻度を調整しやすくなります
 - [x] **多言語の動画台本**生成に対応
-- [x] **Edge TTS**、**Azure Speech**、**SiliconFlow**、**Google Gemini**、**Xiaomi MiMo**、**ElevenLabs**、**Chatterbox** による音声合成とリアルタイムプレビューに対応
+- [x] **Edge TTS**、**Azure Speech**、**SiliconFlow**、**Google Gemini**、**Xiaomi MiMo**、**ElevenLabs**、**Chatterbox**、**Fish Audio** による音声合成とリアルタイムプレビューに対応
 - [x] **字幕生成**に対応。フォント、位置、色、サイズ、縁取り、背景スタイルを設定できます
 - [x] ランダムまたはカスタムの **BGM** に対応し、音量も調整できます
 - [x] 手持ちの**ローカル素材**に加え、**Pexels**、**Pixabay**、**Coverr** の無料で使える高画質素材に対応
@@ -352,7 +352,7 @@ uv run python cli.py --help
 
 ## 音声合成 🗣
 
-既定のプロバイダーは無料の **Edge TTS** で、WebUI 上では **Azure TTS V1** と表示されます。MoneyPrinterTurbo は **Azure TTS V2**、**SiliconFlow TTS**、**Google Gemini TTS**、**Xiaomi MiMo TTS**、**ElevenLabs TTS**、セルフホストの **Chatterbox TTS**、および音声なしモードにも対応しています。
+既定のプロバイダーは無料の **Edge TTS** で、WebUI 上では **Azure TTS V1** と表示されます。MoneyPrinterTurbo は **Azure TTS V2**、**SiliconFlow TTS**、**Google Gemini TTS**、**Xiaomi MiMo TTS**、**ElevenLabs TTS**、セルフホストの **Chatterbox TTS**、**Fish Audio TTS**、および音声なしモードにも対応しています。
 
 WebUI でプロバイダーと音声を選択し、必要な認証情報については画面の案内に従ってください。Edge TTS に API キーは不要です。[Azure TTS V2](https://portal.azure.com/) やその他のクラウドプロバイダーでは、それぞれのプラットフォームで発行した認証情報が必要です。利用可能な Edge TTS の音声は[音声リスト](./docs/voice-list.txt)で確認できます。
 


### PR DESCRIPTION
## Problem

Fish Audio TTS support was added in recent TTS pull requests (e.g. #1228 `feat(tts): add verified Female and Male reference_id voice models for Fish Audio`). The Chinese README (`README.md`) already lists Fish Audio in both the **Features** list and the **Voice Synthesis** section, but the English (`README-en.md`) and Japanese (`README-ja.md`) READMEs still omit it from both places. This leaves the multilingual docs inconsistent with the actual supported providers and with each other.

## Solution

Add **Fish Audio** / **Fish Audio TTS** to the English and Japanese READMEs, matching the existing Chinese wording:

- `README-en.md`: added to the Features list and the Voice Synthesis section.
- `README-ja.md`: added to the Features list (機能) and the 音声合成 section.

No code, dependencies, or architecture are touched — this is a documentation-only change across 2 files, 4 insertions / 4 deletions.

## Testing

- Verified via `grep -c "Fish Audio"` that all three READMEs now mention Fish Audio exactly twice (Features + Voice Synthesis), so the provider lists are consistent.
- Confirmed the edited lines preserve the original formatting, markdown checkboxes, and surrounding context (no broken list structure).
- The change is confined to Markdown documentation, so it does not affect build, tests, or runtime behavior.
