### PR TITLE
fix(voice): anchor SiliconFlow subtitle timeline end to full audio duration

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -948,74 +948,24 @@ def siliconflow_tts(
                 with open(voice_file, "wb") as f:
                     f.write(response.content)
 
-                # 这里仍然沿用项目原有的字幕结构，因此需要补齐旧字段。
                 sub_maker = ensure_legacy_submaker_fields(SubMaker())
 
-                # 获取音频文件的实际长度
                 try:
-                    # 尝试使用moviepy获取音频长度
-                    from moviepy import AudioFileClip
-
                     audio_clip = AudioFileClip(voice_file)
-                    audio_duration = audio_clip.duration
-                    audio_clip.close()
-
-                    # 将音频长度转换为100纳秒单位（与edge_tts兼容）
-                    audio_duration_100ns = int(audio_duration * 10000000)
-
-                    # 使用文本分割来创建更准确的字幕
-                    # 将文本按标点符号分割成句子
-                    sentences = utils.split_string_by_punctuations(text)
-
-                    if sentences:
-                        # 计算每个句子的大致时长（按字符数比例分配）
-                        total_chars = sum(len(s) for s in sentences)
-                        char_duration = (
-                            audio_duration_100ns / total_chars if total_chars > 0 else 0
-                        )
-
-                        current_offset = 0
-                        for sentence in sentences:
-                            if not sentence.strip():
-                                continue
-
-                            # 计算当前句子的时长
-                            sentence_chars = len(sentence)
-                            sentence_duration = int(sentence_chars * char_duration)
-
-                            # 添加到SubMaker
-                            sub_maker.subs.append(sentence)
-                            sub_maker.offset.append(
-                                (current_offset, current_offset + sentence_duration)
-                            )
-
-                            # 更新偏移量
-                            current_offset += sentence_duration
-                    else:
-                        # 如果无法分割，则使用整个文本作为一个字幕
-                        sub_maker.subs = [text]
-                        sub_maker.offset = [(0, audio_duration_100ns)]
-
+                    try:
+                        audio_duration = audio_clip.duration
+                    finally:
+                        audio_clip.close()
                 except Exception as e:
-                    logger.warning(f"Failed to create accurate subtitles: {str(e)}")
-                    # 回退到简单的字幕
-                    sub_maker.subs = [text]
-                    # 使用音频文件的实际长度，如果无法获取，则假设为10秒
-                    sub_maker.offset = [
-                        (
-                            0,
-                            audio_duration_100ns
-                            if "audio_duration_100ns" in locals()
-                            else 10000000,
-                        )
-                    ]
+                    logger.warning(f"Failed to read audio duration: {str(e)}")
+                    audio_duration = 10.0
 
                 logger.success(f"siliconflow tts succeeded: {voice_file}")
-                logger.debug(
-                    "siliconflow subtitle timeline generated, "
-                    f"subs: {len(sub_maker.subs)}, offsets: {len(sub_maker.offset)}"
+                return populate_legacy_submaker_with_full_text(
+                    sub_maker=sub_maker,
+                    text=text,
+                    audio_duration_seconds=audio_duration,
                 )
-                return sub_maker
             else:
                 logger.error(
                     f"siliconflow tts failed with status code {response.status_code}: {response.text}"

--- a/test/services/test_voice.py
+++ b/test/services/test_voice.py
@@ -1318,7 +1318,57 @@ class TestElevenLabsVoice(unittest.TestCase):
                     )
 
 
+    def test_siliconflow_subtitle_spans_full_audio_duration(self):
+        """Last subtitle entry must end at the actual audio end, not truncated early.
+
+        The old ad-hoc loop applied integer division independently to every
+        sentence, so accumulated truncation meant the final subtitle always
+        ended a few units before the real audio end. Every other TTS provider
+        already delegates to populate_legacy_submaker_with_full_text, which
+        anchors the last entry to the full duration; this test verifies
+        siliconflow_tts now does the same.
+        """
+        audio_duration_seconds = 7.3
+        expected_end_100ns = int(audio_duration_seconds * 10_000_000)
+
+        fake_response = SimpleNamespace(status_code=200, content=b"fake-mp3")
+        fake_clip = SimpleNamespace(
+            duration=audio_duration_seconds, close=lambda: None
+        )
+
+        with (
+            tempfile.TemporaryDirectory() as tmp_dir,
+            patch.object(vs.requests, "post", return_value=fake_response),
+            patch.object(vs, "AudioFileClip", return_value=fake_clip),
+            patch.object(vs.config, "siliconflow", {"api_key": "test-key"}),
+        ):
+            voice_file = str(Path(tmp_dir) / "test.mp3")
+            sub_maker = vs.siliconflow_tts(
+                text=(
+                    "First sentence. Second sentence. "
+                    "Third sentence. Fourth sentence."
+                ),
+                model="FunAudioLLM/CosyVoice2-0.5B",
+                voice="FunAudioLLM/CosyVoice2-0.5B:alex",
+                voice_rate=1.0,
+                voice_file=voice_file,
+            )
+
+        self.assertIsNotNone(sub_maker)
+        offsets = getattr(sub_maker, "offset", [])
+        self.assertGreater(
+            len(offsets), 1, "multi-sentence text must produce multiple subtitles"
+        )
+        last_end = offsets[-1][1]
+        self.assertEqual(
+            last_end,
+            expected_end_100ns,
+            f"last subtitle end ({last_end}) must equal the full audio duration "
+            f"({expected_end_100ns} units = {audio_duration_seconds}s)",
+        )
+
+
 if __name__ == "__main__":
     # python -m unittest test.services.test_voice.TestVoiceService.test_azure_tts_v1
     # python -m unittest test.services.test_voice.TestVoiceService.test_azure_tts_v2
-    unittest.main() 
+    unittest.main()


### PR DESCRIPTION
## Problem

`siliconflow_tts` built its subtitle offsets with a hand-rolled loop:

    sentence_duration = int(sentence_chars * char_duration)

Accumulated integer truncation across multiple sentences means the last
subtitle always ends a few 100-nanosecond units before the actual audio
end. Users see a subtitle gap at the tail of every SiliconFlow-narrated
video.

## Fix

Replaced the ad-hoc loop with `populate_legacy_submaker_with_full_text`,
the shared helper that all other providers (`gemini_tts`, `mimo_tts`,
`minimax_tts`) already use. It explicitly anchors the last subtitle entry
to the real `audio_duration_100ns`, eliminating the truncation gap.

Also removed a redundant local `from moviepy import AudioFileClip` import
(already imported at module level) and wrapped `audio_clip.close()` in a
`finally` block so the handle is always released.

## Tests

Added a unit test that mocks the HTTP response and `AudioFileClip`,
calls `siliconflow_tts` with a multi-sentence script, and asserts that
`offsets[-1][1] == int(audio_duration_seconds * 10_000_000)`.