### PR TITLE
fix(cli): use human-readable unit in batch manifest size error

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -815,7 +815,7 @@ def _load_batch_manifest(raw_path: str) -> tuple[str, list[dict[str, Any]]]:
         payload = manifest_file.read(_BATCH_FILE_MAX_BYTES + 1)
     if len(payload) > _BATCH_FILE_MAX_BYTES:
         raise ValueError(
-            f"batch manifest exceeds the {_BATCH_FILE_MAX_BYTES}-byte limit"
+            f"batch manifest exceeds the 1 MiB limit"
         )
 
     try:

--- a/test/services/test_cli.py
+++ b/test/services/test_cli.py
@@ -990,7 +990,7 @@ class TestCli(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             oversized = Path(temp_dir) / "oversized.jsonl"
             oversized.write_bytes(b"x" * (cli._BATCH_FILE_MAX_BYTES + 1))
-            with self.assertRaisesRegex(ValueError, "byte limit"):
+            with self.assertRaisesRegex(ValueError, "1 MiB limit"):
                 cli._load_batch_manifest(str(oversized))
 
             too_many = Path(temp_dir) / "too-many.json"


### PR DESCRIPTION
## Summary

- The batch manifest size error message was interpolating the raw byte constant (`1048576`) instead of the plain-English `1 MiB` used in the help text and companion task-count error message.
- Changed the error to say `"batch manifest exceeds the 1 MiB limit"` for consistency and readability.

## Test plan

- [ ] Provide a batch manifest file larger than 1 MiB and confirm the error message reads `"batch manifest exceeds the 1 MiB limit"`
