### PR TITLE
fix(llm): use non-greedy quantifier when stripping bracket and paren groups from script

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -536,9 +536,11 @@ def generate_script(
         response = response.replace("*", "")
         response = response.replace("#", "")
 
-        # Remove markdown syntax
-        response = re.sub(r"\[.*\]", "", response)
-        response = re.sub(r"\(.*\)", "", response)
+        # Remove markdown syntax.  Use non-greedy .*? so each bracket/paren
+        # group is removed independently; the greedy form would eat all text
+        # between the first opener and the last closer on the same line.
+        response = re.sub(r"\[.*?\]", "", response)
+        response = re.sub(r"\(.*?\)", "", response)
 
         # Split the script into paragraphs
         paragraphs = response.split("\n\n")

--- a/test/services/test_llm.py
+++ b/test/services/test_llm.py
@@ -155,6 +155,41 @@ class TestScriptPromptOptions(unittest.TestCase):
         self.assertIs(captured["app_config"], app_config)
         self.assertEqual(captured["app_config"]["openai_api_key"], "snapshot-key")
 
+    def test_generate_script_strips_each_bracket_group_independently(self):
+        """
+        format_response must remove each [bracket] and (paren) group in
+        isolation.  The greedy form [.*] matches from the first opener to
+        the *last* closer on the line, silently deleting all text in between.
+
+        Example – greedy bug:
+            "[Intro] Great content [end]"  →  "."     (all inner text lost)
+        Expected with non-greedy fix:
+            "[Intro] Great content [end]"  →  " Great content "
+        """
+
+        def fake_generate_response(prompt):
+            # Two bracket groups and two paren groups on the same line.
+            return (
+                "[Scene: Beach] A beautiful day at the [location: ocean].\n\n"
+                "Save (at least) 10% of your income (monthly)."
+            )
+
+        with patch.object(
+            llm, "_generate_response", side_effect=fake_generate_response
+        ):
+            result = llm.generate_script(
+                video_subject="savings tips", language="en-US"
+            )
+
+        # Each bracket / paren group should be gone, but the surrounding words
+        # must survive.
+        self.assertNotIn("[", result)
+        self.assertNotIn("]", result)
+        self.assertNotIn("(", result)
+        self.assertNotIn(")", result)
+        self.assertIn("A beautiful day at the", result)
+        self.assertIn("10% of your income", result)
+
     def test_generate_terms_can_request_script_ordered_keywords(self):
         """
         按文案顺序匹配素材依赖 LLM 返回有序关键词。这里不调用真实模型，


### PR DESCRIPTION
## Summary
- `format_response` in `generate_script` used `re.sub(r"\[.*\]", ...)` and
  `re.sub(r"\(.*\)", ...)`. The greedy `.*` matches from the first opener
  to the **last** closer on the same line, deleting all text in between.
- Examples of silent data loss:
  - `"[Intro] Great content [end]"` → `"."`
  - `"Save (at least) 10% of income (monthly)."` → `"Save ."`
- Replaced `.*` with `.*?` so each bracket/paren group is removed
  independently, leaving surrounding words intact.

## Test plan
- [ ] `test_generate_script_strips_each_bracket_group_independently` passes
- [ ] Existing `test_generate_script_sends_custom_prompt_to_llm` passes