### PR TITLE
fix(audio): measure audio_duration from the real file, not SubMaker cues

### DIFF
--- a/app/services/task.py
+++ b/app/services/task.py
@@ -535,7 +535,19 @@ def generate_audio(
                 "failed to synthesize audio; verify the selected voice and TTS connectivity",
             )
             return None, None, None
-        audio_duration = math.ceil(voice.get_audio_duration(sub_maker))
+        # Measure the real written audio_file, not sub_maker.cues[-1].end.
+        # SubMaker duration is the last WORD BOUNDARY's end time; TTS engines
+        # commonly leave a short tail beyond that (silence/breath room), so
+        # the two differ. Using the word-boundary figure as "the" audio
+        # duration under-counts - verified with a 2-sentence test TTS call
+        # where SubMaker measured 5.39s vs 7s for the actual file, a 1.6s
+        # gap. Anything sized off the under-counted duration (e.g. video
+        # clips trimmed to match narration length) can end up shorter than
+        # the real audio, silently truncating the end of the narration.
+        file_duration = voice.get_audio_duration(audio_file)
+        audio_duration = math.ceil(
+            file_duration if file_duration > 0 else voice.get_audio_duration(sub_maker)
+        )
         if audio_duration == 0:
             _mark_task_failed(task_id, "audio", "generated audio duration is zero")
             return None, None, None

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -535,15 +535,13 @@ def generate_audio(
                 "failed to synthesize audio; verify the selected voice and TTS connectivity",
             )
             return None, None, None
-        # Measure the real written audio_file, not sub_maker.cues[-1].end.
-        # SubMaker duration is the last WORD BOUNDARY's end time; TTS engines
-        # commonly leave a short tail beyond that (silence/breath room), so
-        # the two differ. Using the word-boundary figure as "the" audio
-        # duration under-counts - verified with a 2-sentence test TTS call
-        # where SubMaker measured 5.39s vs 7s for the actual file, a 1.6s
-        # gap. Anything sized off the under-counted duration (e.g. video
-        # clips trimmed to match narration length) can end up shorter than
-        # the real audio, silently truncating the end of the narration.
+        # Measure the real written audio_file, not sub_maker.cues[-1].end:
+        # the latter is the last WORD BOUNDARY, and TTS leaves a fixed tail
+        # past it (Edge TTS: ~0.88s at any length - 19% of a 7-word clip but
+        # 1.4% of a 153-word one, so short scripts suffer most). The
+        # under-count sizes paid generate_bgm() calls, is reported as
+        # audio_duration to the API/WebUI, and under-sources
+        # download_videos() material, scaled by video_count.
         file_duration = voice.get_audio_duration(audio_file)
         audio_duration = math.ceil(
             file_duration if file_duration > 0 else voice.get_audio_duration(sub_maker)

--- a/test/services/test_task.py
+++ b/test/services/test_task.py
@@ -831,6 +831,144 @@ class TestTaskService(unittest.TestCase):
         self.assertEqual(failed_task["failed_stage"], "audio")
         self.assertIn("does not exist", failed_task["error"])
 
+    def test_generate_audio_prefers_file_duration_over_sub_maker(self):
+        # Every fixture deliberately makes the file duration and the SubMaker
+        # duration ceil to DIFFERENT integers. If someone "simplifies" them to
+        # values that share a ceil, this test can no longer tell which source
+        # the implementation used - it stops discriminating, silently.
+        cases = (
+            # The maintainer's own reproduction numbers from the PR discussion.
+            (8.4, 7.8375, 9),
+            # An exact-integer file duration: proves math.ceil() is really
+            # used and rules out int()+1 style code that adds a spurious
+            # second. The SubMaker value ceils to 7, so 8 can only come
+            # from the file.
+            (8.0, 6.2, 8),
+            # File duration shorter than the SubMaker value: the only case
+            # where this change makes audio_duration smaller than before (the
+            # old code returned 8). The contract is "the file wins", not
+            # "the larger value wins".
+            (5.0, 7.8375, 5),
+        )
+
+        for file_duration, sub_maker_duration, expected in cases:
+            with self.subTest(file_duration=file_duration):
+                task_id = f"test-tts-audio-priority-{uuid4().hex}"
+                task_dir = utils.task_dir(task_id)
+                audio_path = os.path.join(task_dir, "audio.mp3")
+                params = VideoParams(
+                    video_subject="tts audio",
+                    video_script="",
+                    voice_name="test-voice",
+                )
+                sub_maker = MagicMock()
+
+                def fake_duration(target, _file=file_duration, _sub=sub_maker_duration):
+                    # Dispatch on argument type, never on call order: a
+                    # sequence side_effect would still pass against an
+                    # implementation that measured the SubMaker first, which
+                    # is exactly the regression this test exists to catch.
+                    return _file if isinstance(target, str) else _sub
+
+                try:
+                    with (
+                        patch.object(tm.voice, "tts", return_value=sub_maker) as tts,
+                        patch.object(
+                            tm.voice, "get_audio_duration", side_effect=fake_duration
+                        ) as get_duration,
+                    ):
+                        audio_file, audio_duration, result_sub_maker = tm.generate_audio(
+                            task_id, params, "script"
+                        )
+                finally:
+                    shutil.rmtree(task_dir, ignore_errors=True)
+
+                self.assertEqual(audio_file, audio_path)
+                self.assertEqual(audio_duration, expected)
+                # Asserting the value alone would still pass an
+                # implementation returning 9.0; the type assertion pins the
+                # other side of the rounding contract, so a refactor cannot
+                # drop math.ceil() and pass the float straight through.
+                self.assertIsInstance(audio_duration, int)
+                self.assertIs(result_sub_maker, sub_maker)
+                tts.assert_called_once()
+                # When file measurement succeeds the SubMaker must not be
+                # measured at all: exactly one call, and that call's argument
+                # is the audio file path. Both assertions together are what
+                # prove the priority order.
+                self.assertEqual(len(get_duration.call_args_list), 1)
+                self.assertEqual(get_duration.call_args_list[0].args[0], audio_path)
+
+    def test_generate_audio_falls_back_to_sub_maker_when_file_duration_is_zero(self):
+        task_id = "test-tts-audio-fallback"
+        task_dir = utils.task_dir(task_id)
+        audio_path = os.path.join(task_dir, "audio.mp3")
+        params = VideoParams(
+            video_subject="tts audio",
+            video_script="",
+            voice_name="test-voice",
+        )
+        sub_maker = MagicMock()
+
+        def fake_duration(target):
+            # voice.get_audio_duration() returns 0.0 when file measurement
+            # fails (missing file or decode error); only then may the
+            # SubMaker word-boundary duration be used.
+            return 0.0 if isinstance(target, str) else 7.8375
+
+        try:
+            with (
+                patch.object(tm.voice, "tts", return_value=sub_maker),
+                patch.object(
+                    tm.voice, "get_audio_duration", side_effect=fake_duration
+                ) as get_duration,
+            ):
+                audio_file, audio_duration, result_sub_maker = tm.generate_audio(
+                    task_id, params, "script"
+                )
+        finally:
+            shutil.rmtree(task_dir, ignore_errors=True)
+
+        self.assertEqual(audio_file, audio_path)
+        self.assertEqual(audio_duration, 8)
+        self.assertIsInstance(audio_duration, int)
+        self.assertIs(result_sub_maker, sub_maker)
+        self.assertEqual(len(get_duration.call_args_list), 2)
+        self.assertEqual(get_duration.call_args_list[0].args[0], audio_path)
+        self.assertIs(get_duration.call_args_list[1].args[0], sub_maker)
+
+    def test_generate_audio_fails_when_file_and_sub_maker_durations_are_zero(self):
+        # This change replaces the source of audio_duration, so the
+        # pre-existing zero-duration guard must be proven to still fire
+        # rather than be bypassed by the new file-measurement branch.
+        task_id = "test-tts-audio-zero-duration"
+        task_dir = utils.task_dir(task_id)
+        params = VideoParams(
+            video_subject="tts audio",
+            video_script="",
+            voice_name="test-voice",
+        )
+        sub_maker = MagicMock()
+
+        try:
+            with (
+                patch.object(tm.voice, "tts", return_value=sub_maker),
+                patch.object(tm.voice, "get_audio_duration", return_value=0.0),
+                patch.object(tm, "_mark_task_failed") as mark_task_failed,
+            ):
+                audio_file, audio_duration, result_sub_maker = tm.generate_audio(
+                    task_id, params, "script"
+                )
+        finally:
+            shutil.rmtree(task_dir, ignore_errors=True)
+
+        self.assertIsNone(audio_file)
+        self.assertIsNone(audio_duration)
+        self.assertIsNone(result_sub_maker)
+        mark_task_failed.assert_called_once_with(
+            task_id, "audio", "generated audio duration is zero"
+        )
+
     def test_generate_subtitle_uses_whisper_for_custom_audio_without_sub_maker(self):
         """
         自定义音频不会经过 TTS，所以没有 sub_maker。


### PR DESCRIPTION
## Summary

`generate_audio()` computed `audio_duration` from `voice.get_audio_duration(sub_maker)`, which reads `SubMaker.cues[-1].end` — the last **word boundary** reported by the TTS engine's streaming metadata. TTS engines leave a short tail of silence beyond that boundary, so this systematically under-counts the real audio length.

**This is not a new opinion about which number is correct — it is an internal inconsistency the codebase already resolves the other way.** The WebUI voice-preview path measures the real file (`webui/Main.py:4205` → `voice.get_audio_duration(audio_file)`), and `generate_audio()` returns `math.ceil()` of that value when the preview cache is reused (`app/services/task.py:474`). So before this change, the *same script with the same voice* produced a different `audio_duration` depending on whether the preview cache happened to hit (file-measured, correct) or miss (word-boundary, short). This PR makes the TTS path agree with the path right above it.

## Measured

Live Edge TTS, `en-US-AriaNeural`, measured with the project's own `voice.get_audio_duration()` on both targets and cross-checked with `ffprobe`:

| Script | SubMaker | Real file | Gap | Error |
|---|---|---|---|---|
| 7 words | 3.750s | 4.630s | 0.880s | **19.0%** |
| 39 words | 16.450s | 17.330s | 0.880s | 5.1% |
| 153 words | 60.575s | 61.460s | 0.885s | 1.4% |

The gap is a **constant ~0.88s tail, not a proportional error** — identical across a 13× range of audio length, and byte-deterministic across repeated synthesis of the same text. The tail size varies by voice (@harry0703 measured 0.5625s on his reproduction: 7.8375s vs 8.4s), but it is constant within a voice.

Because the tail is fixed, **the relative error is worst on short clips** — 19% on a 7-word script — which is this project's primary use case.

## What the under-count actually affects

Ranked by impact:

1. **`generate_bgm(video_duration=audio_duration)`** (`app/services/task.py:838`) — a paid third-party call (Sonilo/ElevenLabs) sized off the under-count, producing music shorter than the video you were billed for.
2. **Reported duration** (`app/services/task.py:1350`, `:1444`) — the API response and WebUI show a duration that is short by the tail.
3. **`download_videos(audio_duration=audio_duration * params.video_count)`** (`app/services/task.py:721`) — under-sourced footage, with the error multiplied by `video_count`. `combine_videos()` compensates by looping clips (`app/services/video.py:724-737`), so the visible result is more repetition rather than a short video.

**Correction to the original description of this PR:** I initially wrote that the final mux truncates the narration via `-shortest`. That is wrong for this pipeline and I want to withdraw it rather than have it merged into the history. `combine_videos()` never receives `audio_duration`; it re-measures the audio from the real file (`app/services/video.py:549-553`) and adds a 0.1s safety margin (`app/services/video.py:94-102`), and there is no `-shortest` anywhere in `app/` (zero grep hits). The final render is correct today — which is exactly why @harry0703's end-to-end check matched the 8.4s audio. The defect is the wrong *value*, not a truncated *render*.

## Fix

Measure `audio_file` first; fall back to the SubMaker figure only when file measurement returns `0` — which `voice.get_audio_duration()` returns for a missing file (`app/services/voice.py:2204`) or a decode failure (`:2211`). `voice.get_audio_duration()` already accepted a file path (`_get_audio_duration_from_file`); the call site simply wasn't using it even though `audio_file` was in scope.

## Test plan

Regression coverage as requested, in `test/services/test_task.py`:

- [x] **Priority** — a valid file duration wins over the shorter SubMaker duration, asserted with your own reproduction numbers (8.4 vs 7.8375 → 9). Two further cases: an exact-integer file duration (8.0 → 8, ruling out an off-by-one in the `ceil`), and a file duration *shorter* than the SubMaker value (5.0 vs 7.8375 → 5), which pins the contract as "the file wins" rather than "the larger value wins".
- [x] **Fallback** — when file measurement returns 0, the SubMaker duration is used.
- [x] **Zero guard** — when both measurements are 0, the existing `"generated audio duration is zero"` failure still fires. This branch had no coverage anywhere in `test/`; since this PR changes how `audio_duration` is computed, it is a regression test for this change.
- [x] Tests verified to be load-bearing: reverting the fix turns the priority cases red.
- [x] `ruff check` and the full `pytest -q test` suite pass locally on Python 3.11.

Mocked at the `voice.tts` / `voice.get_audio_duration` boundary, following the existing convention in this file — no real ffmpeg, since `test_task.py` also runs in the Windows smoke job.

## Follow-ups (deliberately not in this PR)

Two adjacent issues I found while writing these tests, left out to keep this change reviewable:

1. `generate_audio()` returns an `int` from the TTS branch (`math.ceil`) but a raw `float` from the custom-audio branch (`app/services/task.py:557`), and both land in the same `audio_duration` key and the same `video_duration=` argument.
2. The `"custom audio duration is zero"` branch (`app/services/task.py:558`) is also untested.

Happy to open a separate PR for either if you want them.
