### PR TITLE
fix(llm): suppress spurious "trying again" warning on the final retry attempt

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -569,7 +569,7 @@ def generate_script(
         except Exception as e:
             logger.error(f"failed to generate script: {e}")
 
-        if i < _max_retries:
+        if i < _max_retries - 1:
             logger.warning(f"failed to generate video script, trying again... {i + 1}")
     if "Error: " in final_script:
         logger.error(f"failed to generate video script: {final_script}")
@@ -695,7 +695,7 @@ Please note that you must use English for generating video search terms; Chinese
 
         if search_terms and len(search_terms) > 0:
             break
-        if i < _max_retries:
+        if i < _max_retries - 1:
             logger.warning(f"failed to generate video terms, trying again... {i + 1}")
 
     logger.success(f"completed: \n{search_terms}")

--- a/test/services/test_llm.py
+++ b/test/services/test_llm.py
@@ -1736,5 +1736,55 @@ class TestLiteLLMLiveIntegration(unittest.TestCase):
         self.assertIn("4", result)
 
 
+class TestRetryWarningBoundary(unittest.TestCase):
+    """'trying again' must not be logged on the last retry attempt."""
+
+    def _trying_again_count(self, mock_logger: object, fragment: str) -> int:
+        return sum(
+            1
+            for call in mock_logger.warning.call_args_list
+            if fragment in str(call)
+        )
+
+    def test_generate_script_no_spurious_warning_on_last_attempt(self):
+        with (
+            patch.object(
+                llm,
+                "_generate_response",
+                side_effect=RuntimeError("provider unavailable"),
+            ),
+            patch.object(llm, "logger") as mock_logger,
+        ):
+            llm.generate_script(video_subject="test subject")
+
+        count = self._trying_again_count(mock_logger, "trying again")
+        self.assertEqual(
+            count,
+            llm._max_retries - 1,
+            "Warning must not fire on the final attempt — no further retry will occur",
+        )
+
+    def test_generate_terms_no_spurious_warning_on_last_attempt(self):
+        with (
+            patch.object(
+                llm,
+                "_generate_response",
+                side_effect=RuntimeError("provider unavailable"),
+            ),
+            patch.object(llm, "logger") as mock_logger,
+        ):
+            llm.generate_terms(
+                video_subject="test subject",
+                video_script="some script text",
+            )
+
+        count = self._trying_again_count(mock_logger, "trying again")
+        self.assertEqual(
+            count,
+            llm._max_retries - 1,
+            "Warning must not fire on the final attempt — no further retry will occur",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
generate_script and generate_terms guarded the "trying again…" log with if i < _max_retries:. Since the loop is for i in range(_max_retries), i maxes out at _max_retries - 1, making the condition always True — the misleading warning fired even on the last attempt when no retry would follow.

Changed the guard to if i < _max_retries - 1:, matching the identical pattern already present in generate_social_metadata (line 958). Added unit tests verifying the warning fires exactly _max_retries - 1 times when every attempt fails.