### PR TITLE
fix(webui): fall back to in-browser preview for Play/Open Folder on headless servers

### DIFF
--- a/webui/Main.py
+++ b/webui/Main.py
@@ -860,14 +860,29 @@ def _collect_task_summaries(limit=20):
     return sorted(tasks, key=lambda item: item["mtime"], reverse=True)[:limit]
 
 
+def _is_headless_server():
+    # Docker 或无桌面的服务器部署中，WebUI 进程接触不到用户的桌面环境：
+    # xdg-open / webbrowser 只会在容器内静默失败。此时应改为浏览器内预览
+    # 视频、以路径提示代替打开目录。macOS/Windows 桌面部署不受影响。
+    if sys.platform == "darwin" or sys.platform.startswith("win"):
+        return False
+    return not (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
 def _open_task_path(task_path):
     tasks_root = os.path.abspath(utils.task_dir())
     normalized_path = os.path.abspath(task_path)
     if not normalized_path.startswith(tasks_root + os.sep):
         logger.warning(f"invalid task folder path: {normalized_path}")
         return
-    if os.path.isdir(normalized_path):
-        webbrowser.open(f"file://{normalized_path}")
+    if not os.path.isdir(normalized_path):
+        return
+    if _is_headless_server():
+        # storage 目录通常以卷挂载映射回宿主机，提示相对路径即可定位文件。
+        rel_path = os.path.relpath(normalized_path, os.path.dirname(tasks_root))
+        st.toast(f"{tr('Open Task Folder')}: ./storage/{rel_path}", icon="📂")
+        return
+    webbrowser.open(f"file://{normalized_path}")
 
 
 def _open_task_video(video_file):
@@ -881,6 +896,11 @@ def _open_task_video(video_file):
         return
     if not os.path.isfile(normalized_file):
         logger.warning(f"task video does not exist: {normalized_file}")
+        return
+
+    if _is_headless_server():
+        # 无桌面环境时在任务面板内嵌播放器预览，代替调用系统播放器。
+        st.session_state["task_preview_video_file"] = normalized_file
         return
 
     try:
@@ -1095,6 +1115,37 @@ def _render_task_manager_panel(tasks=None):
                 if status_key == "all" or _task_state_filter_key(task) == status_key
             ]
             _render_task_table(filtered_tasks, status_key)
+
+    _render_task_video_preview()
+
+
+def _render_task_video_preview():
+    # 无桌面部署下“播放”按钮的浏览器内回退：在任务面板底部渲染播放器。
+    preview_file = st.session_state.get("task_preview_video_file")
+    if not preview_file:
+        return
+
+    tasks_root = os.path.abspath(utils.task_dir())
+    if not (
+        preview_file.startswith(tasks_root + os.sep) and os.path.isfile(preview_file)
+    ):
+        st.session_state.pop("task_preview_video_file", None)
+        return
+
+    st.divider()
+    preview_cols = st.columns([5, 1], vertical_alignment="center")
+    task_name = os.path.basename(os.path.dirname(preview_file))
+    preview_cols[0].caption(f"{os.path.basename(preview_file)} · {task_name}")
+    closed = preview_cols[1].button(
+        "✕",
+        key="close_task_video_preview",
+        use_container_width=True,
+        help=tr("Close"),
+    )
+    if closed:
+        st.session_state.pop("task_preview_video_file", None)
+        return
+    st.video(preview_file)
 
 
 @st.fragment(run_every="2s")

--- a/webui/i18n/en.json
+++ b/webui/i18n/en.json
@@ -72,6 +72,7 @@
     "Task Actions": "Actions",
     "Play Video": "Play",
     "Play": "Play",
+    "Close": "Close",
     "Open": "Open",
     "Delete": "Delete",
     "Delete Task": "Delete Task",

--- a/webui/i18n/zh.json
+++ b/webui/i18n/zh.json
@@ -72,6 +72,7 @@
     "Task Actions": "操作",
     "Play Video": "播放",
     "Play": "播放",
+    "Close": "关闭",
     "Open": "打开",
     "Delete": "删除",
     "Delete Task": "删除任务",


### PR DESCRIPTION
## Problem

In Docker (and any desktop-less server) deployments, the Task Manager's **Play** and **Open Folder** buttons silently do nothing.

Both actions execute on the server side:

- Play runs `xdg-open <file>` (`_open_task_video`)
- Open Folder runs `webbrowser.open("file://<path>")` (`_open_task_path`)

Inside a container there is no desktop environment, so the calls fail invisibly and the user gets no feedback. The recommended `docker-compose.release.yml` deployment is affected out of the box.

## Fix

Adds a `_is_headless_server()` check (Linux without `DISPLAY`/`WAYLAND_DISPLAY`) with browser-based fallbacks, leaving desktop behavior unchanged:

- **Play** → renders an inline `st.video` player at the bottom of the Task Manager panel (with a close button), streaming the video to the user's browser.
- **Open Folder** → shows a toast with the `./storage/tasks/<task_id>` path, which maps back to the host through the `./storage` volume mount.
- Adds the `Close` i18n key for `zh`/`en` (other locales fall back to English per existing policy).

macOS, Windows, and Linux-with-display installs keep the original open-with-system-player / open-folder behavior.

## Testing

- Verified in a Docker deployment (`docker-compose.release.yml`, image `ghcr.io/harry0703/moneyprinterturbo:latest` v1.3.5) with the patched `webui/` mounted: Play shows the inline player and streams the task video; Open Folder shows the path toast.
- `ruff check webui/Main.py` passes (ruff 0.15.21, matching CI).
- `python -m py_compile` passes on the image's Python 3.11.
- Both i18n files validated as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)