### PR TITLE
fix(api): omit Redis auth segment when password is not configured

### DIFF
--- a/app/controllers/v1/video.py
+++ b/app/controllers/v1/video.py
@@ -48,7 +48,13 @@ _redis_password = config.app.get("redis_password", None)
 _max_concurrent_tasks = config.app.get("max_concurrent_tasks", 5)
 _max_queued_tasks = config.app.get("max_queued_tasks", 100)
 
-redis_url = f"redis://:{_redis_password}@{_redis_host}:{_redis_port}/{_redis_db}"
+
+def _build_redis_url(host: str, port: int, db: int, password: str | None) -> str:
+    auth = f":{password}@" if password else ""
+    return f"redis://{auth}{host}:{port}/{db}"
+
+
+redis_url = _build_redis_url(_redis_host, _redis_port, _redis_db, _redis_password)
 # 根据配置选择合适的任务管理器
 if _enable_redis:
     task_manager = RedisTaskManager(

--- a/test/services/test_controller_video.py
+++ b/test/services/test_controller_video.py
@@ -541,5 +541,28 @@ class TestVideoControllerFiles(unittest.TestCase):
         self.assertEqual(response.media_type, "video/mp4")
 
 
+class TestBuildRedisUrl(unittest.TestCase):
+    def test_no_password_omits_auth_segment(self):
+        """None and empty-string passwords must not embed a literal 'None' or ':@'."""
+        from app.controllers.v1.video import _build_redis_url
+
+        self.assertEqual(
+            _build_redis_url("localhost", 6379, 0, None),
+            "redis://localhost:6379/0",
+        )
+        self.assertEqual(
+            _build_redis_url("localhost", 6379, 0, ""),
+            "redis://localhost:6379/0",
+        )
+
+    def test_password_is_included_in_url(self):
+        from app.controllers.v1.video import _build_redis_url
+
+        self.assertEqual(
+            _build_redis_url("redis-host", 6380, 1, "s3cr3t"),
+            "redis://:s3cr3t@redis-host:6380/1",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- When `redis_password` is unset (the default `None`), the previous f-string
  produced `redis://:None@host:port/db` — Python's `None` got stringified verbatim,
  so redis-py sent `AUTH None` to Redis and failed on every password-less server.
- Extract a small `_build_redis_url()` helper that only includes the `:password@`
  auth segment when a password is actually provided.
- Covers `None`, empty string (both produce a no-auth URL), and a real password
  value with unit tests.

## Test plan

- [ ] `TestBuildRedisUrl.test_no_password_omits_auth_segment` — `None` and `""` both produce `redis://localhost:6379/0`
- [ ] `TestBuildRedisUrl.test_password_is_included_in_url` — real password produces correct URL
- [ ] Existing `TestVideoControllerTasks` and `TestRedisTaskManager` suites still pass
