### PR TITLE
fix(material): 200 响应 body 非图片时跳过关键词而非中断任务

### DIFF
--- a/app/services/material.py
+++ b/app/services/material.py
@@ -1413,7 +1413,17 @@ def generate_images_openai(
         )
         return []
 
-    image_path, width, height = _save_openai_image_file(image_bytes, save_dir)
+    try:
+        image_path, width, height = _save_openai_image_file(image_bytes, save_dir)
+    except Exception as e:
+        # 兼容层可能返回 200 但 body 不是图片（如伪装成 JSON 的 HTML 错误页、
+        # 网关的降级提示页）。图片无法解码属于"该次生成已失败"，按素材源
+        # 约定返回空列表让上层跳过该关键词继续，而不是让异常中断整个任务。
+        logger.error(
+            "openai image response is not a decodable image, skipping term: "
+            f"term={search_term!r}, error={type(e).__name__}, detail={e}"
+        )
+        return []
     item = MaterialInfo()
     item.provider = "openai_image"
     item.url = image_path

--- a/test/services/test_material_openai_image.py
+++ b/test/services/test_material_openai_image.py
@@ -152,6 +152,43 @@ class TestOpenAIImageProvider(unittest.TestCase):
             "https://cdn.example.com/generated/abc.png?sig=1",
         )
 
+    def test_generate_images_openai_skips_b64_json_with_invalid_image(self):
+        """
+        兼容层返回 200 但 body 不是可解码图片（如伪装成 JSON 的 HTML 错误页）
+        时，必须按素材源约定返回空列表让上层跳过该关键词，而不是让解码
+        异常中断整个任务。
+        """
+        fake_content = b"<html><body>gateway degraded</body></html>"
+        response = _image_response(
+            {"data": [{"b64_json": base64.b64encode(fake_content).decode("ascii")}]}
+        )
+
+        with patch("app.services.material.requests.post", return_value=response):
+            results = material.generate_images_openai(
+                "sunrise over mountains", minimum_duration=5, save_dir=self.save_dir
+            )
+
+        self.assertEqual(results, [])
+        self.assertEqual(os.listdir(self.save_dir), [])
+
+    def test_generate_images_openai_skips_url_download_with_invalid_content(self):
+        """临时 URL 下载到 200 的非图片内容时同样走跳过路径。"""
+        response = _image_response(
+            {"data": [{"url": "https://cdn.example.com/generated/abc.png?sig=1"}]}
+        )
+        download = _download_response(b"\x89PNG\r\n\x1a\nnot-really-a-png")
+
+        with (
+            patch("app.services.material.requests.post", return_value=response),
+            patch("app.services.material.requests.get", return_value=download),
+        ):
+            results = material.generate_images_openai(
+                "city at night", minimum_duration=3, save_dir=self.save_dir
+            )
+
+        self.assertEqual(results, [])
+        self.assertEqual(os.listdir(self.save_dir), [])
+
     # ------------------------------------------------------------------
     # 退避重试与 key 轮换
     # ------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1295

## 问题

个别兼容层/网关故障降级时会返回 200 但 body 不是可解码图片（伪装成 JSON 的 HTML 错误页，或临时 URL 下载到 200 的非图片内容）。此时 Image.open 抛出的 UnidentifiedImageError 会穿透 generate_images_openai 中断整个视频生成任务，而不是按素材源既有的降级约定跳过该关键词继续。

## 修复

在 generate_images_openai 的落盘点捕获解码失败：记错误日志并返回空列表，上层按需生成循环走与其他单张失败完全一致的跳过路径。

改动 2 个文件，+48/−1：
- app/services/material.py：落盘点 try/except 守卫（+11）
- test/services/test_material_openai_image.py：新增 2 个用例覆盖 b64_json / URL 下载两条伪装内容路径（+37）

## 测试

- 单测：25/25 通过（原 23 + 新增 2）
- 全量：866 passed, 11 skipped, 7863 subtests（唯一失败 test_webui_headless_task_actions 为本地 Windows 环境预存问题，未改动分支同样失败）
- ruff check 通过

这是 #1291 合并时我在 PR 描述中主动披露的遗留边界，现按计划补上闭环。