### PR TITLE
Add Telemarketing MVP scaffold: backend, frontend, Docker, roles, CSV export

### DIFF
--- a/TELEMARKETING-MVP-README.md
+++ b/TELEMARKETING-MVP-README.md
@@ -1,0 +1,104 @@
+Plataforma Telemarketing — MVP
+
+Resumen
+- Stack recomendado: Node.js (Express) + React (frontend).
+- Canales prioritarios: WhatsApp y Redes sociales (Instagram/Facebook/LinkedIn).
+- Objetivo: herramienta para prospectar, contactar, presentar oferta, gestionar objeciones y cerrar ventas; con CRM básico y panel de ventas.
+
+MVP — Funcionalidades clave
+1. Prospección automatizada (importar listas, búsquedas básicas, guardar leads).
+2. Contacto y mensajería: integración WhatsApp Business API (o Twilio) + plantillas para redes.
+3. CRM: contactos, etiquetas, pipeline (etapas: Prospecto, Contactado, Interesado, Negociación, Cerrado).
+4. Conversaciones: historial, asignación de agente, notas.
+5. Panel de ventas: métricas básicas y export CSV.
+6. Gestión de usuarios y roles (admin/agente).
+
+Descargar el proyecto (pasos rápidos)
+1. Clonar el repositorio:
+   git clone https://github.com/harry0703/MoneyPrinterTurbo.git
+   cd MoneyPrinterTurbo
+   git checkout reduno3-plataforma-telemarketing
+
+2. Recomendado: usar Node 18+. Instalar dependencias (backend y frontend cuando existan):
+   # Backend (en /server o raíz si corresponde)
+   npm install
+
+   # Frontend (en /client)
+   cd client
+   npm install
+
+Entorno y variables (.env)
+- Crear un archivo .env en backend con al menos:
+  PORT=3000
+  NODE_ENV=development
+  DATABASE_URL=postgres://user:pass@localhost:5432/telemarketing_db     # o cadena MySQL
+  JWT_SECRET=tu_secreto
+  WHATSAPP_API_URL=...
+  WHATSAPP_API_TOKEN=...
+
+Bases de datos — opciones
+A) PostgreSQL (ejemplo rápido)
+- Crear base y usuario:
+  sudo -u postgres psql
+  CREATE USER teleuser WITH ENCRYPTED PASSWORD 'telepass';
+  CREATE DATABASE telemarketing_db OWNER teleuser;
+  \q
+
+- En .env usar: DATABASE_URL=postgres://teleuser:telepass@localhost:5432/telemarketing_db
+
+B) MySQL (ejemplo rápido)
+- Crear base y usuario:
+  mysql -u root -p
+  CREATE DATABASE telemarketing_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+  CREATE USER 'teleuser'@'localhost' IDENTIFIED BY 'telepass';
+  GRANT ALL PRIVILEGES ON telemarketing_db.* TO 'teleuser'@'localhost';
+  FLUSH PRIVILEGES;
+  EXIT;
+
+- En .env usar: DATABASE_URL=mysql://teleuser:telepass@localhost:3306/telemarketing_db
+
+Docker (opcional) — docker-compose (recomendado)
+- Se ha creado un archivo de compose específico para el scaffold: docker-compose.telemarketing.yml
+- Uso recomendado (desde la raíz del repo):
+  docker compose -f docker-compose.telemarketing.yml up --build -d
+
+Este compose levanta 3 servicios:
+- telemarketing_db: Postgres (puerto 5432)
+- telemarketing_app: backend Express (puerto 4000)
+- telemarketing_client: frontend Vite (puerto 5173)
+
+Ejecutar migraciones Prisma después de levantar los servicios:
+  docker compose -f docker-compose.telemarketing.yml exec -T telemarketing_app npx prisma migrate deploy
+
+Si prefieres usar los archivos compose del proyecto original, no los sobreescribe; este archivo nuevo es independiente y específico para el MVP.
+
+Migraciones y ORM
+- Elegir ORM (Sequelize, TypeORM, Prisma). Para novatos Prisma o Sequelize son buenas opciones.
+- Comandos típicos (ejemplo Prisma):
+  npx prisma migrate dev --name init
+
+Arrancar la aplicación (desarrollo)
+- Backend:
+  npm run dev          # o npm start según scaffold
+- Frontend (client):
+  cd client
+  npm run start
+
+Despliegue en servidor personalizado
+1. Subir código al servidor (git pull o rsync).
+2. Instalar Node.js y dependencias.
+3. Configurar la base de datos (MySQL o Postgres) en el servidor.
+4. Ejecutar migraciones.
+5. Configurar un proceso PM2 o systemd para mantener la app en producción.
+6. (Opcional) Usar Nginx como proxy inverso y SSL (Let's Encrypt).
+
+Siguientes pasos (implementación que voy a crear ahora si confirmas)
+- Scaffold minimal: backend Express con endpoints para leads, contactos, pipeline, auth JWT.
+- Frontend React con panel básico para crear/editar leads y ver pipeline.
+- Integración inicial con WhatsApp vía Twilio (mock si no hay credenciales).
+- Docker Compose para la app + DB, y scripts de inicialización.
+
+Si confirmas, comienzo creando la estructura inicial del backend y README de instalación detallada. Para crear archivos en el repo ya se renombró la rama a: reduno3-plataforma-telemarketing
+
+Contacto
+Si necesitas que use PostgreSQL o MySQL por defecto en el scaffold indícalo; por defecto usaré PostgreSQL pero dejaré instrucciones para MySQL.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,10 @@
+# Copy to .env and fill values
+PORT=4000
+DATABASE_URL=postgresql://teleuser:telepass@db:5432/telemarketing_db?schema=public
+JWT_SECRET=change-me
+ADMIN_SECRET=
+# Optional: create an initial admin user automatically on startup if ADMIN_INITIAL_EMAIL and ADMIN_INITIAL_PASSWORD are set
+ADMIN_INITIAL_EMAIL=
+ADMIN_INITIAL_PASSWORD=
+WHATSAPP_API_URL=
+WHATSAPP_API_TOKEN=

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.env
+/dev.db
+/prisma/dev.db
+
+**/.env
+**/node_modules

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /usr/src/app
+COPY package.json package-lock.json* ./
+RUN npm install --production
+COPY . .
+RUN npx prisma generate || true
+EXPOSE 4000
+CMD ["node", "src/index.js"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,11 @@
+Backend (Express + Prisma)
+
+Quick start:
+1. Copy backend/.env.example to backend/.env and fill values.
+2. From repo root run: docker-compose up --build
+3. Generate Prisma client (inside container or locally): npx prisma generate
+4. Run migrations (example): npx prisma migrate dev --name init
+
+Notes:
+- Database default in docker-compose is Postgres. To use MySQL, change prisma schema provider and DATABASE_URL accordingly.
+- Integrations: WhatsApp endpoint is a mock; replace with Twilio or WhatsApp Business API in src/index.js /send/whatsapp.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "telemarketing-backend",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "prisma": "^5.12.0",
+    "@prisma/client": "^5.12.0",
+    "jsonwebtoken": "^9.0.0",
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.22"
+  }
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,33 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int     @id @default(autoincrement())
+  email     String  @unique
+  password  String
+  name      String?
+  role      String  @default("agent")
+  createdAt DateTime @default(now())
+}
+
+model Lead {
+  id          Int      @id @default(autoincrement())
+  name        String
+  business    String?
+  phone       String?
+  whatsapp    String?  
+  email       String?
+  source      String?  
+  stage       String   @default("Prospecto")
+  notes       String?
+  ownerId     Int?
+  owner       User?    @relation(fields: [ownerId], references: [id])
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,0 +1,209 @@
+const express = require('express');
+const cors = require('cors');
+const { PrismaClient } = require('@prisma/client');
+const bodyParser = require('express').json;
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+
+require('dotenv').config();
+const prisma = new PrismaClient();
+const app = express();
+app.use(cors());
+app.use(bodyParser());
+
+const PORT = process.env.PORT || 4000;
+const JWT_SECRET = process.env.JWT_SECRET || 'change-me';
+const ADMIN_SECRET = process.env.ADMIN_SECRET || ''; // optional secret to create admin users during registration
+
+// Health
+app.get('/health', (req, res) => res.json({ ok: true }));
+
+// Create initial admin if requested via env variables
+async function ensureInitialAdmin() {
+  const email = process.env.ADMIN_INITIAL_EMAIL;
+  const pwd = process.env.ADMIN_INITIAL_PASSWORD;
+  if (!email || !pwd) {
+    console.log('ADMIN_INITIAL_EMAIL or ADMIN_INITIAL_PASSWORD not set; skipping initial admin creation.');
+    return;
+  }
+  try {
+    const count = await prisma.user.count({ where: { role: 'admin' } });
+    if (count === 0) {
+      const hashed = await bcrypt.hash(pwd, 10);
+      const user = await prisma.user.create({ data: { email, password: hashed, name: 'Administrator', role: 'admin' } });
+      console.log(`Created initial admin user: ${user.email} (change password after first login)`);
+    } else {
+      console.log('Admin user already exists; skipping initial admin creation.');
+    }
+  } catch (e) {
+    console.error('Error while creating initial admin:', e.message || e);
+  }
+}
+
+// Simple auth: register/login
+app.post('/auth/register', async (req, res) => {
+  const { email, password, name, adminSecret } = req.body;
+  if (!email || !password) return res.status(400).json({ error: 'email/password required' });
+  const hashed = await bcrypt.hash(password, 10);
+  const role = (ADMIN_SECRET && adminSecret === ADMIN_SECRET) ? 'admin' : 'agent';
+  try {
+    const user = await prisma.user.create({ data: { email, password: hashed, name, role } });
+    res.json({ id: user.id, email: user.email, role: user.role });
+  } catch (e) {
+    res.status(400).json({ error: 'user exists or invalid' });
+  }
+});
+
+app.post('/auth/login', async (req, res) => {
+  const { email, password } = req.body;
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) return res.status(401).json({ error: 'invalid' });
+  const ok = await bcrypt.compare(password, user.password);
+  if (!ok) return res.status(401).json({ error: 'invalid' });
+  const token = jwt.sign({ sub: user.id, role: user.role }, JWT_SECRET, { expiresIn: '8h' });
+  res.json({ token });
+});
+
+// Middleware
+function auth(req, res, next) {
+  const h = req.headers.authorization;
+  if (!h) return res.status(401).json({ error: 'no auth' });
+  const token = h.replace('Bearer ', '');
+  try {
+    const payload = jwt.verify(token, JWT_SECRET);
+    req.user = payload;
+    next();
+  } catch (e) { res.status(401).json({ error: 'invalid token' }); }
+}
+
+function requireRole(role) {
+  return (req, res, next) => {
+    if (!req.user) return res.status(401).json({ error: 'no auth' });
+    if (req.user.role !== role) return res.status(403).json({ error: 'forbidden' });
+    next();
+  };
+}
+
+// Me endpoint
+app.get('/me', auth, async (req, res) => {
+  const user = await prisma.user.findUnique({ where: { id: req.user.sub } });
+  if (!user) return res.status(404).json({ error: 'not found' });
+  res.json({ id: user.id, email: user.email, name: user.name, role: user.role });
+});
+
+// Users management (admin)
+app.get('/users', auth, requireRole('admin'), async (req, res) => {
+  const users = await prisma.user.findMany({ select: { id: true, email: true, name: true, role: true, createdAt: true } });
+  res.json(users);
+});
+
+app.put('/users/:id/role', auth, requireRole('admin'), async (req, res) => {
+  const id = parseInt(req.params.id);
+  const { role } = req.body;
+  if (!['admin', 'agent'].includes(role)) return res.status(400).json({ error: 'invalid role' });
+  const user = await prisma.user.update({ where: { id }, data: { role } });
+  res.json({ id: user.id, role: user.role });
+});
+
+// Leads routes
+app.get('/leads', auth, async (req, res) => {
+  const leads = await prisma.lead.findMany({ include: { owner: true } });
+  res.json(leads);
+});
+
+app.post('/leads', auth, async (req, res) => {
+  const data = req.body;
+  const lead = await prisma.lead.create({ data: { ...data, ownerId: req.user.sub } });
+  res.json(lead);
+});
+
+app.get('/leads/:id', auth, async (req, res) => {
+  const id = parseInt(req.params.id);
+  const lead = await prisma.lead.findUnique({ where: { id } });
+  res.json(lead);
+});
+
+app.put('/leads/:id', auth, async (req, res) => {
+  const id = parseInt(req.params.id);
+  const lead = await prisma.lead.update({ where: { id }, data: req.body });
+  res.json(lead);
+});
+
+// Delete protected to admin
+app.delete('/leads/:id', auth, requireRole('admin'), async (req, res) => {
+  const id = parseInt(req.params.id);
+  await prisma.lead.delete({ where: { id } });
+  res.json({ ok: true });
+});
+
+// Export leads to CSV (admin only)
+app.get('/leads/export', auth, requireRole('admin'), async (req, res) => {
+  const leads = await prisma.lead.findMany({ include: { owner: true } });
+  const header = ['id','name','business','phone','whatsapp','email','source','stage','notes','owner_email','createdAt','updatedAt'];
+  const rows = leads.map(l => [
+    l.id,
+    escapeCsv(l.name),
+    escapeCsv(l.business || ''),
+    escapeCsv(l.phone || ''),
+    escapeCsv(l.whatsapp || ''),
+    escapeCsv(l.email || ''),
+    escapeCsv(l.source || ''),
+    escapeCsv(l.stage || ''),
+    escapeCsv(l.notes || ''),
+    l.owner ? l.owner.email : '',
+    l.createdAt.toISOString(),
+    l.updatedAt.toISOString()
+  ]);
+  const csv = [header.join(','), ...rows.map(r => r.join(','))].join('\n');
+  res.setHeader('Content-Type', 'text/csv');
+  res.setHeader('Content-Disposition', 'attachment; filename="leads.csv"');
+  res.send(csv);
+});
+
+function escapeCsv(v) {
+  if (v == null) return '';
+  const s = String(v);
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}
+
+// Change password (own account)
+app.put('/auth/password', auth, async (req, res) => {
+  const { currentPassword, newPassword } = req.body;
+  if (!currentPassword || !newPassword) return res.status(400).json({ error: 'currentPassword and newPassword required' });
+  const user = await prisma.user.findUnique({ where: { id: req.user.sub } });
+  if (!user) return res.status(404).json({ error: 'user not found' });
+  const ok = await bcrypt.compare(currentPassword, user.password);
+  if (!ok) return res.status(401).json({ error: 'invalid current password' });
+  const hashed = await bcrypt.hash(newPassword, 10);
+  await prisma.user.update({ where: { id: user.id }, data: { password: hashed } });
+  res.json({ ok: true });
+});
+
+// Admin: change another user's password without current password
+app.put('/users/:id/password', auth, requireRole('admin'), async (req, res) => {
+  const id = parseInt(req.params.id);
+  const { newPassword } = req.body;
+  if (!newPassword) return res.status(400).json({ error: 'newPassword required' });
+  const hashed = await bcrypt.hash(newPassword, 10);
+  await prisma.user.update({ where: { id }, data: { password: hashed } });
+  res.json({ ok: true });
+});
+
+// WhatsApp send mock endpoint (integrate Twilio/WhatsApp Business API later)
+app.post('/send/whatsapp', auth, async (req, res) => {
+  const { to, message } = req.body;
+  // For now just log and return success; replace with real provider call.
+  console.log('WhatsApp send', to, message);
+  res.json({ ok: true, provider: 'mock' });
+});
+
+// Start server after optional initialization
+(async () => {
+  await ensureInitialAdmin();
+  app.listen(PORT, () => {
+    console.log(`Server listening http://localhost:${PORT}`);
+  });
+})();

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env to override frontend API base
+VITE_API_BASE=http://localhost:4000

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /usr/src/app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev"]

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,18 @@
+Telemarketing client (React + Vite)
+
+Run (from repo root):
+cd client
+npm install
+npm run dev
+
+Notes:
+- The client expects backend at http://localhost:4000. Change VITE_API_BASE env var to point elsewhere.
+- Use the UI to register/login, add leads and click 'Enviar WhatsApp' (mock). Replace backend /send/whatsapp with Twilio/WhatsApp provider later.
+
+Admin user creation via UI:
+- Set ADMIN_SECRET in backend/.env (e.g., ADMIN_SECRET=mi_clave_segura).
+- In the client registration form, fill the field "Admin secret (opcional, para crear admin)" with the same value to create an admin account.
+- If ADMIN_SECRET is empty or incorrect, newly registered accounts will have role 'agent' by default.
+
+CLI alternative to create admin:
+- curl -X POST http://localhost:4000/auth/register -H "Content-Type: application/json" -d '{"email":"admin@local","password":"secret","name":"Admin","adminSecret":"mi_clave_segura"}'

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Telemarketing MVP</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "telemarketing-client",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.5.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,122 @@
+import React, { useState, useEffect } from 'react'
+import api from './api2'
+
+export default function App() {
+  const [token, setToken] = useState(localStorage.getItem('token') || '')
+  const [me, setMe] = useState(null)
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [leads, setLeads] = useState([])
+  const [name, setName] = useState('')
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [changing, setChanging] = useState(false)
+
+  useEffect(() => { if (token) { fetchMe(); fetchLeads() } }, [token])
+
+  const [adminSecret, setAdminSecret] = useState('')
+
+  async function register() {
+    await api.register({ email, password, name, adminSecret })
+    alert('Registro creado — ahora inicia sesión')
+  }
+
+  async function login() {
+    const res = await api.login({ email, password })
+    if (res.token) { localStorage.setItem('token', res.token); setToken(res.token); }
+  }
+
+  async function fetchMe() {
+    try {
+      const info = await api.getMe(token)
+      setMe(info)
+    } catch (e) { setMe(null) }
+  }
+
+  async function fetchLeads() {
+    const res = await api.getLeads(token)
+    setLeads(res || [])
+  }
+
+  async function addLead() {
+    await api.createLead(token, { name, source: 'web' })
+    setName('')
+    fetchLeads()
+  }
+
+  async function sendWA(lead) {
+    await api.sendWhatsApp(token, { to: lead.whatsapp || lead.phone, message: `Hola ${lead.name}, te contacto sobre nuestras páginas web profesionales.` })
+    alert('Mensaje enviado (mock)')
+  }
+
+  async function exportCSV() {
+    try {
+      const blob = await api.exportLeads(token)
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'leads.csv'
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      window.URL.revokeObjectURL(url)
+    } catch (e) { alert('Error exporting CSV') }
+  }
+
+  async function changePassword() {
+    if (!currentPassword || !newPassword) { alert('Rellena ambos campos'); return }
+    setChanging(true)
+    try {
+      await api.changePassword(token, { currentPassword, newPassword })
+      alert('Contraseña cambiada')
+      setCurrentPassword('')
+      setNewPassword('')
+    } catch (e) {
+      alert('Error cambiando contraseña')
+    } finally { setChanging(false) }
+  }
+
+  if (!token) return (
+    <div style={{ padding: 20 }}>
+      <h2>Telemarketing MVP — Login / Register</h2>
+      <input placeholder="Nombre" value={name} onChange={e => setName(e.target.value)} />
+      <input placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+      <input placeholder="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
+      <input placeholder="Admin secret (opcional, para crear admin)" value={adminSecret} onChange={e => setAdminSecret(e.target.value)} />
+      <div style={{ marginTop: 10 }}>
+        <button onClick={register}>Registrar</button>
+        <button onClick={login}>Iniciar sesión</button>
+      </div>
+    </div>
+  )
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Pipeline — Leads</h2>
+      <div>
+        <input placeholder="Nuevo lead (nombre)" value={name} onChange={e => setName(e.target.value)} />
+        <button onClick={addLead}>Agregar</button>
+        <button onClick={() => { localStorage.removeItem('token'); setToken(''); setLeads([]); setMe(null) }}>Cerrar sesión</button>
+        {me && me.role === 'admin' && (
+          <button onClick={exportCSV} style={{ marginLeft: 8 }}>Exportar CSV (admin)</button>
+        )}
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <h4>Cambiar contraseña</h4>
+        <input placeholder="Contraseña actual" type="password" value={currentPassword} onChange={e => setCurrentPassword(e.target.value)} />
+        <input placeholder="Nueva contraseña" type="password" value={newPassword} onChange={e => setNewPassword(e.target.value)} />
+        <button onClick={changePassword} disabled={changing}>{changing ? 'Cambiando...' : 'Cambiar contraseña'}</button>
+      </div>
+
+      <ul>
+        {leads.map(l => (
+          <li key={l.id} style={{ margin: '8px 0' }}>
+            <strong>{l.name}</strong> — {l.stage}
+            <button onClick={() => sendWA(l)} style={{ marginLeft: 8 }}>Enviar WhatsApp</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,0 +1,11 @@
+import axios from 'axios'
+
+const BASE = process.env.VITE_API_BASE || 'http://localhost:4000'
+
+export default {
+  register: async (data) => { const r = await axios.post(`${BASE}/auth/register`, data); return r.data },
+  login: async (data) => { const r = await axios.post(`${BASE}/auth/login`, data); return r.data },
+  getLeads: async (token) => { const r = await axios.get(`${BASE}/leads`, { headers: { Authorization: `Bearer ${token}` } }); return r.data },
+  createLead: async (token, data) => { const r = await axios.post(`${BASE}/leads`, data, { headers: { Authorization: `Bearer ${token}` } }); return r.data },
+  sendWhatsApp: async (token, data) => { const r = await axios.post(`${BASE}/send/whatsapp`, data, { headers: { Authorization: `Bearer ${token}` } }); return r.data }
+}

--- a/client/src/api2.js
+++ b/client/src/api2.js
@@ -1,0 +1,15 @@
+import axios from 'axios'
+
+const BASE = process.env.VITE_API_BASE || 'http://localhost:4000'
+
+export default {
+  register: async (data) => { const r = await axios.post(`${BASE}/auth/register`, data); return r.data },
+  login: async (data) => { const r = await axios.post(`${BASE}/auth/login`, data); return r.data },
+  getMe: async (token) => { const r = await axios.get(`${BASE}/me`, { headers: { Authorization: `Bearer ${token}` } }); return r.data },
+  getLeads: async (token) => { const r = await axios.get(`${BASE}/leads`, { headers: { Authorization: `Bearer ${token}` } }); return r.data },
+  createLead: async (token, data) => { const r = await axios.post(`${BASE}/leads`, data, { headers: { Authorization: `Bearer ${token}` } }); return r.data },
+  sendWhatsApp: async (token, data) => { const r = await axios.post(`${BASE}/send/whatsapp`, data, { headers: { Authorization: `Bearer ${token}` } }); return r.data },
+  exportLeads: async (token) => { const r = await axios.get(`${BASE}/leads/export`, { headers: { Authorization: `Bearer ${token}` }, responseType: 'blob' }); return r.data },
+  changePassword: async (token, data) => { const r = await axios.put(`${BASE}/auth/password`, data, { headers: { Authorization: `Bearer ${token}` } }); return r.data },
+  adminChangePassword: async (token, id, data) => { const r = await axios.put(`${BASE}/users/${id}/password`, data, { headers: { Authorization: `Bearer ${token}` } }); return r.data }
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import './styles.css'
+
+createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,0 +1,3 @@
+body { font-family: Arial, sans-serif }
+input { margin: 6px; padding: 6px }
+button { margin: 6px }

--- a/docker-compose.telemarketing.yml
+++ b/docker-compose.telemarketing.yml
@@ -1,0 +1,45 @@
+version: '3.8'
+services:
+  telemarketing_app:
+    build: ./backend
+    container_name: telemarketing_app
+    restart: unless-stopped
+    env_file:
+      - ./backend/.env.example
+    ports:
+      - "4000:4000"
+    depends_on:
+      - telemarketing_db
+
+  telemarketing_client:
+    build:
+      context: ./client
+      dockerfile: Dockerfile
+    container_name: telemarketing_client
+    restart: unless-stopped
+    ports:
+      - "5173:5173"
+    env_file:
+      - ./client/.env
+    depends_on:
+      - telemarketing_app
+
+  telemarketing_db:
+    image: postgres:15
+    container_name: telemarketing_db
+    environment:
+      POSTGRES_USER: teleuser
+      POSTGRES_PASSWORD: telepass
+      POSTGRES_DB: telemarketing_db
+    volumes:
+      - telemarketing_pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+volumes:
+  telemarketing_pgdata:
+
+# Usage:
+# docker compose -f docker-compose.telemarketing.yml up --build -d
+# Then run migrations inside the app container:
+# docker compose -f docker-compose.telemarketing.yml exec -T telemarketing_app npx prisma migrate deploy


### PR DESCRIPTION
This PR adds an initial MVP scaffold for a telemarketing platform.

Key changes:
- Backend: Express + Prisma, user auth (JWT), roles (admin/agent), CSV export for leads, password change endpoints, initial-admin creation via env.
- Frontend: React + Vite app with register/login, lead creation, WhatsApp send (mock), admin CSV export, change password UI.
- Docker compose: docker-compose.telemarketing.yml to run app + client + Postgres for development.
- Docs: TELEMARKETING-MVP-README.md and README updates with setup and admin instructions.

Notes:
- The PR contains environment examples and instructions for creating an initial admin (ADMIN_INITIAL_EMAIL/ADMIN_INITIAL_PASSWORD).
- WhatsApp integration is a mock endpoint; replace with Twilio/WhatsApp Business API when credentials are available.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>