### PR TITLE
fix(webui): decouple upload_post_enabled from auto_upload in settings dialog

### DIFF
--- a/test/services/test_webui_i18n.py
+++ b/test/services/test_webui_i18n.py
@@ -31,6 +31,7 @@ ENGLISH_FALLBACK_KEYS = frozenset(
         "Confirm AI Video Charge Help",
         "Confirm AI Video Charge Required",
         "Custom API Endpoint",
+        "Enable Upload-Post Integration",
         "API Platform",
         "llm_provider_endpoint_selector.moonshot",
         "llm_provider_endpoint_selector_help.moonshot",

--- a/test/services/test_webui_upload_post_settings.py
+++ b/test/services/test_webui_upload_post_settings.py
@@ -34,8 +34,11 @@ def test_webui_upload_post_setup_guide_links_to_required_pages():
         assert "https://app.upload-post.com/manage-users" in setup_guide.value
 
 
-def test_webui_upload_post_checkbox_syncs_persisted_mismatch():
-    # Persisted mismatch: enabled=True, auto_upload=False
+def test_webui_upload_post_checkboxes_stay_decoupled():
+    # enabled=True / auto_upload=False is a deliberate split: an external
+    # pipeline may call Upload-Post while auto-publish stays off. Opening the
+    # settings dialog must not rewrite either key, and each checkbox must
+    # reflect and write only its own key.
     test_app_config = dict(
         config.app,
         upload_post_enabled=True,
@@ -51,16 +54,18 @@ def test_webui_upload_post_checkbox_syncs_persisted_mismatch():
         app.session_state["settings_dialog_open"] = True
         app.run()
 
-        # When UI runs, it sees enabled=True and auto_upload=False.
-        # Checkbox should be UNCHECKED because ui_state = is_enabled and is_auto
-        checkbox = _widget_by_key(app.checkbox, "upload_post_enabled_checkbox")
-        assert checkbox.value is False
+        enabled_box = _widget_by_key(app.checkbox, "upload_post_enabled_checkbox")
+        auto_box = _widget_by_key(app.checkbox, "upload_post_auto_upload_checkbox")
+        assert enabled_box.value is True
+        assert auto_box.value is False
 
-        # Now user clicks it to TRUE
-        checkbox.set_value(True)
+        # Merely rendering the dialog must not have rewritten the split config
+        assert config.app["upload_post_enabled"] is True
+        assert config.app["upload_post_auto_upload"] is False
+
+        # Toggling auto_upload on must leave enabled untouched
+        auto_box.set_value(True)
         app.run()
-
-        # Verify it updated both
         assert config.app["upload_post_enabled"] is True
         assert config.app["upload_post_auto_upload"] is True
 

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -2608,16 +2608,25 @@ def _render_settings_dialog():
 
             is_enabled = config.app.get("upload_post_enabled", False)
             is_auto = config.app.get("upload_post_auto_upload", False)
-            ui_state = is_enabled and is_auto
 
+            # 两个键各自独立:enabled 允许外部流程调用 Upload-Post,
+            # auto_upload 才决定渲染完成后是否自动发布。合并成一个复选框会在
+            # 两键不一致的配置下,仅打开设置对话框就把 enabled 改写为 False。
             upload_post_enabled = st.checkbox(
-                tr("Enable Auto-Publish"),
-                value=ui_state,
+                tr("Enable Upload-Post Integration"),
+                value=is_enabled,
                 key="upload_post_enabled_checkbox"
             )
-            if upload_post_enabled != is_enabled or upload_post_enabled != is_auto:
+            if upload_post_enabled != is_enabled:
                 _set_runtime_config("app", "upload_post_enabled", upload_post_enabled)
-                _set_runtime_config("app", "upload_post_auto_upload", upload_post_enabled)
+
+            upload_post_auto_upload = st.checkbox(
+                tr("Enable Auto-Publish"),
+                value=is_auto,
+                key="upload_post_auto_upload_checkbox"
+            )
+            if upload_post_auto_upload != is_auto:
+                _set_runtime_config("app", "upload_post_auto_upload", upload_post_auto_upload)
 
             upload_post_api_key = st.text_input(
                 tr("Upload-Post API Key"),

--- a/webui/i18n/en.json
+++ b/webui/i18n/en.json
@@ -391,6 +391,7 @@
     "Auto-Publish Settings": "Auto-Publish Settings",
     "Automatically publish generated videos to social media using upload-post.com": "Automatically publish generated videos to social media using upload-post.com",
     "Enable Auto-Publish": "Enable Auto-Publish",
+    "Enable Upload-Post Integration": "Enable Upload-Post Integration",
     "Platforms": "Platforms",
     "Upload-Post API Key": "Upload-Post API Key",
     "Upload-Post API Key Help": "Create and copy an API key on the [Upload-Post API Keys page]({api_keys_url}).",


### PR DESCRIPTION
Fixes #1258.

## Problem

The Auto-Publish settings tab renders one checkbox for two config keys. It computes the checkbox value as `upload_post_enabled and upload_post_auto_upload`, then writes **both** keys whenever the checkbox differs from either. A config with `upload_post_enabled = true` and `upload_post_auto_upload = false` (external tooling uses the Upload-Post integration while post-render auto-upload stays off) mismatches on every render, so opening the Settings dialog persists both keys as `false` without any click. Re-ticking the box from that state sets `auto_upload = true`, which the user had turned off. Full analysis and reproduction in #1258.

## Change

- `webui/Main.py`: two checkboxes, one per key. Each reflects its own saved value and writes only its own key on change.
- `test/services/test_webui_upload_post_settings.py`: the checkbox test now asserts that opening Settings preserves a split config (`enabled = true` / `auto_upload = false`) and that toggling auto-upload leaves `enabled` untouched.
- `webui/i18n/en.json` + `test/services/test_webui_i18n.py`: new label `Enable Upload-Post Integration`, registered in `ENGLISH_FALLBACK_KEYS` so secondary locales fall back to English per the existing convention.

## Testing

Full suite passes with the change: `744 passed, 11 skipped, 6951 subtests` (`python -m pytest test -q`). The rewritten AppTest case renders the real dialog against a split config and fails on the pre-fix behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcyHNEBEz7V7LdDz2L6wWQ
