### PR TITLE
fix(tts): ensure AudioFileClip is always closed in ElevenLabs, Chatterbox, and Fish Audio

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1686,8 +1686,10 @@ def elevenlabs_tts(
                 f.write(response.content)
 
             audio_clip = AudioFileClip(voice_file)
-            audio_duration = audio_clip.duration
-            audio_clip.close()
+            try:
+                audio_duration = audio_clip.duration
+            finally:
+                audio_clip.close()
 
             sub_maker = ensure_legacy_submaker_fields(SubMaker())
             logger.success(f"elevenlabs tts succeeded: {voice_file}")
@@ -1773,8 +1775,10 @@ def chatterbox_tts(
                 f.write(response.content)
 
             audio_clip = AudioFileClip(voice_file)
-            audio_duration = audio_clip.duration
-            audio_clip.close()
+            try:
+                audio_duration = audio_clip.duration
+            finally:
+                audio_clip.close()
 
             sub_maker = ensure_legacy_submaker_fields(SubMaker())
             logger.success(f"chatterbox tts succeeded: {voice_file}")
@@ -1915,8 +1919,10 @@ def fish_audio_tts(
                 f.write(response.content)
 
             audio_clip = AudioFileClip(voice_file)
-            audio_duration = audio_clip.duration
-            audio_clip.close()
+            try:
+                audio_duration = audio_clip.duration
+            finally:
+                audio_clip.close()
 
             sub_maker = ensure_legacy_submaker_fields(SubMaker())
             logger.success(f"fish audio tts succeeded: {voice_file}")

--- a/test/services/test_voice.py
+++ b/test/services/test_voice.py
@@ -953,6 +953,109 @@ class TestVoiceService(unittest.TestCase):
         self.assertIsNone(result)
         self.assertEqual(post.call_count, 3)
 
+    def _make_broken_clip_class(self, close_calls: list):
+        """Return a clip class whose .duration raises and whose .close() records calls."""
+
+        class _BrokenClip:
+            @property
+            def duration(self):
+                raise RuntimeError("FFmpeg probe failed")
+
+            def close(self):
+                close_calls.append(True)
+
+        return _BrokenClip
+
+    def test_elevenlabs_tts_audio_clip_closed_on_duration_error(self):
+        """AudioFileClip.close() must be called even when reading .duration raises."""
+        close_calls: list = []
+        BrokenClip = self._make_broken_clip_class(close_calls)
+
+        class _OkResponse:
+            status_code = 200
+            content = b"fake-mp3"
+            text = ""
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+            out = f.name
+        try:
+            with (
+                patch.object(
+                    vs.config,
+                    "elevenlabs",
+                    {"api_key": "test-key", "model_id": "eleven_multilingual_v2"},
+                ),
+                patch.object(vs.requests, "post", return_value=_OkResponse()),
+                patch.object(vs, "AudioFileClip", side_effect=lambda _: BrokenClip()),
+            ):
+                result = vs.elevenlabs_tts("Hello world.", "voice-id", out)
+        finally:
+            if os.path.exists(out):
+                os.remove(out)
+
+        self.assertIsNone(result)
+        self.assertTrue(close_calls, "AudioFileClip.close() was never called")
+
+    def test_chatterbox_tts_audio_clip_closed_on_duration_error(self):
+        """AudioFileClip.close() must be called even when reading .duration raises."""
+        close_calls: list = []
+        BrokenClip = self._make_broken_clip_class(close_calls)
+
+        class _OkResponse:
+            status_code = 200
+            content = b"fake-mp3"
+            text = ""
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+            out = f.name
+        try:
+            with (
+                patch.object(
+                    vs.config,
+                    "chatterbox",
+                    {"base_url": "http://localhost:4123", "api_key": "", "model_id": "chatterbox"},
+                ),
+                patch.object(vs.requests, "post", return_value=_OkResponse()),
+                patch.object(vs, "AudioFileClip", side_effect=lambda _: BrokenClip()),
+            ):
+                result = vs.chatterbox_tts("Hello world.", "default", out)
+        finally:
+            if os.path.exists(out):
+                os.remove(out)
+
+        self.assertIsNone(result)
+        self.assertTrue(close_calls, "AudioFileClip.close() was never called")
+
+    def test_fish_audio_tts_audio_clip_closed_on_duration_error(self):
+        """AudioFileClip.close() must be called even when reading .duration raises."""
+        close_calls: list = []
+        BrokenClip = self._make_broken_clip_class(close_calls)
+
+        class _OkResponse:
+            status_code = 200
+            content = b"x" * 200
+            text = ""
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+            out = f.name
+        try:
+            with (
+                patch.object(
+                    vs.config,
+                    "fish_audio",
+                    {"api_key": "test-key", "model": "s2.1-pro-free"},
+                ),
+                patch.object(vs.requests, "post", return_value=_OkResponse()),
+                patch.object(vs, "AudioFileClip", side_effect=lambda _: BrokenClip()),
+            ):
+                result = vs.fish_audio_tts("Hello world.", out)
+        finally:
+            if os.path.exists(out):
+                os.remove(out)
+
+        self.assertIsNone(result)
+        self.assertTrue(close_calls, "AudioFileClip.close() was never called")
+
     def test_generate_subtitle_keeps_edge_provider_for_gemini_legacy_submaker(self):
         """
         验证 Gemini TTS 返回的 legacy 字幕结构在 edge provider 下可以直接产出


### PR DESCRIPTION
## Summary
- `elevenlabs_tts`, `chatterbox_tts`, and `fish_audio_tts` each open an
  `AudioFileClip` (spawning an FFmpeg subprocess) and call `.close()` in
  plain sequential code, with no `try/finally`.  If anything raises between
  construction and close the subprocess leaks.
- The pre-existing `_write_validated_minimax_audio` already wraps
  `.duration` in `try/finally`; this PR extends that pattern to the three
  remaining providers.

## Changes
- Wrapped `audio_clip.duration` in `try/finally: audio_clip.close()` in
  `elevenlabs_tts`, `chatterbox_tts`, and `fish_audio_tts`
  (`app/services/voice.py`)
- Added three unit tests that mock `.duration` to raise a `RuntimeError`
  and assert `.close()` is still called

## Test plan
- [ ] `test_elevenlabs_tts_audio_clip_closed_on_duration_error` passes
- [ ] `test_chatterbox_tts_audio_clip_closed_on_duration_error` passes
- [ ] `test_fish_audio_tts_audio_clip_closed_on_duration_error` passes
- [ ] Existing ElevenLabs/Chatterbox TTS success tests still pass