### PR TITLE
fix(logging): keep log records when the project root is on another mount

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,3 +109,4 @@ jobs:
           test/services/test_task_manager.py
           test/services/test_upload_post.py
           test/services/test_controller_video.py
+          test/services/test_webui_task.py

--- a/app/utils/logging_utils.py
+++ b/app/utils/logging_utils.py
@@ -20,6 +20,28 @@ _terminal_handler_id: int | None = 0
 _terminal_handler_lock = threading.RLock()
 
 
+def _project_relative_path(file_path):
+    """
+    把绝对路径缩短为 ``./`` 开头、始终使用正斜杠的项目相对路径。
+
+    Windows 上项目可能通过映射网络盘或 ``subst`` 盘启动。此时调用栈里的路径
+    仍是 ``X:\\MoneyPrinterTurbo\\...``，而 ``PROJECT_ROOT`` 经 ``realpath``
+    解析后落在 ``C:\\...``，``os.path.relpath`` 会直接抛出 ``ValueError``。
+    格式化函数抛错会被 loguru 捕获并丢弃整条记录，终端和 WebUI 日志面板会
+    同时变空，因此这里必须兜底返回原始路径。项目目录之外的文件同理：把
+    ``./`` 拼到 ``..`` 回溯路径上只会得到更难读的结果。
+    """
+    try:
+        relative_path = os.path.relpath(file_path, PROJECT_ROOT)
+    except ValueError:
+        return file_path
+    if relative_path == os.pardir or relative_path.startswith(os.pardir + os.sep):
+        return file_path
+    # Windows 的 relpath 返回反斜杠分隔的路径，直接拼接会得到 ``./app\\utils``
+    # 这种混合分隔符的输出，与其它平台的日志不一致。
+    return f"./{relative_path.replace(os.sep, '/')}"
+
+
 def format_log_record(record):
     """
     统一格式化终端与 WebUI 日志。
@@ -30,8 +52,7 @@ def format_log_record(record):
     """
     file_path = record["file"].path
     if os.path.isabs(file_path):
-        relative_path = os.path.relpath(file_path, PROJECT_ROOT)
-        record["file"].path = f"./{relative_path}"
+        record["file"].path = _project_relative_path(file_path)
 
     # 日志消息有时会包含任务文件的绝对路径。统一缩短为项目相对路径，可以
     # 避免 WebUI 和终端因初始化入口不同而展示两套内容。

--- a/test/services/test_webui_task.py
+++ b/test/services/test_webui_task.py
@@ -33,6 +33,14 @@ def _attribute_name(node):
     return ".".join(reversed(names))
 
 
+def _log_record(file_path, message="generation finished"):
+    """构造 ``format_log_record`` 需要的最小 loguru 记录。"""
+    return {
+        "file": SimpleNamespace(name=os.path.basename(file_path), path=file_path),
+        "message": message,
+    }
+
+
 def test_generation_controls_submit_background_task_instead_of_blocking_page():
     """
     WebUI 生成按钮不能重新直接调用同步流水线。
@@ -345,6 +353,59 @@ def test_worker_logs_are_available_without_streamlit_session_state():
         r"- unique background task log",
         records[0],
     )
+
+
+def test_log_paths_stay_posix_style_on_every_platform():
+    """
+    调用位置必须始终显示为 ``./app/services/task.py``。
+
+    Windows 的 ``os.path.relpath`` 返回反斜杠分隔的路径，直接拼接会输出
+    ``./app\\services\\task.py``，同一份日志在不同系统上格式不一致，也无法
+    和上面按正斜杠断言的后台日志回归测试对齐。
+    """
+    record = _log_record(
+        os.path.join(logging_utils.PROJECT_ROOT, "app", "services", "task.py")
+    )
+
+    logging_utils.format_log_record(record)
+
+    assert record["file"].path == "./app/services/task.py"
+
+
+def test_log_paths_on_another_mount_do_not_discard_the_record():
+    """
+    映射盘或 ``subst`` 盘启动时不能让整条日志消失。
+
+    这种部署下调用栈里的路径仍在 ``X:``，而 ``PROJECT_ROOT`` 已被 realpath
+    解析回 ``C:``，``os.path.relpath`` 会抛出 ``ValueError``。loguru 捕获
+    格式化异常后会丢弃记录，终端和 WebUI 日志面板会同时变空。
+    """
+    absolute_path = os.path.join(
+        logging_utils.PROJECT_ROOT, "app", "services", "task.py"
+    )
+    record = _log_record(absolute_path)
+
+    with patch.object(
+        logging_utils.os.path,
+        "relpath",
+        side_effect=ValueError("path is on mount 'X:', start on mount 'C:'"),
+    ):
+        log_format = logging_utils.format_log_record(record)
+
+    assert log_format == logging_utils.LOG_RECORD_FORMAT
+    assert record["file"].path == absolute_path
+
+
+def test_log_paths_outside_the_project_keep_the_absolute_path():
+    """项目目录之外的文件保持绝对路径，避免输出 ``./../..`` 这类回溯路径。"""
+    outside_path = os.path.join(
+        os.path.dirname(logging_utils.PROJECT_ROOT), "site-packages", "worker.py"
+    )
+    record = _log_record(outside_path)
+
+    logging_utils.format_log_record(record)
+
+    assert record["file"].path == outside_path
 
 
 def test_generation_log_fragment_refreshes_within_half_a_second():


### PR DESCRIPTION
`format_log_record` shortens the absolute source path of every record into a project-relative `./...` form. Two edge cases in that conversion are only reachable on Windows, and one of them silently kills logging.

## The dropped records

`os.path.relpath` raises `ValueError` when the two paths sit on different Windows mounts. That is exactly what happens when the project is launched through a mapped network drive (`net use Z: \\nas\share`) or a `subst` drive: the call frame keeps the drive the user launched from, while `PROJECT_ROOT` is built with `os.path.realpath`, which resolves the mapping away.

Reproduced with `subst X: <parent of the repo>`, then importing the app from `X:\MoneyPrinterTurbo`:

```
--- Logging error in Loguru Handler #2 ---
Record was: {... 'file': (name='config.py', path='X:\\MoneyPrinterTurbo\\app\\config\\config.py'), ...}
Traceback (most recent call last):
  File ".venv\Lib\site-packages\loguru\_handler.py", line 137, in emit
    dynamic_format = self._formatter(record)
  File "X:\MoneyPrinterTurbo\app\utils\logging_utils.py", line 33, in format_log_record
    relative_path = os.path.relpath(file_path, PROJECT_ROOT)
ValueError: path is on mount 'X:', start on mount 'C:'
--- End of logging error ---
```

Loguru catches the formatter exception and discards the record, so the sink receives nothing at all. The terminal prints that dump instead of the log line, and since `webui_task.py` installs a second sink with the same formatter to feed the WebUI log panel, the generation log panel stays empty for the whole run.

## The mixed separators

On Windows `os.path.relpath` returns backslash-separated segments, so the `./` prefix produces `"./app\services\task.py"`. `test_worker_logs_are_available_without_streamlit_session_state` already pins the POSIX form:

```python
r'"\./test/services/test_webui_task\.py:\d+": logged_start '
```

and fails on Windows today. That file is not in the `windows-smoke` job, which is why the drift was never caught.

## The change

| File | Change |
|---|---|
| `app/utils/logging_utils.py` | extract `_project_relative_path`: guard the `ValueError`, keep the absolute path for files outside the project root, normalise separators to `/` |
| `test/services/test_webui_task.py` | three regression tests, next to the existing `logging_utils` coverage |
| `.github/workflows/ci.yml` | add `test/services/test_webui_task.py` to the Windows smoke job |

Files outside `PROJECT_ROOT` keep their absolute path as well: `./..\..\..\AppData\Local\...` is no easier to read than the path it replaces.

## Why the CI file is touched

The formatter change is only observable on Windows, and the test that proves it lives in a file the Windows job does not run. That one line is what keeps the same drift from coming back. Happy to drop it if you would rather keep the smoke list at core services only.

## Verification

Full suite on Windows 11, Python 3.12, `uv sync --frozen`:

```
$ python -X utf8 -m pytest -q test    # before
4 failed, 740 passed, 11 skipped, 6951 subtests passed

$ python -X utf8 -m pytest -q test    # after
1 failed, 746 passed, 11 skipped, 6951 subtests passed
```

`ruff check app cli.py main.py webui test` and `compileall app cli.py main.py webui test` are both clean.

Each new test was confirmed to fail without the `logging_utils.py` change. Two of the three fail on Linux as well; `test_log_paths_stay_posix_style_on_every_platform` is a Windows-only guard, which is what the CI line is for.

The remaining failure is unrelated and fails identically on a clean `main`: `test_headless_open_folder_shows_host_mapped_path` sets `sys.platform` to `"linux"` in its fixture, which makes NumPy take its Linux branch on first import and call `os.uname()`, absent on Windows. It passes on the Linux matrix. Two further failures in the "before" run (`test_corrupted_cache_is_removed_without_breaking_search`, `test_elevenlabs_connection_button_reports_success`) are timing-dependent; both pass in isolation and passed in the "after" run.
