### PR TITLE
fix(material): count actual generated duration in paid generation loops

### DIFF
--- a/app/services/material.py
+++ b/app/services/material.py
@@ -1831,7 +1831,12 @@ def _download_videos_wavespeed_on_demand(
                     f"provider={item.provider}, "
                     f"error={type(source_error).__name__}, detail={source_error}"
                 )
-            total_duration += min(max_clip_duration, item.duration)
+            # 记账必须按实际生成时长累计,不能按 max_clip_duration 封顶:
+            # 模型有最短时长下限,请求时长低于下限时实际生成的素材更长
+            # (例如请求 3s 会生成 4s),而剪辑流程会把整段素材切满、连不足
+            # 一个片段的尾巴也保留,这多出来的时长同样会进入成片。按片段
+            # 时长封顶会少记这部分,导致为已经够用的时长继续下单付费。
+            total_duration += item.duration
             # 用 >= 判断:累计时长恰好等于所需时长时已经够用,再生成会
             # 多付一次费用。内外两处判断必须保持同一语义。
             if total_duration >= audio_duration:
@@ -1943,7 +1948,10 @@ def _download_videos_seedance_on_demand(
                     f"provider=volcengine_seedance, "
                     f"error={type(source_error).__name__}, detail={source_error}"
                 )
-            total_duration += min(clip_duration, item.duration)
+            # 与 WaveSpeed 同理:模型有最短时长下限,请求时长低于下限时实际
+            # 生成的素材更长,而剪辑流程会把整段切满、连尾巴也保留。按
+            # clip_duration 封顶会少记这部分,导致为已经够用的时长继续下单付费。
+            total_duration += item.duration
             if total_duration >= required_duration:
                 break
         if total_duration >= required_duration:

--- a/test/services/test_material.py
+++ b/test/services/test_material.py
@@ -1624,6 +1624,48 @@ class TestWaveSpeedProvider(unittest.TestCase):
         self.assertEqual(generate.call_count, 2)
         self.assertEqual(result, ["/tmp/1.mp4", "/tmp/2.mp4"])
 
+    def test_download_videos_wavespeed_counts_actual_generated_duration(self):
+        """
+        回归:请求片段时长低于模型下限时,实际生成的是更长的素材(请求 3s
+        生成 4s),剪辑流程会把 4s 全部用掉。记账必须按实际生成时长累计,
+        否则会为已经覆盖的时长继续下单付费。
+        """
+        # 模型下限 4s:请求 3s,每段实际生成 4s
+        generated = {
+            f"term-{i}": [
+                self._generated_item(
+                    f"term-{i}", f"https://cdn.example.com/{i}.mp4", duration=4
+                )
+            ]
+            for i in range(1, 5)
+        }
+
+        def fake_generate(search_term, minimum_duration, video_aspect):
+            return generated[search_term]
+
+        with (
+            patch(
+                "app.services.material.generate_videos_wavespeed",
+                side_effect=fake_generate,
+            ) as generate,
+            patch(
+                "app.services.material.save_video",
+                side_effect=lambda video_url, save_dir="": f"/tmp/{video_url.rsplit('/', 1)[-1]}",
+            ),
+        ):
+            result = material.download_videos(
+                task_id="test-wavespeed-actual-duration",
+                search_terms=[f"term-{i}" for i in range(1, 5)],
+                source="wavespeed",
+                audio_duration=8,
+                max_clip_duration=3,
+            )
+
+        # 4s + 4s == 8s 已覆盖;按 max_clip_duration 封顶只会记 3s + 3s,
+        # 从而多下两次单
+        self.assertEqual(generate.call_count, 2)
+        self.assertEqual(result, ["/tmp/1.mp4", "/tmp/2.mp4"])
+
     def test_download_videos_wavespeed_skips_failed_segment_and_continues(self):
         """单个片段生成失败(空结果)时跳过该关键词,继续为后续片段生成。"""
         generated = {

--- a/test/services/test_volcengine_seedance.py
+++ b/test/services/test_volcengine_seedance.py
@@ -557,11 +557,11 @@ class TestVolcEngineSeedanceService(unittest.TestCase):
 
 class TestVolcEngineSeedanceMaterialIntegration(unittest.TestCase):
     @staticmethod
-    def _item(term: str, url: str) -> MaterialInfo:
+    def _item(term: str, url: str, duration: int = 5) -> MaterialInfo:
         return MaterialInfo(
             provider="volcengine_seedance",
             url=url,
-            duration=5,
+            duration=duration,
             source_info={
                 "provider": "volcengine_seedance",
                 "search_term": term,
@@ -598,6 +598,46 @@ class TestVolcEngineSeedanceMaterialIntegration(unittest.TestCase):
         self.assertEqual(generate.call_count, 2)
         self.assertEqual(persist.call_args.args[0], "seedance-materials")
         self.assertEqual(len(persist.call_args.args[1]), 2)
+
+    def test_on_demand_generation_counts_actual_generated_duration(self):
+        """
+        回归:请求片段时长低于模型下限时,实际生成的素材更长(这里每段 5s),
+        剪辑流程会把整段用掉。记账必须按实际生成时长累计,否则会为已经
+        覆盖的时长继续下单付费。
+        """
+        with (
+            patch.object(
+                seedance,
+                "generate_videos",
+                side_effect=[
+                    [self._item("one", "https://cdn.example.com/one.mp4", duration=5)],
+                    [self._item("two", "https://cdn.example.com/two.mp4", duration=5)],
+                    [
+                        self._item(
+                            "three", "https://cdn.example.com/three.mp4", duration=5
+                        )
+                    ],
+                ],
+            ) as generate,
+            patch.object(
+                material,
+                "save_video",
+                side_effect=["/tmp/one.mp4", "/tmp/two.mp4", "/tmp/three.mp4"],
+            ),
+            patch.object(material, "_persist_material_sources"),
+        ):
+            result = material.download_videos(
+                task_id="seedance-actual-duration",
+                search_terms=["one", "two", "three"],
+                source="volcengine_seedance",
+                audio_duration=10,
+                max_clip_duration=3,
+            )
+
+        # 5s + 5s == 10s 已覆盖;按 max_clip_duration 封顶只会记 3s + 3s,
+        # 从而多下一次单
+        self.assertEqual(generate.call_count, 2)
+        self.assertEqual(result, ["/tmp/one.mp4", "/tmp/two.mp4"])
 
     def test_non_positive_audio_duration_avoids_paid_submission(self):
         for audio_duration in (0, -1, -0.1):


### PR DESCRIPTION
## 问题

WaveSpeed 和 Seedance 的按需生成循环用片段时长封顶来累计已覆盖时长：

```python
total_duration += min(max_clip_duration, item.duration)   # material.py:1834 / 1946
```

这两个素材源都会把请求时长向模型下限钳制：

- `WAVESPEED_MIN_DURATION_SECONDS = 4`（`material.py:617`）
- Seedance `DEFAULT_MIN_DURATION_SECONDS = 2`（`volcengine_seedance.py:17`）

所以用户把片段时长设成 3s 时，实际生成并计费的是 4s 素材，`item.duration`
也等于 4。

而 `video.py` 的切片逻辑（`combine_videos`，"保留所有有效分段"）会把整段
素材切满，连不足一个片段的尾巴也不丢弃 —— 这 4s 会全部进入成片。按
`max_clip_duration` 封顶记账因此少记了多出来的时长，循环误判为还没凑够，
继续为后续关键词提交付费生成任务。

生成按条计费，这是实打实的多付费。以 88s 配音、片段时长 3s 为例：

| | 每段记账 | 满足退出条件所需段数 |
|---|---|---|
| 修复前 | 3s | 30 |
| 修复后 | 4s | 22 |

`generate_videos_wavespeed` 里的注释（"生成比请求更长不会影响成片：剪辑
流程仍按片段时长裁剪"）与切片实现不一致 —— 多出的时长不会被裁掉，而是
成为一个尾部分段。

## 改动

两处按需生成循环改为按实际生成时长累计：

```python
total_duration += item.duration
```

## 不受影响的地方

- **`openai_image` 按需生成（`material.py:1511`）**：没有模型下限钳制，
  `item.duration` 恒等于 `max_clip_duration`，`render_image_zoom_video`
  渲染出的片段也正好是这个时长，`min()` 是恒等运算，未改动。
- **库存素材下载路径（`material.py:1762` / `2048`）**：下载免费，少记只
  会多下几段，不涉及付费安全，未改动。

## 测试

新增两处回归测试，均在修复前失败、修复后通过：

- `test_download_videos_wavespeed_counts_actual_generated_duration`
- `test_on_demand_generation_counts_actual_generated_duration`

（`test_volcengine_seedance.py` 的 `_item()` 增加了 `duration` 参数，默认值
保持 5，现有调用方不受影响。）

完整测试套件：`867 passed, 11 skipped`。

---

<details>
<summary>English summary</summary>

The WaveSpeed and Seedance on-demand generation loops credit
`min(max_clip_duration, item.duration)` toward the covered duration. Both
providers clamp the requested clip length up to a model minimum (WaveSpeed 4s,
Seedance 2s), so requesting 3s actually generates — and bills for — a 4s clip.

`combine_videos` in `video.py` splits each source clip into
`max_clip_duration` chunks and explicitly keeps the short tail, so all 4s reach
the final cut. Capping the accounting undercounts real footage, the loop thinks
it is still short, and it submits additional paid generation requests that
aren't needed. For 88s of narration at 3s clips that's 30 generations instead
of 22.

Fix: credit `item.duration`. `openai_image` is unaffected (no minimum-duration
clamp, so `min()` is a no-op there) and the free stock-download paths are left
alone. Two regression tests added, both failing before the change.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5wPrDNwdBi9yg7C7QxWD4
