### PR TITLE
feat: scene-based video generation — core backend

### DIFF
--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -70,6 +70,59 @@ class MaterialInfo:
     source_info: Optional[dict[str, Any]] = None
 
 
+class SceneConfig(BaseModel):
+    """Description of a single scene within a video.
+
+    Each scene can have its own script text, search keywords, materials,
+    duration, and transition to the next scene. When scenes are defined,
+    the video pipeline processes each scene independently before combining
+    them into the final output.
+    """
+
+    scene_id: int = Field(
+        default=0,
+        ge=0,
+        description="Scene number (1-based). Auto-assigned if 0.",
+    )
+    script: str = Field(
+        default="",
+        max_length=8000,
+        description="Scene narration text. If empty, uses the full video_script.",
+    )
+    search_terms: Optional[List[str]] = Field(
+        default=None,
+        description="Keywords for material search. If empty, LLM generates from script.",
+    )
+    materials: Optional[List[MaterialInfo]] = Field(
+        default=None,
+        description="Local materials for this scene. Overrides search_terms.",
+    )
+    duration: Optional[float] = Field(
+        default=None,
+        ge=0.5,
+        description=(
+            "Target scene duration in seconds. Currently accepted but not yet used "
+            "to trim or extend the scene — the actual duration is determined by the "
+            "TTS audio length. Reserved for future use."
+        ),
+    )
+    transition: Optional[VideoTransitionMode] = Field(
+        default=None,
+        description=(
+            "Transition applied to the FIRST clip of this scene. "
+            "Used at the boundary between this scene and the previous one. "
+            "Not applied to the first scene (there is no previous scene to transition from)."
+        ),
+    )
+    clip_transition: Optional[VideoTransitionMode] = Field(
+        default=None,
+        description=(
+            "Transition applied between clips WITHIN this scene. "
+            "Independent from the between-scene transition."
+        ),
+    )
+
+
 class VideoParams(BaseModel):
     """
     {
@@ -135,6 +188,31 @@ class VideoParams(BaseModel):
     paragraph_number: int = Field(default=1, ge=1, le=10)
     video_script_prompt: str = Field(default="", max_length=2000)
     custom_system_prompt: str = Field(default="", max_length=8000)
+
+    # Scene-based video generation. When set, the pipeline processes each
+    # scene independently (its own script, keywords, materials, audio,
+    # subtitles) before combining them into the final video. If None or
+    # empty, the standard single-script pipeline is used.
+    scenes: Optional[List[SceneConfig]] = None
+
+    # Default transition applied between scenes at scene boundaries.
+    # Can be overridden per-scene via SceneConfig.transition.
+    scene_transition: Optional[VideoTransitionMode] = Field(
+        default=None,
+        description=(
+            "Default transition between scenes. Per-scene transition "
+            "in SceneConfig.transition takes precedence."
+        ),
+    )
+    # Default transition applied between clips WITHIN each scene.
+    # Can be overridden per-scene via SceneConfig.clip_transition.
+    clip_transition: Optional[VideoTransitionMode] = Field(
+        default=None,
+        description=(
+            "Default transition between clips within a scene. Per-scene "
+            "clip_transition in SceneConfig takes precedence."
+        ),
+    )
 
 
 class SubtitleRequest(BaseModel):

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -705,6 +705,304 @@ Please note that you must use English for generating video search terms; Chinese
 
 
 # =============================================================================
+# Scene-based generation
+#
+# Generate scripts and keywords for multiple scenes in a single LLM call.
+# Each scene gets its own narration text and search terms. The LLM returns
+# structured JSON so the WebUI can distribute results into per-scene blocks.
+# =============================================================================
+
+MIN_SCENE_COUNT = 2
+MAX_SCENE_COUNT = 10
+MAX_SCENE_SCRIPT_LENGTH = 4000
+MAX_SCENE_TERMS_PER_SCENE = 5
+
+
+DEFAULT_SCENE_SCRIPT_SYSTEM_PROMPT = """
+# Role: Multi-Scene Video Script Generator
+
+## Goals:
+Generate a script for a video divided into {scene_count} distinct scenes, depending
+on the subject of the video.
+
+## Constrains:
+1. each scene must be a self-contained narration segment that can stand on its own.
+2. the scenes must follow a logical narrative progression (introduction → body → conclusion).
+3. do not under any circumstance reference this prompt in your response.
+4. get straight to the point, don't start with unnecessary things like "welcome to this video".
+5. you must not include any type of markdown or formatting in the script, never use a title.
+6. do not include "voiceover", "narrator" or similar indicators at the beginning of each scene.
+7. you must not mention the prompt, or anything about the script itself.
+8. respond in the same language as the video subject.
+9. you MUST return exactly {scene_count} scenes in the JSON array.
+
+## Output Format:
+You MUST return a valid JSON object matching this exact structure:
+{{
+  "scenes": [
+    {{"scene_id": 1, "script": "narration text for scene 1"}},
+    {{"scene_id": 2, "script": "narration text for scene 2"}}
+  ]
+}}
+
+Return ONLY the JSON object. No other text, no code fences, no explanation.
+""".strip()
+
+
+DEFAULT_SCENE_KEYWORD_SYSTEM_PROMPT = """
+# Role: Multi-Scene Video Search Terms Generator
+
+## Goals:
+Generate stock-video search terms for each scene of a video. The video has
+{scene_count} scenes.
+
+## Constrains:
+1. return search terms as a JSON object matching the structure below exactly.
+2. each scene should have {terms_per_scene} search terms (1-3 words each, in English).
+3. search terms must be visually descriptive — they describe what should appear on screen.
+4. respond in English for the search terms regardless of the script language.
+5. you MUST return exactly {scene_count} scenes in the JSON array.
+6. return ONLY the JSON object. No other text, no code fences.
+
+## Output Format:
+{{
+  "scenes": [
+    {{"scene_id": 1, "terms": ["search term 1", "search term 2"]}},
+    {{"scene_id": 2, "terms": ["search term 3", "search term 4"]}}
+  ]
+}}
+""".strip()
+
+
+def _normalize_scene_count(scene_count: int | None) -> int:
+    """Clamp scene count to the supported range."""
+    if not scene_count:
+        return 2
+    return max(MIN_SCENE_COUNT, min(int(scene_count), MAX_SCENE_COUNT))
+
+
+def generate_scene_scripts(
+    video_subject: str,
+    scene_count: int = 2,
+    language: str = "",
+    video_script_prompt: str = "",
+    custom_system_prompt: str = "",
+    app_config=None,
+) -> list[dict]:
+    """Generate narration scripts for multiple scenes in a single LLM call.
+
+    Returns a list of dicts: [{"scene_id": 1, "script": "..."}, ...].
+    On failure returns an empty list.
+    """
+    scene_count = _normalize_scene_count(scene_count)
+    video_script_prompt = _limit_script_text(
+        video_script_prompt, MAX_SCRIPT_PROMPT_LENGTH, "video_script_prompt"
+    )
+    custom_system_prompt = _limit_script_text(
+        custom_system_prompt, MAX_SCENE_SCRIPT_LENGTH, "custom_system_prompt"
+    )
+
+    prompt = custom_system_prompt or DEFAULT_SCENE_SCRIPT_SYSTEM_PROMPT.format(
+        scene_count=scene_count,
+    )
+    prompt += f"""
+
+# Initialization:
+- video subject: {video_subject}
+- number of scenes: {scene_count}
+""".rstrip()
+    if language:
+        prompt += f"\n- language: {language}"
+    if video_script_prompt:
+        prompt += f"""
+
+# Additional User Requirements:
+{video_script_prompt}
+""".rstrip()
+
+    logger.info(
+        "generating scene scripts: "
+        f"subject={video_subject}, scene_count={scene_count}"
+    )
+
+    response = ""
+    for i in range(_max_retries):
+        try:
+            if app_config is None:
+                response = _generate_response(prompt=prompt)
+            else:
+                response = _generate_response(prompt=prompt, app_config=app_config)
+
+            if not response:
+                logger.error("LLM returned empty response for scene scripts")
+                continue
+
+            if response.startswith("Error: "):
+                logger.error(f"failed to generate scene scripts: {response}")
+                return []
+
+            raw = _strip_code_fence(response)
+            data = json.loads(raw)
+            scenes = data.get("scenes", [])
+            if not isinstance(scenes, list) or len(scenes) == 0:
+                logger.warning("response.scenes is not a non-empty list")
+                continue
+
+            result = []
+            for scene in scenes:
+                sid = scene.get("scene_id", 0)
+                script = scene.get("script", "").strip()
+                if script:
+                    result.append({"scene_id": sid, "script": script})
+
+            if result:
+                logger.success(
+                    f"generated {len(result)} scene scripts (requested {scene_count})"
+                )
+                return result
+        except Exception as exc:
+            logger.warning(f"failed to parse scene scripts (attempt {i+1}): {exc}")
+            if response:
+                # Try regex recovery: extract {"scenes": [...]} from response
+                match = re.search(r'\{"scenes"\s*:\s*\[.*?\]\s*\}', response, re.DOTALL)
+                if match:
+                    try:
+                        data = json.loads(match.group())
+                        scenes = data.get("scenes", [])
+                        result = [
+                            {"scene_id": s.get("scene_id", 0), "script": s.get("script", "").strip()}
+                            for s in scenes if s.get("script", "").strip()
+                        ]
+                        if result:
+                            logger.success(f"recovered {len(result)} scene scripts via regex")
+                            return result
+                    except Exception as exc2:
+                        logger.warning(f"regex recovery also failed: {exc2}")
+
+        if i < _max_retries - 1:
+            logger.warning(f"retrying scene script generation... {i + 1}")
+
+    logger.error(f"failed to generate scene scripts after {_max_retries} attempts")
+    return []
+
+
+def generate_scene_keywords(
+    video_subject: str,
+    scene_scripts: list[dict],
+    scene_count: int = 2,
+    terms_per_scene: int = 5,
+    app_config=None,
+) -> list[dict]:
+    """Generate search keywords for multiple scenes based on their scripts.
+
+    Args:
+        video_subject: The video topic.
+        scene_scripts: List of {"scene_id": int, "script": str} dicts.
+        scene_count: Expected number of scenes.
+        terms_per_scene: Number of search terms per scene.
+        app_config: Optional LLM config override.
+
+    Returns a list of dicts: [{"scene_id": 1, "terms": ["term1", ...]}, ...].
+    On failure returns an empty list.
+    """
+    scene_count = _normalize_scene_count(scene_count)
+    terms_per_scene = max(1, min(terms_per_scene, MAX_SCENE_TERMS_PER_SCENE))
+
+    script_context = "\n\n".join(
+        f"Scene {s.get('scene_id', i+1)}: {s.get('script', '')}"
+        for i, s in enumerate(scene_scripts)
+        if s.get("script", "").strip()
+    )
+    if not script_context:
+        logger.error("no scene scripts provided for keyword generation")
+        return []
+
+    prompt = DEFAULT_SCENE_KEYWORD_SYSTEM_PROMPT.format(
+        scene_count=scene_count,
+        terms_per_scene=terms_per_scene,
+    )
+    prompt += f"""
+
+## Context:
+### Video Subject
+{video_subject}
+
+### Scene Scripts
+{script_context}
+
+Please generate English search terms only.
+""".strip()
+
+    logger.info(
+        f"generating scene keywords: subject={video_subject}, "
+        f"scenes={len(scene_scripts)}, terms_per_scene={terms_per_scene}"
+    )
+
+    response = ""
+    for i in range(_max_retries):
+        try:
+            if app_config is None:
+                response = _generate_response(prompt)
+            else:
+                response = _generate_response(prompt, app_config=app_config)
+
+            if not response:
+                logger.error("LLM returned empty response for scene keywords")
+                continue
+
+            if response.startswith("Error: "):
+                logger.error(f"failed to generate scene keywords: {response}")
+                return []
+
+            raw = _strip_code_fence(response)
+            data = json.loads(raw)
+            scenes = data.get("scenes", [])
+            if not isinstance(scenes, list):
+                logger.warning("response.scenes is not a list")
+                continue
+
+            result = []
+            for scene in scenes:
+                sid = scene.get("scene_id", 0)
+                terms = scene.get("terms", [])
+                if isinstance(terms, list) and terms:
+                    # Ensure all terms are strings
+                    clean_terms = [str(t).strip() for t in terms if str(t).strip()]
+                    if clean_terms:
+                        result.append({"scene_id": sid, "terms": clean_terms})
+
+            if result:
+                logger.success(
+                    f"generated keywords for {len(result)} scenes "
+                    f"(requested {scene_count})"
+                )
+                return result
+        except Exception as exc:
+            logger.warning(f"failed to parse scene keywords (attempt {i+1}): {exc}")
+            if response:
+                match = re.search(r'\{"scenes"\s*:\s*\[.*?\]\s*\}', response, re.DOTALL)
+                if match:
+                    try:
+                        data = json.loads(match.group())
+                        scenes = data.get("scenes", [])
+                        result = [
+                            {"scene_id": s.get("scene_id", 0), "terms": s.get("terms", [])}
+                            for s in scenes if s.get("terms")
+                        ]
+                        if result:
+                            logger.success(f"recovered keywords for {len(result)} scenes via regex")
+                            return result
+                    except Exception as exc2:
+                        logger.warning(f"regex recovery also failed: {exc2}")
+
+        if i < _max_retries - 1:
+            logger.warning(f"retrying scene keyword generation... {i + 1}")
+
+    logger.error(f"failed to generate scene keywords after {_max_retries} attempts")
+    return []
+
+
+# =============================================================================
 # Social publishing metadata
 #
 # 根据视频主题和脚本生成发布到短视频平台时常用的 title、caption 和 hashtags。

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -447,10 +447,9 @@ def _generate_single_scene(
     logger.info(f"scene {scene.scene_id}: generating audio")
     sub_maker = voice.tts(
         text=script,
-        voice_name=params.voice_name,
+        voice_name=voice.parse_voice_name(params.voice_name),
         voice_rate=params.voice_rate,
         voice_file=audio_file,
-        voice_volume=params.voice_volume,
     )
     if not sub_maker and not voice.is_no_voice(params.voice_name):
         logger.error(f"scene {scene.scene_id}: TTS failed")
@@ -1906,13 +1905,14 @@ def _run_pipeline(
 
     sm.state.update_task(task_id, state=const.TASK_STATE_PROCESSING, progress=40)
 
-    # Scene mode handles materials per-scene in _generate_single_scene.
-    # The standard get_video_materials path is not designed for scenes.
+    # Scene mode only supports stop_at="video".  Intermediate stages
+    # (audio, subtitle, materials) don't make sense because each scene
+    # handles its own audio/subtitles/materials internally.
     if processed_scenes:
         return _mark_task_failed(
             task_id,
-            "materials",
-            "scene mode does not support stop_at=materials; "
+            stop_at,
+            f"scene mode does not support stop_at={stop_at}; "
             "use stop_at=video to generate full scene videos",
         )
 

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -10,10 +10,11 @@ from os import path
 from uuid import uuid4
 
 from loguru import logger
+from moviepy import AudioFileClip
 
 from app.config import config
 from app.models import const
-from app.models.schema import VideoConcatMode, VideoParams
+from app.models.schema import SceneConfig, VideoConcatMode, VideoParams
 from app.services import bgm as bgm_service
 from app.services import (
     elevenlabs_music,
@@ -27,8 +28,8 @@ from app.services import (
     task_artifacts,
     twelvelabs,
     video,
-    volcengine_seedance,
     voice,
+    volcengine_seedance,
 )
 from app.services import upload_post
 from app.services import state as sm
@@ -348,6 +349,232 @@ def generate_terms(task_id, params, video_script):
         )
 
     return video_terms
+
+
+def generate_scenes(task_id, params, video_script):
+    """Process scene definitions and generate keywords for each scene.
+
+    For each scene in params.scenes:
+    - If scene.script is empty, use the full video_script
+    - If scene.search_terms is empty, generate them via LLM
+    - Auto-assign scene_id if it's 0
+
+    Returns a list of processed SceneConfig objects, or None on failure.
+    """
+    if not params.scenes:
+        return None
+
+    logger.info(f"\n\n## processing {len(params.scenes)} scenes")
+    processed_scenes = []
+
+    for index, scene in enumerate(params.scenes):
+        # Auto-assign scene_id if not set
+        scene_id = scene.scene_id if scene.scene_id > 0 else index + 1
+
+        # Use full script if scene script is empty
+        scene_script = scene.script.strip() if scene.script else video_script
+        if not scene_script:
+            logger.warning(f"scene {scene_id} has no script, using full video script")
+            scene_script = video_script
+
+        # Generate search terms if not provided
+        search_terms = scene.search_terms
+        if not search_terms and not scene.materials:
+            logger.info(f"generating search terms for scene {scene_id}")
+            try:
+                search_terms = llm.generate_terms(
+                    video_subject=params.video_subject,
+                    video_script=scene_script,
+                    amount=3,
+                    match_script_order=True,
+                )
+            except Exception as exc:
+                logger.warning(
+                    f"failed to generate terms for scene {scene_id}: {exc}"
+                )
+                search_terms = []
+
+        processed_scene = SceneConfig(
+            scene_id=scene_id,
+            script=scene_script,
+            search_terms=search_terms,
+            materials=scene.materials,
+            duration=scene.duration,
+            transition=scene.transition,
+            clip_transition=scene.clip_transition,
+        )
+        processed_scenes.append(processed_scene)
+        logger.info(
+            f"scene {scene_id}: script_len={len(scene_script)}, "
+            f"terms={len(search_terms or [])}, "
+            f"materials={len(scene.materials or [])}, "
+            f"duration={scene.duration}"
+        )
+
+    return processed_scenes
+
+
+def _generate_single_scene(
+    task_id: str,
+    scene: SceneConfig,
+    params: VideoParams,
+    scene_index: int,
+    allow_server_file_input: bool = False,
+) -> str | None:
+    """Build a single scene as a self-contained video.
+
+    Each scene goes through the full mini-pipeline:
+    1. Determine script (from scene.script)
+    2. Generate audio (TTS or silent) → audio_duration defines scene length
+    3. Generate subtitles for this scene's audio
+    4. Download or use materials for this scene
+    5. combine_videos(materials, audio, clip_transition) → combined scene video
+    6. generate_video(combined, audio, subtitles) → final scene video
+       (audio and subtitles are burned into the scene video)
+
+    Returns the path to the assembled scene video, or None on failure.
+    """
+    scene_dir = os.path.join(utils.task_dir(task_id), f"scene-{scene_index}")
+    os.makedirs(scene_dir, exist_ok=True)
+
+    script = scene.script.strip()
+    if not script:
+        logger.warning(f"scene {scene.scene_id}: empty script, skipping")
+        return None
+
+    # Step 1: Generate audio (TTS or silent for no-voice mode)
+    audio_file = os.path.join(scene_dir, "audio.mp3")
+    logger.info(f"scene {scene.scene_id}: generating audio")
+    sub_maker = voice.tts(
+        text=script,
+        voice_name=params.voice_name,
+        voice_rate=params.voice_rate,
+        voice_file=audio_file,
+        voice_volume=params.voice_volume,
+    )
+    if not sub_maker and not voice.is_no_voice(params.voice_name):
+        logger.error(f"scene {scene.scene_id}: TTS failed")
+        return None
+
+    # Determine scene duration from audio
+    try:
+        audio_clip = AudioFileClip(audio_file)
+        audio_duration = audio_clip.duration
+        audio_clip.close()
+    except Exception as exc:
+        logger.error(f"scene {scene.scene_id}: failed to read audio duration: {exc}")
+        return None
+    logger.info(f"scene {scene.scene_id}: audio duration = {audio_duration:.2f}s")
+
+    # Step 2: Generate subtitles for this scene
+    subtitle_path = ""
+    if params.subtitle_enabled and sub_maker:
+        subtitle_path = os.path.join(scene_dir, "subtitle.srt")
+        logger.info(f"scene {scene.scene_id}: generating subtitles")
+        subtitle_provider = config.app.get("subtitle_provider", "edge").strip().lower()
+        if subtitle_provider == "edge":
+            voice.create_subtitle(
+                text=script, sub_maker=sub_maker, subtitle_file=subtitle_path,
+            )
+            if not os.path.exists(subtitle_path):
+                logger.warning(f"scene {scene.scene_id}: edge subtitle generation failed")
+                subtitle_path = ""
+        elif subtitle_provider == "whisper":
+            subtitle.create(audio_file=audio_file, subtitle_file=subtitle_path)
+            if subtitle_path:
+                subtitle.correct(subtitle_file=subtitle_path, video_script=script)
+
+    # Step 3: Get materials for this scene
+    if scene.materials:
+        # Validate local materials through the same path as the standard pipeline
+        processed = video.preprocess_video(
+            materials=scene.materials,
+            clip_duration=params.video_clip_duration,
+        )
+        if not processed:
+            logger.warning(f"scene {scene.scene_id}: no valid local materials after preprocessing")
+            return None
+        downloaded_videos = [m.url for m in processed if m.url]
+        logger.info(f"scene {scene.scene_id}: using {len(downloaded_videos)} local materials")
+    elif scene.search_terms:
+        logger.info(f"scene {scene.scene_id}: downloading materials for {len(scene.search_terms)} terms")
+        downloaded_videos = material.download_videos(
+            task_id=task_id,
+            search_terms=scene.search_terms,
+            source=params.video_source,
+            video_aspect=params.video_aspect,
+            video_concat_mode=VideoConcatMode.sequential,
+            audio_duration=audio_duration,
+            max_clip_duration=params.video_clip_duration,
+            match_script_order=True,
+        )
+    else:
+        logger.info(f"scene {scene.scene_id}: generating search terms from script")
+        try:
+            terms = llm.generate_terms(
+                video_subject=params.video_subject,
+                video_script=script,
+                amount=3,
+                match_script_order=True,
+            )
+        except Exception as exc:
+            logger.warning(f"scene {scene.scene_id}: failed to generate terms: {exc}")
+            terms = []
+        if terms:
+            downloaded_videos = material.download_videos(
+                task_id=task_id,
+                search_terms=terms,
+                source=params.video_source,
+                video_aspect=params.video_aspect,
+                video_concat_mode=VideoConcatMode.sequential,
+                audio_duration=audio_duration,
+                max_clip_duration=params.video_clip_duration,
+                match_script_order=True,
+            )
+        else:
+            downloaded_videos = []
+
+    if not downloaded_videos:
+        logger.warning(f"scene {scene.scene_id}: no materials found, skipping scene")
+        return None
+    logger.info(f"scene {scene.scene_id}: got {len(downloaded_videos)} video segments")
+
+    # Step 4: Combine materials into scene video
+    # combine_videos reads audio_duration from the audio file to determine
+    # the target video length — so scene.duration vs audio_duration conflict
+    # does not exist here. The audio file IS the scene's audio.
+    combined_path = os.path.join(scene_dir, "combined.mp4")
+    logger.info(f"scene {scene.scene_id}: combining video segments")
+    video.combine_videos(
+        combined_video_path=combined_path,
+        video_paths=downloaded_videos,
+        audio_file=audio_file,
+        video_aspect=params.video_aspect,
+        video_concat_mode=VideoConcatMode.sequential,
+        video_transition_mode=scene.clip_transition or params.clip_transition,
+        max_clip_duration=params.video_clip_duration,
+        threads=params.n_threads,
+        clip_speed=params.video_clip_speed,
+    )
+
+    # Step 5: Burn audio + subtitles into the scene video.
+    # BGM must NOT be applied here — it is overlaid once on the final
+    # concatenated video in concat_scene_videos_with_transitions().  We
+    # pass an explicit empty override so generate_video skips BGM.
+    #   - None  = "resolve BGM from params.bgm_type" (we do NOT want this)
+    #   - ""    = "explicitly disable BGM for this video"  (correct choice)
+    scene_video_path = os.path.join(scene_dir, "scene.mp4")
+    logger.info(f"scene {scene.scene_id}: generating final scene video")
+    video.generate_video(
+        video_path=combined_path,
+        audio_path=audio_file,
+        subtitle_path=subtitle_path,
+        output_file=scene_video_path,
+        params=params,
+        bgm_file_override="",
+    )
+    logger.success(f"scene {scene.scene_id}: scene video ready at {scene_video_path}")
+    return scene_video_path
 
 
 def save_script_data(task_id, video_script, video_terms, params):
@@ -834,6 +1061,7 @@ def generate_final_videos(
         video_music_provider is not None
         and bgm_service.should_use_bgm(params.bgm_type, params.bgm_volume)
     )
+
     # 多视频生成默认会打散素材以增加差异；但“按文案顺序匹配素材”追求的是
     # 时间线稳定性和可解释性，所以开启后所有输出都使用顺序拼接。
     if params.match_materials_to_script:
@@ -851,6 +1079,7 @@ def generate_final_videos(
             utils.task_dir(task_id), f"combined-{index}.mp4"
         )
         logger.info(f"\n\n## combining video: {index} => {combined_video_path}")
+
         video.combine_videos(
             combined_video_path=combined_video_path,
             video_paths=downloaded_videos,
@@ -1382,7 +1611,15 @@ def _run_pipeline(
         )
 
     # 1. Generate script
-    video_script = generate_script(task_id, params)
+    # In scene mode each scene carries its own script, so a global script
+    # is unnecessary.  We still need *something* in video_script for task
+    # artifacts; concatenate scene scripts instead of calling the LLM.
+    video_script = ""
+    if params.scenes:
+        scene_scripts = [s.script.strip() for s in params.scenes if s.script.strip()]
+        video_script = "\n\n".join(scene_scripts)
+    if not video_script:
+        video_script = generate_script(task_id, params)
     if not video_script or "Error: " in video_script:
         error = (
             video_script.removeprefix("Error: ").strip()
@@ -1399,9 +1636,25 @@ def _run_pipeline(
         )
         return {"script": video_script}
 
-    # 2. Generate terms
+    # 2. Generate terms (or process scenes)
     video_terms = ""
-    if params.video_source != "local":
+    processed_scenes = None
+
+    if params.scenes:
+        # Scene-based mode: process each scene independently
+        processed_scenes = generate_scenes(task_id, params, video_script)
+        if not processed_scenes:
+            return _mark_task_failed(
+                task_id,
+                "terms",
+                "failed to process video scenes",
+            )
+        # Collect all search terms from scenes for backward compatibility
+        video_terms = []
+        for scene in processed_scenes:
+            if scene.search_terms:
+                video_terms.extend(scene.search_terms)
+    elif params.video_source != "local":
         video_terms = generate_terms(task_id, params, video_script)
         if not video_terms:
             return _mark_task_failed(
@@ -1419,6 +1672,197 @@ def _run_pipeline(
         return {"script": video_script, "terms": video_terms}
 
     sm.state.update_task(task_id, state=const.TASK_STATE_PROCESSING, progress=20)
+
+    # === SCENE MODE: Build each scene independently then concatenate ===
+    if processed_scenes and stop_at == "video":
+        logger.info(f"\n\n## scene mode: building {len(processed_scenes)} scenes independently")
+
+        # TODO(future): Parallelize scene processing
+        # Each scene (download materials + combine video) is independent.
+        # Current code processes scenes sequentially for simplicity.
+        # Future: use ThreadPoolExecutor to process multiple scenes concurrently.
+        #   with ThreadPoolExecutor(max_workers=???) as executor:
+        #       futures = {
+        #           executor.submit(_generate_single_scene, task_id, scene, params, i): i
+        #           for i, scene in enumerate(processed_scenes, 1)
+        #       }
+        #       for future in as_completed(futures):
+        #           ...
+
+        scene_video_paths = []
+        scene_transitions = []
+        scene_warnings = []
+        for i, scene in enumerate(processed_scenes):
+            scene_index = i + 1
+            sm.state.update_task(
+                task_id,
+                state=const.TASK_STATE_PROCESSING,
+                progress=20 + int(60 * i / len(processed_scenes)),
+            )
+            scene_video = _generate_single_scene(
+                task_id=task_id,
+                scene=scene,
+                params=params,
+                scene_index=scene_index,
+                allow_server_file_input=allow_server_file_input,
+            )
+            if scene_video:
+                scene_video_paths.append(scene_video)
+                # Scene 1 has no transition INTO it (there's no previous scene).
+                # Scene N (N>1) uses the transition defined on that scene or the
+                # global fallback.
+                if i == 0:
+                    scene_transitions.append(None)
+                else:
+                    scene_transitions.append(
+                        scene.transition or params.scene_transition
+                    )
+                logger.info(f"scene {scene.scene_id}: ready ({scene_video})")
+            else:
+                logger.warning(f"scene {scene.scene_id}: generation failed, skipping")
+                scene_warnings.append({
+                    "code": "scene_generation_failed",
+                    "scene_id": scene.scene_id,
+                })
+
+        if not scene_video_paths:
+            return _mark_task_failed(
+                task_id, "video", "no scene videos were generated successfully"
+            )
+
+        sm.state.update_task(task_id, state=const.TASK_STATE_PROCESSING, progress=85)
+
+        # Resolve BGM override for the final video.
+        # - bgm_file_override=None → concat function resolves from bgm_type
+        #   (same as generate_video does for the standard pipeline)
+        # - For AI-generated BGM (sonilo/elevenlabs), generate it now and
+        #   pass the path as override.
+        bgm_file_override = None
+        video_music_provider = _VIDEO_MUSIC_PROVIDERS.get(params.bgm_type)
+        video_music_requested = (
+            video_music_provider is not None
+            and bgm_service.should_use_bgm(params.bgm_type, params.bgm_volume)
+        )
+        if video_music_requested:
+            service = video_music_provider["service"]
+            generated_bgm_path = path.join(
+                utils.task_dir(task_id),
+                f"{params.bgm_type}-bgm{video_music_provider['suffix']}",
+            )
+            # Compute total duration from scene videos for BGM providers
+            # that need it (sonilo, elevenlabs).
+            total_scene_duration = 0.0
+            for svp in scene_video_paths:
+                try:
+                    clip = AudioFileClip(svp)
+                    total_scene_duration += clip.duration
+                    clip.close()
+                except Exception:
+                    pass
+            try:
+                service.generate_bgm(
+                    video_path=scene_video_paths[0],
+                    output_path=generated_bgm_path,
+                    video_duration=total_scene_duration,
+                    prompt=_get_video_music_prompt(params),
+                )
+                bgm_file_override = generated_bgm_path
+            except video_music_provider["error_type"] as exc:
+                logger.warning(
+                    f"{video_music_provider['display_name']} BGM generation failed: "
+                    f"task_id={task_id}, error={exc}"
+                )
+                bgm_file_override = ""
+
+        # Concatenate scene videos and overlay BGM on the final result.
+        # Scene transitions are applied before concatenation.
+        final_video_path = path.join(utils.task_dir(task_id), "final-1.mp4")
+        logger.info(
+            f"\n\n## concatenating {len(scene_video_paths)} scenes + BGM"
+        )
+        video.concat_scene_videos_with_transitions(
+            scene_video_paths=scene_video_paths,
+            output_file=final_video_path,
+            scene_transitions=scene_transitions,
+            bgm_file_override=bgm_file_override,
+            bgm_type=params.bgm_type,
+            bgm_file=params.bgm_file or "",
+            bgm_volume=params.bgm_volume,
+            threads=params.n_threads,
+        )
+
+        final_video_paths = [final_video_path]
+        generation_warnings = scene_warnings
+        combined_video_paths = []
+
+        logger.success(
+            f"task {task_id} finished (scene mode), generated {len(final_video_paths)} videos."
+        )
+
+        sm.state.update_task(task_id, state=const.TASK_STATE_PROCESSING, progress=95)
+
+        # Cross-posting (same as standard mode)
+        cross_post_enabled = (
+            upload_post.upload_post_service.is_configured()
+            and upload_post.upload_post_service.auto_upload
+        )
+        platforms = (
+            list(upload_post.upload_post_service.platforms) if cross_post_enabled else []
+        )
+        should_cross_post = cross_post_enabled and bool(platforms)
+        if cross_post_enabled and not platforms:
+            logger.warning(
+                f"skip cross-post because no platforms are configured, task_id: {task_id}"
+            )
+        cross_post_state = const.CROSS_POST_STATE_PENDING if should_cross_post else None
+
+        audio_duration_sum = 0.0
+        try:
+            for svp in scene_video_paths:
+                clip = AudioFileClip(svp)
+                audio_duration_sum += clip.duration
+                clip.close()
+        except Exception:
+            audio_duration_sum = 0.0
+
+        kwargs = {
+            "videos": final_video_paths,
+            "combined_videos": combined_video_paths,
+            "script": video_script,
+            "terms": video_terms,
+            "audio_file": "",
+            "audio_duration": audio_duration_sum,
+            "subtitle_path": "",
+            "materials": [],
+            "cross_post_state": cross_post_state,
+            "cross_post_results": None,
+            "cross_post_error": None,
+            "cross_post_owner": _cross_post_process_owner if should_cross_post else None,
+            "warnings": generation_warnings or None,
+        }
+        sm.state.update_task(
+            task_id, state=const.TASK_STATE_COMPLETE, progress=100, **kwargs
+        )
+
+        if should_cross_post:
+            scheduling_error = _schedule_cross_post(
+                task_id=task_id,
+                video_paths=final_video_paths,
+                params=params,
+                video_script=video_script,
+                platforms=platforms,
+                youtube_privacy_status=(
+                    upload_post.upload_post_service.youtube_privacy_status
+                ),
+            )
+            if scheduling_error:
+                kwargs["cross_post_state"] = const.CROSS_POST_STATE_FAILED
+                kwargs["cross_post_error"] = scheduling_error
+                kwargs["cross_post_owner"] = None
+
+        return kwargs
+
+    # === STANDARD MODE (non-scene or intermediate stop_at) ===
 
     # 3. Generate audio
     audio_file, audio_duration, sub_maker = generate_audio(
@@ -1461,6 +1905,16 @@ def _run_pipeline(
         return {"subtitle_path": subtitle_path}
 
     sm.state.update_task(task_id, state=const.TASK_STATE_PROCESSING, progress=40)
+
+    # Scene mode handles materials per-scene in _generate_single_scene.
+    # The standard get_video_materials path is not designed for scenes.
+    if processed_scenes:
+        return _mark_task_failed(
+            task_id,
+            "materials",
+            "scene mode does not support stop_at=materials; "
+            "use stop_at=video to generate full scene videos",
+        )
 
     # 5. Get video materials
     downloaded_videos = get_video_materials(

--- a/app/services/video.py
+++ b/app/services/video.py
@@ -22,6 +22,7 @@ from moviepy import (
     TextClip,
     VideoFileClip,
     afx,
+    concatenate_videoclips,
 )
 from moviepy.video.tools.subtitles import SubtitlesClip
 from PIL import Image, ImageDraw, ImageFont
@@ -355,6 +356,10 @@ def concat_video_clips_with_ffmpeg(
             concat_list_file,
             "-c:v",
             codec,
+            "-c:a",
+            "aac",
+            "-b:a",
+            audio_bitrate,
             "-threads",
             str(threads or 2),
             "-pix_fmt",
@@ -822,6 +827,270 @@ def combine_videos(
             
     logger.info("video combining completed")
     return combined_video_path
+
+
+def _apply_scene_transition(
+    input_path: str,
+    output_path: str,
+    transition: VideoTransitionMode,
+):
+    """Apply a transition effect to the beginning of a video file.
+
+    Used to create visual transitions between scenes. The transition visual
+    effect is applied to the first ~1 second of the video.
+    """
+    transition_value = getattr(transition, "value", transition)
+    if transition_value in (None, VideoTransitionMode.none.value):
+        return
+
+    clip = _open_video_clip_quietly(input_path, audio=True)
+    try:
+        transition_duration = min(1.0, clip.duration * 0.15)
+        if transition_duration <= 0:
+            return
+
+        shuffle_side = random.choice(["left", "right", "top", "bottom"])
+
+        if transition_value == VideoTransitionMode.fade_in.value:
+            clip = video_effects.fadein_transition(clip, transition_duration)
+        elif transition_value == VideoTransitionMode.fade_out.value:
+            clip = video_effects.fadeout_transition(clip, transition_duration)
+        elif transition_value == VideoTransitionMode.slide_in.value:
+            clip = video_effects.slidein_transition(clip, transition_duration, shuffle_side)
+        elif transition_value == VideoTransitionMode.slide_out.value:
+            clip = video_effects.slideout_transition(clip, transition_duration, shuffle_side)
+        elif transition_value == VideoTransitionMode.zoom_in.value:
+            clip = video_effects.zoomin_transition(clip, transition_duration)
+        elif transition_value == VideoTransitionMode.zoom_out.value:
+            clip = video_effects.zoomout_transition(clip, transition_duration)
+        elif transition_value == VideoTransitionMode.shuffle.value:
+            transition_funcs = [
+                lambda c: video_effects.fadein_transition(c, transition_duration),
+                lambda c: video_effects.fadeout_transition(c, transition_duration),
+                lambda c: video_effects.slidein_transition(c, transition_duration, shuffle_side),
+                lambda c: video_effects.slideout_transition(c, transition_duration, shuffle_side),
+                lambda c: video_effects.zoomin_transition(c, transition_duration),
+                lambda c: video_effects.zoomout_transition(c, transition_duration),
+            ]
+            clip = random.choice(transition_funcs)(clip)
+        else:
+            logger.warning(f"unsupported scene transition: {transition_value}")
+            return
+
+        _write_videofile_with_codec_fallback(
+            clip,
+            output_path,
+            codec=_get_configured_video_codec(),
+            logger=None,
+            fps=fps,
+        )
+        logger.info(
+            f"applied scene transition={transition_value} "
+            f"(duration={transition_duration:.2f}s) to {os.path.basename(input_path)}"
+        )
+    finally:
+        close_clip(clip)
+
+
+def concat_scene_videos_with_transitions(
+    scene_video_paths: List[str],
+    output_file: str,
+    scene_transitions: List[VideoTransitionMode | None] | None = None,
+    bgm_file_override: str | None = None,
+    bgm_type: str = "",
+    bgm_file: str = "",
+    bgm_volume: float = 0.0,
+    threads: int = 2,
+):
+    """Concatenate fully assembled scene videos into the final output.
+
+    Uses MoviePy for the entire pipeline (open → transitions → concatenate
+    → BGM → write) to ensure compatibility across scenes with different
+    resolutions, sample rates, or codecs.  Mirrors how generate_video()
+    handles its clips.
+
+    Args:
+        scene_video_paths: Paths to assembled scene videos, in order.
+        output_file: Path for the final output video.
+        scene_transitions: Per-scene transition list. Index 0 is for scene 1
+            (usually None), index 1 for scene 2 (transition into scene 2), etc.
+            If None, no transitions are applied.
+        bgm_file_override: BGM resolution strategy.
+            - None  → resolve from bgm_type (random/custom)
+            - ""    → explicitly disable BGM for this video
+            - path? → use this specific BGM file
+        bgm_type: BGM type for resolution when bgm_file_override is None.
+        bgm_file: User's bgm file path (for custom BGM).
+        bgm_volume: Background music volume (0.0 = silent, 1.0 = full).
+        threads: FFmpeg thread count (used for final write).
+    """
+    if not scene_video_paths:
+        logger.warning("no scene videos to concatenate")
+        return
+
+    output_dir = os.path.dirname(output_file)
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Resolve BGM file (same contract as generate_video):
+    #   bgm_file_override=None  → resolve from bgm_type
+    #   bgm_file_override=""    → no BGM
+    #   bgm_file_override=path  → use this file
+    bgm_resolved = ""
+    if bgm_volume > 0 and bgm_file_override is not None:
+        bgm_resolved = bgm_file_override if bgm_file_override else ""
+    elif bgm_volume > 0 and bgm_service.should_use_bgm(bgm_type, bgm_volume):
+        bgm_resolved = get_bgm_file(bgm_type=bgm_type, bgm_file=bgm_file)
+
+    if bgm_resolved and not os.path.isfile(bgm_resolved):
+        logger.warning(f"BGM file not found: {bgm_resolved}")
+        bgm_resolved = ""
+
+    logger.info(
+        f"concatenating {len(scene_video_paths)} scene videos "
+        f"(BGM={'yes' if bgm_resolved else 'no'})"
+    )
+
+    scene_clips = []
+    with ExitStack() as clip_stack:
+        for i, video_path in enumerate(scene_video_paths):
+            clip = clip_stack.enter_context(
+                _open_video_clip_quietly(video_path, audio=True)
+            )
+
+            # Apply scene transition (if any) to scenes 2+
+            transition = (
+                scene_transitions[i]
+                if scene_transitions and i < len(scene_transitions)
+                else None
+            )
+            if transition and i > 0:
+                transition_value = getattr(transition, "value", transition)
+                if transition_value not in (None, VideoTransitionMode.none.value):
+                    duration = min(1.0, clip.duration * 0.15)
+                    if duration > 0:
+                        side = random.choice(["left", "right", "top", "bottom"])
+                        if transition_value == VideoTransitionMode.fade_in.value:
+                            clip = video_effects.fadein_transition(clip, duration)
+                        elif transition_value == VideoTransitionMode.fade_out.value:
+                            clip = video_effects.fadeout_transition(clip, duration)
+                        elif transition_value == VideoTransitionMode.slide_in.value:
+                            clip = video_effects.slidein_transition(clip, duration, side)
+                        elif transition_value == VideoTransitionMode.slide_out.value:
+                            clip = video_effects.slideout_transition(clip, duration, side)
+                        elif transition_value == VideoTransitionMode.zoom_in.value:
+                            clip = video_effects.zoomin_transition(clip, duration)
+                        elif transition_value == VideoTransitionMode.zoom_out.value:
+                            clip = video_effects.zoomout_transition(clip, duration)
+                        elif transition_value == VideoTransitionMode.shuffle.value:
+                            transition_funcs = [
+                                lambda c: video_effects.fadein_transition(c, duration),
+                                lambda c: video_effects.fadeout_transition(c, duration),
+                                lambda c: video_effects.slidein_transition(c, duration, side),
+                                lambda c: video_effects.slideout_transition(c, duration, side),
+                                lambda c: video_effects.zoomin_transition(c, duration),
+                                lambda c: video_effects.zoomout_transition(c, duration),
+                            ]
+                            clip = random.choice(transition_funcs)(clip)
+
+            scene_clips.append(clip)
+
+        if not scene_clips:
+            logger.warning("no valid scene clips to concatenate")
+            return
+
+        # Concatenate all scenes — MoviePy handles resolution/audio mismatch
+        logger.info(f"concatenating {len(scene_clips)} scene clips with MoviePy")
+        final_clip = concatenate_videoclips(scene_clips, method="compose")
+        clip_stack.callback(final_clip.close)
+
+        final_audio = final_clip.audio
+
+        # Overlay BGM if resolved (same pattern as generate_video)
+        # Only loop BGM for random/custom sources — provider-generated BGM
+        # (sonilo/elevenlabs) is already sized to the video duration.
+        if bgm_resolved:
+            bgm_effects = [
+                afx.MultiplyVolume(bgm_volume),
+                afx.AudioFadeOut(3),
+            ]
+            if bgm_file_override is None:
+                # Random/custom BGM may be shorter than the video — loop it
+                bgm_effects.append(afx.AudioLoop(duration=final_clip.duration))
+            bgm_source = clip_stack.enter_context(AudioFileClip(bgm_resolved))
+            bgm_clip = bgm_source.with_effects(bgm_effects)
+            final_audio = CompositeAudioClip([final_audio, bgm_clip])
+            logger.info(f"BGM overlaid: {bgm_resolved}")
+
+        final_clip = final_clip.with_audio(final_audio)
+        clip_stack.callback(final_clip.close)
+
+        output_audio_fps = int(getattr(final_audio, "fps", 0) or 44100)
+        _write_videofile_with_codec_fallback(
+            final_clip,
+            output_file=output_file,
+            codec=_get_configured_video_codec(),
+            audio_codec=audio_codec,
+            audio_fps=output_audio_fps,
+            audio_bitrate=audio_bitrate,
+            temp_audiofile_path=_get_temp_audio_dir(output_dir),
+            threads=threads or 2,
+            logger=None,
+            fps=fps,
+        )
+
+    logger.info(f"final scene concatenation complete: {output_file}")
+
+
+def _overlay_bgm_on_video(
+    video_path: str,
+    bgm_file: str,
+    bgm_volume: float,
+    output_path: str,
+    threads: int = 2,
+):
+    """Overlay background music onto a video file.
+
+    Uses MoviePy CompositeAudioClip — the same approach as generate_video().
+    The video's existing audio (voice narrations) is kept and the BGM is
+    layered on top with the specified volume. BGM is looped to match the
+    video duration and faded out over the last 3 seconds.
+    """
+    output_dir = os.path.dirname(output_path)
+    with ExitStack() as clip_stack:
+        video_clip = clip_stack.enter_context(
+            _open_video_clip_quietly(video_path, audio=True)
+        )
+
+        # Keep existing audio (voice) as-is
+        original_audio = video_clip.audio
+
+        # Load BGM, loop it, and mix with voice — identical to generate_video()
+        bgm_effects = [
+            afx.MultiplyVolume(bgm_volume),
+            afx.AudioFadeOut(3),
+            afx.AudioLoop(duration=video_clip.duration),
+        ]
+        bgm_source_clip = clip_stack.enter_context(AudioFileClip(bgm_file))
+        bgm_clip = bgm_source_clip.with_effects(bgm_effects)
+        mixed_audio = CompositeAudioClip([original_audio, bgm_clip])
+
+        final_clip = video_clip.with_audio(mixed_audio)
+        clip_stack.callback(final_clip.close)
+
+        output_audio_fps = int(getattr(mixed_audio, "fps", 0) or 44100)
+        _write_videofile_with_codec_fallback(
+            final_clip,
+            output_file=output_path,
+            codec=_get_configured_video_codec(),
+            audio_codec=audio_codec,
+            audio_fps=output_audio_fps,
+            audio_bitrate=audio_bitrate,
+            temp_audiofile_path=_get_temp_audio_dir(output_dir),
+            threads=threads or 2,
+            logger=None,
+            fps=fps,
+        )
+    logger.info(f"BGM overlay completed: {bgm_file}")
 
 
 def wrap_text(text, max_width, font="Arial", fontsize=60):

--- a/app/services/video.py
+++ b/app/services/video.py
@@ -1039,6 +1039,7 @@ def concat_scene_videos_with_transitions(
         )
 
     logger.info(f"final scene concatenation complete: {output_file}")
+    return bool(bgm_resolved)
 
 
 def _overlay_bgm_on_video(

--- a/docs/planned_ideas_scenes.md
+++ b/docs/planned_ideas_scenes.md
@@ -1,0 +1,175 @@
+# Future Ideas — Scene-Based Video Generation
+
+Ideas collected during scene-pipeline development. Not scheduled for the current PR.
+
+---
+
+## 1. Per-Scene Transitions
+
+**Status:** Idea  
+**Complexity:** Medium  
+
+Allow each scene to have its own unique transition (fade_in, slide_in, zoom_in, etc.)
+independent of other scenes. Currently a single global `scene_transition` applies to all
+scene boundaries.
+
+**UI:** Each scene block gets its own transition dropdown.  
+**Schema:** `SceneConfig.transition` already supports this — the field exists but the UI
+doesn't expose it per-scene yet.  
+**Backend:** `task.py:1690` already reads `scene.transition or params.scene_transition`,
+so the backend is ready.
+
+---
+
+## 2. Parallel Scene Processing (Multi-threaded)
+
+**Status:** Idea  
+**Complexity:** High  
+
+Process independent scenes concurrently using `ThreadPoolExecutor`. Scene N+1's audio
+generation doesn't depend on scene N's video composition.
+
+**Current state:** `task.py:1666` has a commented-out `executor.submit` stub.  
+**Risks:** TTS services may have rate limits; material downloads may share bandwidth;
+progress reporting becomes harder.  
+**Approach:** Generate all audio first (parallel), then all materials (parallel), then
+compose each scene (parallel), then concatenate (sequential). Each stage waits for the
+previous to complete across all scenes.
+
+---
+
+## 3. Per-Scene Progress in WebUI
+
+**Status:** Idea  
+**Complexity:** Medium  
+
+Show "Processing scene 2/5..." in the WebUI progress bar and log console. Currently the
+pipeline logs individual scene progress to stdout, but the WebUI progress bar only shows
+overall percentage.
+
+---
+
+## 4. Per-Scene Add/Remove & Reordering in UI
+
+**Status:** Idea  
+**Complexity:** Medium  
+
+Currently scene count is controlled only by the slider, and scenes can only be added/removed
+from the end. Future: per-scene `+` button between scenes (insert at position) and `×` on
+each scene block (remove specific scene), plus drag-and-drop or arrow buttons for reordering.
+
+---
+
+## 5. Scene-Specific TTS Voice
+
+**Status:** Idea  
+**Complexity:** Low-Medium  
+
+Allow different voices for different scenes (e.g., narrator in scene 1, character in scene
+2). `SceneConfig` could have an optional `voice_name` field that overrides
+`params.voice_name`.
+
+---
+
+## 6. Scene Duration Override (Trim/Extend)
+
+**Status:** Idea  
+**Complexity:** High  
+
+`SceneConfig.duration` is currently accepted but unused — actual duration is determined by
+TTS audio length. Future enhancement: use `duration` to trim or extend the final scene
+video (slow down / speed up audio, or use silence padding).
+
+---
+
+## 7. Scene Templates / Presets
+
+**Status:** Idea  
+**Complexity:** Low  
+
+Pre-built scene templates: "3 scenes: Intro → Main → Conclusion", "5 scenes: Hook →
+Problem → Solution → Demo → CTA". User picks a template and gets pre-filled scene blocks.
+
+---
+
+## 8. i18n: Translate New Scene UI Elements
+
+**Status:** TODO (before PR submission)  
+**Complexity:** Low  
+
+The scene-mode UI currently has translations only in `en.json` and `ru.json`. All other
+supported languages need the same keys added:
+
+**Languages to update:** `zh.json`, `de.json`, `es.json`, `fr.json`, `id.json`, `it.json`,
+`ko.json`, `pt.json`, `tr.json`, `vi.json`, `ja.json`
+
+**Keys to translate:**
+```
+Generation Mode, Generation Mode whole, Generation Mode scenes, Generation Mode Help,
+Scenes, Scene, Add Scene, Remove Scene, Number of Scenes,
+Generate Scene Scripts, Generate Scene Keywords,
+Generating Scene Scripts, Generating Scene Keywords,
+Generate Scene Scripts and Keywords,
+Failed to generate scene scripts, Failed to generate scene keywords,
+Please Generate Scene Scripts First,
+Scene count adjusted, Scene keyword count adjusted
+```
+
+---
+
+## 9. Scene-Mode Transition Dropdowns in Video Settings
+
+**Status:** Idea  
+**Complexity:** Low  
+
+Currently `scene_transition` and `clip_transition` are not exposed as separate controls in
+scene mode. The existing `video_transition_mode` dropdown is used as a fallback. Need two
+dedicated dropdowns visible only in scene mode:
+- "Transition between scenes" → `params.scene_transition`
+- "Transition between clips within a scene" → `params.clip_transition`
+
+**Backend:** Fully ready — `task.py` reads both fields and passes them to the pipeline.
+
+---
+
+## 10. LoomLoom Scene Script Generation
+
+**Status:** Idea  
+**Complexity:** Medium  
+
+Scene mode currently only supports local LLM for script/keyword generation. LoomLoom
+integration (`_render_loomloom_script_generation`) is not connected to scene mode. Need to
+allow LoomLoom to generate per-scene scripts and distribute them into scene blocks.
+
+---
+
+## 11. Task Restore with Scene Data
+
+**Status:** Idea  
+**Complexity:** Low-Medium  
+
+When a historical task is loaded from the task manager, `params.scenes` may not round-trip
+correctly if scenes weren't persisted to `script_data.json`. Need to verify that
+`save_script_data` includes scenes and that `_load_task_restore_payload` reconstructs them.
+
+---
+
+## 12. Settings Presets for Scene Blocks
+
+**Status:** Idea  
+**Complexity:** Low  
+
+The WebUI settings export/import (`_parse_settings_preset`) doesn't include scene blocks.
+Need to persist `scene_scripts`, `scene_keywords`, and `scene_count` in preset files.
+
+---
+
+## 13. Scene Duration Override (Trim/Extend)
+
+**Status:** Idea  
+**Complexity:** High  
+
+`SceneConfig.duration` is accepted but unused — actual duration is determined by TTS audio.
+Future: use `duration` to trim or extend the scene video (speed up/slow down audio, or
+use silence padding). This was separated from idea #6 because it also affects subtitle
+timing and transition calculations.

--- a/test/services/test_scene_pipeline.py
+++ b/test/services/test_scene_pipeline.py
@@ -1,0 +1,1470 @@
+"""End-to-end tests for the scene-based video generation pipeline.
+
+Tests verify that scene structure is preserved through all pipeline stages:
+script processing, audio, subtitle, material download, and video composition.
+Each scene is assembled as a self-contained video before final concatenation.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def _mock_clip(duration=10.0):
+    """Create a MagicMock that behaves as a context manager (for ExitStack)."""
+    clip = MagicMock()
+    clip.duration = duration
+    clip.__enter__ = MagicMock(return_value=clip)
+    clip.__exit__ = MagicMock(return_value=False)
+    return clip
+
+
+from app.models.schema import (
+    MaterialInfo,
+    SceneConfig,
+    VideoConcatMode,
+    VideoParams,
+    VideoTransitionMode,
+)
+from app.services import task as tm
+from app.services import video as vd
+
+
+class TestGenerateScenes(unittest.TestCase):
+    """Tests for generate_scenes() function."""
+
+    def test_returns_none_when_no_scenes(self):
+        params = VideoParams(video_subject="test", scenes=None)
+        result = tm.generate_scenes("task-1", params, "full script")
+        self.assertIsNone(result)
+
+    def test_returns_none_for_empty_scenes(self):
+        params = VideoParams(video_subject="test", scenes=[])
+        result = tm.generate_scenes("task-1", params, "full script")
+        self.assertIsNone(result)
+
+    def test_auto_assigns_scene_ids(self):
+        params = VideoParams(
+            video_subject="test",
+            scenes=[
+                SceneConfig(script="Scene 1", duration=5.0),
+                SceneConfig(script="Scene 2", duration=10.0),
+            ],
+        )
+        with patch.object(tm.llm, "generate_terms", return_value=["term"]):
+            result = tm.generate_scenes("task-1", params, "full script")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0].scene_id, 1)
+        self.assertEqual(result[1].scene_id, 2)
+
+    def test_preserves_explicit_scene_ids(self):
+        params = VideoParams(
+            video_subject="test",
+            scenes=[
+                SceneConfig(scene_id=5, script="Scene 1"),
+                SceneConfig(scene_id=10, script="Scene 2"),
+            ],
+        )
+        with patch.object(tm.llm, "generate_terms", return_value=["term"]):
+            result = tm.generate_scenes("task-1", params, "full script")
+
+        self.assertEqual(result[0].scene_id, 5)
+        self.assertEqual(result[1].scene_id, 10)
+
+    def test_uses_full_script_when_scene_script_empty(self):
+        params = VideoParams(
+            video_subject="test",
+            scenes=[SceneConfig(script="", duration=5.0)],
+        )
+        with patch.object(tm.llm, "generate_terms", return_value=["term"]):
+            result = tm.generate_scenes("task-1", params, "full narration script")
+
+        self.assertEqual(result[0].script, "full narration script")
+
+    def test_generates_terms_from_llm_when_not_provided(self):
+        params = VideoParams(
+            video_subject="test",
+            scenes=[SceneConfig(script="Scene text", duration=5.0)],
+        )
+        with patch.object(
+            tm.llm, "generate_terms", return_value=["term1", "term2"]
+        ) as mock_terms:
+            result = tm.generate_scenes("task-1", params, "full script")
+
+        mock_terms.assert_called_once()
+        self.assertEqual(result[0].search_terms, ["term1", "term2"])
+
+    def test_preserves_provided_search_terms(self):
+        params = VideoParams(
+            video_subject="test",
+            scenes=[
+                SceneConfig(
+                    script="Scene text",
+                    search_terms=["custom1", "custom2"],
+                    duration=5.0,
+                ),
+            ],
+        )
+        result = tm.generate_scenes("task-1", params, "full script")
+        self.assertEqual(result[0].search_terms, ["custom1", "custom2"])
+
+    def test_preserves_transition_and_clip_transition(self):
+        params = VideoParams(
+            video_subject="test",
+            scenes=[
+                SceneConfig(
+                    script="S1",
+                    transition=VideoTransitionMode.fade_in,
+                    clip_transition=VideoTransitionMode.slide_in,
+                ),
+            ],
+        )
+        with patch.object(tm.llm, "generate_terms", return_value=["term"]):
+            result = tm.generate_scenes("task-1", params, "full script")
+
+        self.assertEqual(result[0].transition, VideoTransitionMode.fade_in)
+        self.assertEqual(result[0].clip_transition, VideoTransitionMode.slide_in)
+
+    def test_preserves_local_materials(self):
+        materials = [MaterialInfo(provider="local", url="/test.mp4", duration=5)]
+        params = VideoParams(
+            video_subject="test",
+            scenes=[SceneConfig(script="S1", materials=materials)],
+        )
+        result = tm.generate_scenes("task-1", params, "full script")
+        self.assertIsNotNone(result[0].materials)
+        self.assertEqual(len(result[0].materials), 1)
+        self.assertEqual(result[0].materials[0].url, "/test.mp4")
+
+
+class TestGenerateSingleScene(unittest.TestCase):
+    """Tests for _generate_single_scene() -- full scene video assembly."""
+
+    def test_returns_none_for_empty_script(self):
+        scene = SceneConfig(scene_id=1, script="", search_terms=["t1"])
+        params = VideoParams(video_subject="test")
+        result = tm._generate_single_scene("task-1", scene, params, 1)
+        self.assertIsNone(result)
+
+    def test_generates_tts_audio_and_subtitles(self):
+        """Scene assembly should produce audio and subtitles for that scene."""
+        scene = SceneConfig(
+            scene_id=1, script="Test narration.", search_terms=["term1"]
+        )
+        params = VideoParams(
+            video_subject="test",
+            voice_name="zh-CN-XiaoxiaoNeural-Female",
+            subtitle_enabled=True,
+        )
+
+        mock_sub_maker = MagicMock()
+
+        with patch.object(tm.voice, "tts", return_value=mock_sub_maker) as mock_tts, \
+             patch("app.services.task.AudioFileClip") as mock_audio_clip, \
+             patch.object(tm.subtitle, "create"), \
+             patch.object(tm.subtitle, "correct"), \
+             patch.object(tm.voice, "create_subtitle"), \
+             patch.object(
+                 tm.material, "download_videos", return_value=["/v1.mp4"]
+             ), \
+             patch.object(tm.video, "combine_videos"), \
+             patch.object(tm.video, "generate_video", return_value=True), \
+             patch("os.path.exists", return_value=True), \
+             patch("os.makedirs"):
+
+            mock_clip_instance = MagicMock()
+            mock_clip_instance.duration = 5.0
+            mock_audio_clip.return_value = mock_clip_instance
+
+            result = tm._generate_single_scene("task-1", scene, params, 1)
+
+        self.assertIsNotNone(result)
+        mock_tts.assert_called_once()
+        # TTS should be called with the SCENE script, not the global script
+        call_kwargs = mock_tts.call_args.kwargs
+        self.assertEqual(call_kwargs["text"], "Test narration.")
+
+    def test_uses_clip_transition_for_within_scene(self):
+        """combine_videos should use scene's clip_transition."""
+        scene = SceneConfig(
+            scene_id=1,
+            script="Test.",
+            search_terms=["term1"],
+            clip_transition=VideoTransitionMode.fade_in,
+        )
+        params = VideoParams(video_subject="test", voice_name="no-voice")
+
+        with patch.object(tm.voice, "tts", return_value=MagicMock()), \
+             patch("app.services.task.AudioFileClip") as mock_audio_clip, \
+             patch.object(
+                 tm.material, "download_videos", return_value=["/v1.mp4"]
+             ), \
+             patch.object(tm.video, "combine_videos") as mock_combine, \
+             patch.object(tm.video, "generate_video", return_value=True), \
+             patch("os.path.exists", return_value=True), \
+             patch("os.makedirs"):
+
+            mock_clip_instance = MagicMock()
+            mock_clip_instance.duration = 5.0
+            mock_audio_clip.return_value = mock_clip_instance
+
+            tm._generate_single_scene("task-1", scene, params, 1)
+
+        combine_kwargs = mock_combine.call_args.kwargs
+        self.assertEqual(
+            combine_kwargs["video_transition_mode"], VideoTransitionMode.fade_in
+        )
+
+    def test_falls_back_to_global_clip_transition(self):
+        """When scene has no clip_transition, use params.clip_transition as default."""
+        scene = SceneConfig(
+            scene_id=1, script="Test.", search_terms=["term1"]
+        )
+        params = VideoParams(
+            video_subject="test",
+            voice_name="no-voice",
+            clip_transition=VideoTransitionMode.slide_in,
+        )
+
+        with patch.object(tm.voice, "tts", return_value=MagicMock()), \
+             patch("app.services.task.AudioFileClip") as mock_audio_clip, \
+             patch.object(
+                 tm.material, "download_videos", return_value=["/v1.mp4"]
+             ), \
+             patch.object(tm.video, "combine_videos") as mock_combine, \
+             patch.object(tm.video, "generate_video", return_value=True), \
+             patch("os.path.exists", return_value=True), \
+             patch("os.makedirs"):
+
+            mock_clip_instance = MagicMock()
+            mock_clip_instance.duration = 5.0
+            mock_audio_clip.return_value = mock_clip_instance
+
+            tm._generate_single_scene("task-1", scene, params, 1)
+
+        combine_kwargs = mock_combine.call_args.kwargs
+        self.assertEqual(
+            combine_kwargs["video_transition_mode"], VideoTransitionMode.slide_in
+        )
+
+    def test_uses_search_terms_for_material_download(self):
+        """download_videos should be called with scene's search terms."""
+        scene = SceneConfig(
+            scene_id=1, script="Test.", search_terms=["drift", "night"]
+        )
+        params = VideoParams(video_subject="Drift", voice_name="no-voice")
+
+        with patch.object(tm.voice, "tts", return_value=MagicMock()), \
+             patch("app.services.task.AudioFileClip") as mock_audio_clip, \
+             patch.object(
+                 tm.material, "download_videos", return_value=["/v1.mp4"]
+             ) as mock_download, \
+             patch.object(tm.video, "combine_videos"), \
+             patch.object(tm.video, "generate_video", return_value=True), \
+             patch("os.path.exists", return_value=True), \
+             patch("os.makedirs"):
+
+            mock_clip_instance = MagicMock()
+            mock_clip_instance.duration = 5.0
+            mock_audio_clip.return_value = mock_clip_instance
+
+            tm._generate_single_scene("task-1", scene, params, 1)
+
+        download_kwargs = mock_download.call_args.kwargs
+        self.assertEqual(download_kwargs["search_terms"], ["drift", "night"])
+        self.assertEqual(
+            download_kwargs["video_concat_mode"], VideoConcatMode.sequential
+        )
+
+    def test_returns_none_when_no_materials_found(self):
+        """Should return None if no materials could be downloaded."""
+        scene = SceneConfig(scene_id=1, script="Test.", search_terms=["term1"])
+        params = VideoParams(video_subject="test", voice_name="no-voice")
+
+        with patch.object(tm.voice, "tts", return_value=MagicMock()), \
+             patch("app.services.task.AudioFileClip") as mock_audio_clip, \
+             patch.object(tm.material, "download_videos", return_value=[]), \
+             patch("os.path.exists", return_value=True), \
+             patch("os.makedirs"):
+
+            mock_clip_instance = MagicMock()
+            mock_clip_instance.duration = 5.0
+            mock_audio_clip.return_value = mock_clip_instance
+
+            result = tm._generate_single_scene("task-1", scene, params, 1)
+
+        self.assertIsNone(result)
+
+    def test_generates_terms_from_llm_when_not_provided(self):
+        """When scene has no search_terms, should use LLM to generate them."""
+        scene = SceneConfig(scene_id=1, script="Drift art.")
+        params = VideoParams(video_subject="Drift", voice_name="no-voice")
+
+        with patch.object(tm.voice, "tts", return_value=MagicMock()), \
+             patch("app.services.task.AudioFileClip") as mock_audio_clip, \
+             patch.object(
+                 tm.llm, "generate_terms", return_value=["drift", "night"]
+             ), \
+             patch.object(
+                 tm.material, "download_videos", return_value=["/v1.mp4"]
+             ), \
+             patch.object(tm.video, "combine_videos"), \
+             patch.object(tm.video, "generate_video", return_value=True), \
+             patch("os.path.exists", return_value=True), \
+             patch("os.makedirs"):
+
+            mock_clip_instance = MagicMock()
+            mock_clip_instance.duration = 5.0
+            mock_audio_clip.return_value = mock_clip_instance
+
+            result = tm._generate_single_scene("task-1", scene, params, 1)
+
+        self.assertIsNotNone(result)
+
+
+class TestSceneScriptsConcatenation(unittest.TestCase):
+    """Tests that scene scripts are concatenated for backward compatibility."""
+
+    def test_concatenation_contains_all_scene_scripts(self):
+        processed_scenes = [
+            SceneConfig(scene_id=1, script="First scene."),
+            SceneConfig(scene_id=2, script="Second scene."),
+        ]
+
+        scene_scripts = [s.script for s in processed_scenes if s.script]
+        video_script = "\n\n".join(scene_scripts) if scene_scripts else ""
+
+        self.assertIn("First scene.", video_script)
+        self.assertIn("Second scene.", video_script)
+        self.assertIn("\n\n", video_script)
+
+    def test_no_scenes_preserves_original_script(self):
+        """When there are no scenes, video_script should remain unchanged."""
+        video_script = "full narration script"
+        processed_scenes = []
+
+        scene_scripts = [s.script for s in processed_scenes if s.script]
+        if scene_scripts:
+            video_script = "\n\n".join(scene_scripts)
+
+        self.assertEqual(video_script, "full narration script")
+
+
+class TestSceneOrderPreservation(unittest.TestCase):
+    """Tests that scene order is preserved through the pipeline."""
+
+    def test_scenes_processed_in_order(self):
+        """generate_scenes should process scenes in definition order."""
+        params = VideoParams(
+            video_subject="test",
+            scenes=[
+                SceneConfig(scene_id=1, script="First", search_terms=["t1"]),
+                SceneConfig(scene_id=2, script="Second", search_terms=["t2"]),
+                SceneConfig(scene_id=3, script="Third", search_terms=["t3"]),
+            ],
+        )
+        result = tm.generate_scenes("task-1", params, "full script")
+
+        self.assertIsNotNone(result)
+        self.assertEqual([s.scene_id for s in result], [1, 2, 3])
+        self.assertEqual([s.script for s in result], ["First", "Second", "Third"])
+
+
+class TestSceneTransitionDefaults(unittest.TestCase):
+    """Tests that scene/clip transitions fall back to global defaults."""
+
+    def test_scene_transition_fallback(self):
+        scene = SceneConfig(scene_id=1, script="Test.")
+        params = VideoParams(
+            video_subject="test",
+            scene_transition=VideoTransitionMode.fade_in,
+        )
+        effective = scene.transition or params.scene_transition
+        self.assertEqual(effective, VideoTransitionMode.fade_in)
+
+    def test_clip_transition_fallback(self):
+        scene = SceneConfig(scene_id=1, script="Test.")
+        params = VideoParams(
+            video_subject="test",
+            clip_transition=VideoTransitionMode.slide_in,
+        )
+        effective = scene.clip_transition or params.clip_transition
+        self.assertEqual(effective, VideoTransitionMode.slide_in)
+
+    def test_per_scene_transition_takes_precedence(self):
+        scene = SceneConfig(
+            scene_id=1, script="Test.", transition=VideoTransitionMode.zoom_in
+        )
+        params = VideoParams(
+            video_subject="test",
+            scene_transition=VideoTransitionMode.fade_in,
+        )
+        effective = scene.transition or params.scene_transition
+        self.assertEqual(effective, VideoTransitionMode.zoom_in)
+
+
+class TestSceneTimeline(unittest.TestCase):
+    """Timeline-level tests verifying actual durations and transitions."""
+
+    def test_scene_video_duration_matches_audio(self):
+        """Each scene's video should be trimmed to its audio duration."""
+        scene = SceneConfig(scene_id=1, script="Test.", search_terms=["t1"])
+        params = VideoParams(video_subject="test", voice_name="no-voice")
+
+        with patch.object(tm.voice, "tts", return_value=MagicMock()), \
+             patch("app.services.task.AudioFileClip") as mock_audio_clip, \
+             patch.object(
+                 tm.material, "download_videos", return_value=["/v1.mp4"]
+             ), \
+             patch.object(tm.video, "combine_videos") as mock_combine, \
+             patch.object(tm.video, "generate_video", return_value=True), \
+             patch("os.path.exists", return_value=True), \
+             patch("os.makedirs"):
+
+            mock_clip_instance = MagicMock()
+            mock_clip_instance.duration = 3.5  # Scene's audio is 3.5 seconds
+            mock_audio_clip.return_value = mock_clip_instance
+
+            tm._generate_single_scene("task-1", scene, params, 1)
+
+        # combine_videos uses the scene's own audio file, not global audio
+        combine_call = mock_combine.call_args
+        self.assertIn("scene-1", combine_call.kwargs["audio_file"])
+
+    def test_each_scene_has_own_audio_and_subtitle_files(self):
+        """Each scene should produce its own audio and subtitle files."""
+        scene1 = SceneConfig(scene_id=1, script="First.", search_terms=["t1"])
+        scene2 = SceneConfig(scene_id=2, script="Second.", search_terms=["t2"])
+        params = VideoParams(
+            video_subject="test",
+            voice_name="no-voice",
+            subtitle_enabled=False,
+        )
+
+        scene_paths = []
+        for i, scene in enumerate([scene1, scene2], 1):
+            with patch.object(tm.voice, "tts", return_value=MagicMock()), \
+                 patch("app.services.task.AudioFileClip") as mock_audio_clip, \
+                 patch.object(
+                     tm.material, "download_videos", return_value=[f"/v{i}.mp4"]
+                 ), \
+                 patch.object(tm.video, "combine_videos"), \
+                 patch.object(tm.video, "generate_video", return_value=True), \
+                 patch("os.path.exists", return_value=True), \
+                 patch("os.makedirs"):
+
+                mock_clip_instance = MagicMock()
+                mock_clip_instance.duration = float(i * 3)
+                mock_audio_clip.return_value = mock_clip_instance
+
+                result = tm._generate_single_scene("task-1", scene, params, i)
+                scene_paths.append(result)
+
+        # Both scenes should have generated valid paths in different directories
+        self.assertIsNotNone(scene_paths[0])
+        self.assertIsNotNone(scene_paths[1])
+        self.assertIn("scene-1", scene_paths[0])
+        self.assertIn("scene-2", scene_paths[1])
+        self.assertNotEqual(scene_paths[0], scene_paths[1])
+
+
+class TestSceneConfig(unittest.TestCase):
+    """Tests for SceneConfig model validation."""
+
+    def test_default_values(self):
+        scene = SceneConfig()
+        self.assertEqual(scene.scene_id, 0)
+        self.assertEqual(scene.script, "")
+        self.assertIsNone(scene.search_terms)
+        self.assertIsNone(scene.materials)
+        self.assertIsNone(scene.duration)
+        self.assertIsNone(scene.transition)
+        self.assertIsNone(scene.clip_transition)
+
+    def test_valid_scene(self):
+        scene = SceneConfig(
+            scene_id=1,
+            script="Drift is art.",
+            search_terms=["drift car"],
+            duration=5.0,
+            transition=VideoTransitionMode.fade_in,
+            clip_transition=VideoTransitionMode.slide_in,
+        )
+        self.assertEqual(scene.scene_id, 1)
+        self.assertEqual(scene.script, "Drift is art.")
+        self.assertEqual(scene.search_terms, ["drift car"])
+        self.assertEqual(scene.duration, 5.0)
+        self.assertEqual(scene.transition, VideoTransitionMode.fade_in)
+        self.assertEqual(scene.clip_transition, VideoTransitionMode.slide_in)
+
+    def test_rejects_negative_scene_id(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            SceneConfig(scene_id=-1)
+
+    def test_rejects_duration_below_minimum(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            SceneConfig(duration=0.1)
+
+    def test_accepts_minimum_duration(self):
+        scene = SceneConfig(duration=0.5)
+        self.assertEqual(scene.duration, 0.5)
+
+
+class TestVideoParamsWithScenes(unittest.TestCase):
+    """Tests for VideoParams with scenes and transition defaults."""
+
+    def test_scenes_field_defaults_to_none(self):
+        params = VideoParams(video_subject="Test")
+        self.assertIsNone(params.scenes)
+
+    def test_transition_defaults_are_none(self):
+        params = VideoParams(video_subject="Test")
+        self.assertIsNone(params.scene_transition)
+        self.assertIsNone(params.clip_transition)
+
+    def test_backward_compatibility_without_scenes(self):
+        params = VideoParams(
+            video_subject="Test",
+            video_script="Full script",
+            video_terms=["term1", "term2"],
+        )
+        self.assertIsNone(params.scenes)
+        self.assertEqual(params.video_script, "Full script")
+
+    def test_with_multiple_scenes_and_transitions(self):
+        scenes = [
+            SceneConfig(
+                scene_id=1,
+                script="Scene 1",
+                transition=VideoTransitionMode.fade_in,
+                clip_transition=VideoTransitionMode.slide_in,
+            ),
+            SceneConfig(
+                scene_id=2,
+                script="Scene 2",
+                transition=VideoTransitionMode.zoom_in,
+            ),
+        ]
+        params = VideoParams(
+            video_subject="Test",
+            scenes=scenes,
+            scene_transition=VideoTransitionMode.shuffle,
+            clip_transition=VideoTransitionMode.fade_out,
+        )
+        self.assertEqual(len(params.scenes), 2)
+        self.assertEqual(params.scene_transition, VideoTransitionMode.shuffle)
+        self.assertEqual(params.clip_transition, VideoTransitionMode.fade_out)
+        # Per-scene values
+        self.assertEqual(params.scenes[0].transition, VideoTransitionMode.fade_in)
+        self.assertEqual(params.scenes[1].transition, VideoTransitionMode.zoom_in)
+        self.assertEqual(
+            params.scenes[0].clip_transition, VideoTransitionMode.slide_in
+        )
+        self.assertIsNone(params.scenes[1].clip_transition)
+
+
+class TestApplySceneTransition(unittest.TestCase):
+    """Tests for _apply_scene_transition() in video.py.
+
+    All tests use fully mocked I/O — no file writes required.
+    """
+
+    def _run_transition(self, transition, *, duration=5.0):
+        """Helper: run _apply_scene_transition with full mocks."""
+        fake_clip = types.SimpleNamespace(duration=duration)
+        with patch.object(vd, "_open_video_clip_quietly", return_value=fake_clip):
+            with patch("app.services.video.video_effects") as mock_effects:
+                mock_effects.fadein_transition.return_value = fake_clip
+                mock_effects.fadeout_transition.return_value = fake_clip
+                mock_effects.slidein_transition.return_value = fake_clip
+                mock_effects.slideout_transition.return_value = fake_clip
+                mock_effects.zoomin_transition.return_value = fake_clip
+                mock_effects.zoomout_transition.return_value = fake_clip
+                with patch.object(vd, "_write_videofile_with_codec_fallback"):
+                    with patch.object(vd, "close_clip"):
+                        vd._apply_scene_transition(
+                            "input.mp4", "output.mp4", transition
+                        )
+        return mock_effects
+
+    def test_none_transition_returns_immediately(self):
+        """No-op when transition is None — should not open clip or write."""
+        with patch.object(vd, "_open_video_clip_quietly") as open_mock:
+            vd._apply_scene_transition("input.mp4", "output.mp4", VideoTransitionMode.none)
+        open_mock.assert_not_called()
+
+    def test_fade_in_calls_correct_effect(self):
+        effects = self._run_transition(VideoTransitionMode.fade_in)
+        effects.fadein_transition.assert_called_once()
+
+    def test_fade_out_calls_correct_effect(self):
+        """Bug fix: fade_out was previously silently ignored."""
+        effects = self._run_transition(VideoTransitionMode.fade_out)
+        effects.fadeout_transition.assert_called_once()
+
+    def test_slide_in_calls_correct_effect(self):
+        effects = self._run_transition(VideoTransitionMode.slide_in)
+        effects.slidein_transition.assert_called_once()
+
+    def test_slide_out_calls_correct_effect(self):
+        """Bug fix: slide_out was previously silently ignored."""
+        effects = self._run_transition(VideoTransitionMode.slide_out)
+        effects.slideout_transition.assert_called_once()
+
+    def test_zoom_in_calls_correct_effect(self):
+        effects = self._run_transition(VideoTransitionMode.zoom_in)
+        effects.zoomin_transition.assert_called_once()
+
+    def test_zoom_out_calls_correct_effect(self):
+        """Bug fix: zoom_out was previously silently ignored."""
+        effects = self._run_transition(VideoTransitionMode.zoom_out)
+        effects.zoomout_transition.assert_called_once()
+
+    def test_shuffle_picks_from_all_transition_types(self):
+        """Shuffle should randomly pick from ALL 6 transition types (in + out)."""
+        seen = set()
+        fake_clip = types.SimpleNamespace(duration=5.0)
+
+        for _ in range(100):
+            with patch.object(vd, "_open_video_clip_quietly", return_value=fake_clip):
+                with patch("app.services.video.video_effects") as mock_effects:
+                    called = []
+                    for name in (
+                        "fadein_transition", "fadeout_transition",
+                        "slidein_transition", "slideout_transition",
+                        "zoomin_transition", "zoomout_transition",
+                    ):
+                        def make_tracker(n):
+                            def tracker(*a, **kw):
+                                called.append(n)
+                                return fake_clip
+                            return tracker
+                        setattr(mock_effects, name, make_tracker(name))
+                    with patch.object(vd, "_write_videofile_with_codec_fallback"):
+                        with patch.object(vd, "close_clip"):
+                            vd._apply_scene_transition(
+                                "input.mp4", "output.mp4", VideoTransitionMode.shuffle
+                            )
+                    self.assertEqual(len(called), 1)
+                    seen.add(called[0])
+        # After 100 runs, we should have seen at least 3 different transition types
+        self.assertGreaterEqual(len(seen), 3, f"Only saw transitions: {seen}")
+
+    def test_zero_duration_clip_returns_early(self):
+        """Clips with zero duration should not be processed."""
+        fake_clip = types.SimpleNamespace(duration=0.0)
+        with patch.object(vd, "_open_video_clip_quietly", return_value=fake_clip):
+            with patch.object(vd, "_write_videofile_with_codec_fallback") as write_mock:
+                with patch.object(vd, "close_clip"):
+                    vd._apply_scene_transition(
+                        "input.mp4", "output.mp4", VideoTransitionMode.fade_in
+                    )
+        write_mock.assert_not_called()
+
+    def test_unsupported_transition_returns_without_writing(self):
+        """Unknown transition values should log a warning and not write output."""
+        fake_clip = types.SimpleNamespace(duration=5.0)
+        with patch.object(vd, "_open_video_clip_quietly", return_value=fake_clip):
+            with patch.object(vd, "_write_videofile_with_codec_fallback") as write_mock:
+                with patch.object(vd, "close_clip"):
+                    vd._apply_scene_transition(
+                        "input.mp4", "output.mp4", "UnknownTransition"
+                    )
+        write_mock.assert_not_called()
+
+
+class TestConcatSceneVideosWithTransitions(unittest.TestCase):
+    """Tests for concat_scene_videos_with_transitions() in video.py.
+
+    Uses fully mocked ffmpeg and file operations.
+    """
+
+    def test_empty_paths_returns_without_error(self):
+        """Empty input should not crash."""
+        with patch.object(vd, "concat_video_clips_with_ffmpeg") as concat_mock:
+            vd.concat_scene_videos_with_transitions(
+                scene_video_paths=[], output_file="/fake/output.mp4"
+            )
+        concat_mock.assert_not_called()
+
+    def test_single_scene_concatenates(self):
+        """Single scene should be concatenated without transitions."""
+        mock_clip = _mock_clip()
+        with patch("app.services.video.os.makedirs"):
+            with patch.object(vd, "_open_video_clip_quietly", return_value=mock_clip):
+                with patch("app.services.video.concatenate_videoclips") as concat_mock:
+                    concat_mock.return_value = mock_clip
+                    with patch.object(vd, "_write_videofile_with_codec_fallback"):
+                        vd.concat_scene_videos_with_transitions(
+                            scene_video_paths=["scene1.mp4"],
+                            output_file="/fake/output.mp4",
+                        )
+        concat_mock.assert_called_once()
+
+    def test_multi_scene_without_transitions(self):
+        """Multiple scenes without transitions should all be passed directly."""
+        mock_clip = _mock_clip()
+        scenes = ["scene1.mp4", "scene2.mp4", "scene3.mp4"]
+        with patch("app.services.video.os.makedirs"):
+            with patch.object(vd, "_open_video_clip_quietly", return_value=mock_clip):
+                with patch("app.services.video.concatenate_videoclips") as concat_mock:
+                    concat_mock.return_value = mock_clip
+                    with patch.object(vd, "_write_videofile_with_codec_fallback"):
+                        vd.concat_scene_videos_with_transitions(
+                            scene_video_paths=scenes,
+                            output_file="/fake/output.mp4",
+                        )
+        concat_mock.assert_called_once()
+        # Should have 3 clips
+        call_args = concat_mock.call_args[0][0]
+        self.assertEqual(len(call_args), 3)
+
+    def test_transitions_applied_to_non_first_scenes(self):
+        """Transitions should be applied inline to scene clips 2+."""
+        mock_clip = _mock_clip()
+        scenes = ["s1.mp4", "s2.mp4", "s3.mp4"]
+        transitions = [
+            None,
+            VideoTransitionMode.fade_in,
+            VideoTransitionMode.slide_in,
+        ]
+        with patch("app.services.video.os.makedirs"):
+            with patch.object(vd, "_open_video_clip_quietly", return_value=mock_clip):
+                with patch("app.services.video.video_effects") as mock_effects:
+                    mock_effects.fadein_transition.return_value = mock_clip
+                    mock_effects.slidein_transition.return_value = mock_clip
+                    with patch("app.services.video.concatenate_videoclips") as concat_mock:
+                        concat_mock.return_value = mock_clip
+                        with patch.object(vd, "_write_videofile_with_codec_fallback"):
+                            vd.concat_scene_videos_with_transitions(
+                                scene_video_paths=scenes,
+                                output_file="/fake/output.mp4",
+                                scene_transitions=transitions,
+                            )
+        mock_effects.fadein_transition.assert_called_once()
+        mock_effects.slidein_transition.assert_called_once()
+
+    def test_transition_failure_falls_back_to_original(self):
+        """If _open_video_clip_quietly returns a clip, transitions apply inline."""
+        mock_clip = _mock_clip()
+        scenes = ["s1.mp4", "s2.mp4"]
+        transitions = [None, VideoTransitionMode.fade_in]
+
+        with patch("app.services.video.os.makedirs"):
+            with patch.object(vd, "_open_video_clip_quietly", return_value=mock_clip):
+                with patch("app.services.video.video_effects") as mock_effects:
+                    # fadein returns a clip (succeeds)
+                    mock_effects.fadein_transition.return_value = mock_clip
+                    with patch("app.services.video.concatenate_videoclips") as concat_mock:
+                        concat_mock.return_value = mock_clip
+                        with patch.object(vd, "_write_videofile_with_codec_fallback"):
+                            vd.concat_scene_videos_with_transitions(
+                                scene_video_paths=scenes,
+                                output_file="/fake/output.mp4",
+                                scene_transitions=transitions,
+                            )
+        # concatenate should receive 2 clips
+        call_args = concat_mock.call_args[0][0]
+        self.assertEqual(len(call_args), 2)
+
+    def test_bgm_overlay_called_when_enabled(self):
+        """BGM should be overlaid when bgm_file_override is a file path."""
+        mock_clip = _mock_clip()
+        mock_clip.audio = MagicMock()
+
+        with patch("app.services.video.os.makedirs"):
+            with patch("app.services.video.os.path.isfile", return_value=True):
+                with patch.object(vd, "_open_video_clip_quietly", return_value=mock_clip):
+                    with patch("app.services.video.concatenate_videoclips") as concat_mock:
+                        concat_mock.return_value = mock_clip
+                        with patch("app.services.video.AudioFileClip") as mock_audio:
+                            mock_audio.return_value.__enter__ = MagicMock(return_value=MagicMock())
+                            mock_audio.return_value.__exit__ = MagicMock(return_value=False)
+                            with patch("app.services.video.CompositeAudioClip", return_value=MagicMock()):
+                                with patch.object(vd, "_write_videofile_with_codec_fallback"):
+                                    vd.concat_scene_videos_with_transitions(
+                                        scene_video_paths=["s1.mp4"],
+                                        output_file="/fake/output.mp4",
+                                        bgm_file_override="/fake/bgm.mp3",
+                                        bgm_volume=0.3,
+                                    )
+        # AudioFileClip should be called with the bgm file
+        mock_audio.assert_called_once_with("/fake/bgm.mp3")
+
+    def test_bgm_not_overlayed_when_volume_zero(self):
+        """BGM should NOT be overlaid when volume is 0."""
+        mock_clip = _mock_clip()
+        mock_clip.audio = MagicMock()
+
+        with patch("app.services.video.os.makedirs"):
+            with patch.object(vd, "_open_video_clip_quietly", return_value=mock_clip):
+                with patch("app.services.video.concatenate_videoclips") as concat_mock:
+                    concat_mock.return_value = mock_clip
+                    with patch("app.services.video.AudioFileClip") as mock_audio:
+                        with patch.object(vd, "_write_videofile_with_codec_fallback"):
+                            vd.concat_scene_videos_with_transitions(
+                                scene_video_paths=["s1.mp4"],
+                                output_file="/fake/output.mp4",
+                                bgm_file_override="/fake/bgm.mp3",
+                                bgm_volume=0.0,
+                            )
+        # AudioFileClip should NOT be called (no BGM)
+        mock_audio.assert_not_called()
+
+    def test_bgm_not_overlayed_when_file_missing(self):
+        """BGM should NOT be overlaid when the bgm file doesn't exist."""
+        mock_clip = _mock_clip()
+        mock_clip.audio = MagicMock()
+
+        with patch("app.services.video.os.makedirs"):
+            with patch.object(vd, "_open_video_clip_quietly", return_value=mock_clip):
+                with patch("app.services.video.concatenate_videoclips") as concat_mock:
+                    concat_mock.return_value = mock_clip
+                    with patch("app.services.video.os.path.isfile", return_value=False):
+                        with patch("app.services.video.AudioFileClip") as mock_audio:
+                            with patch.object(vd, "_write_videofile_with_codec_fallback"):
+                                vd.concat_scene_videos_with_transitions(
+                                    scene_video_paths=["s1.mp4"],
+                                    output_file="/fake/output.mp4",
+                                    bgm_file_override="/nonexistent/bgm.mp3",
+                                    bgm_volume=0.3,
+                                )
+        mock_audio.assert_not_called()
+
+    def test_bgm_resolves_from_type_when_override_none(self):
+        """When bgm_file_override=None, BGM should be resolved from bgm_type."""
+        mock_clip = _mock_clip()
+        mock_clip.audio = MagicMock()
+
+        with patch("app.services.video.os.makedirs"):
+            with patch("app.services.video.os.path.isfile", return_value=True):
+                with patch.object(vd, "_open_video_clip_quietly", return_value=mock_clip):
+                    with patch("app.services.video.concatenate_videoclips") as concat_mock:
+                        concat_mock.return_value = mock_clip
+                        with patch("app.services.video.get_bgm_file", return_value="/bgm/random.mp3"):
+                            with patch("app.services.video.bgm_service") as mock_bgm:
+                                mock_bgm.should_use_bgm.return_value = True
+                                with patch("app.services.video.AudioFileClip") as mock_audio:
+                                    mock_audio.return_value.__enter__ = MagicMock(return_value=MagicMock())
+                                    mock_audio.return_value.__exit__ = MagicMock(return_value=False)
+                                    with patch("app.services.video.CompositeAudioClip", return_value=MagicMock()):
+                                        with patch.object(vd, "_write_videofile_with_codec_fallback"):
+                                            vd.concat_scene_videos_with_transitions(
+                                                scene_video_paths=["s1.mp4"],
+                                                output_file="/fake/output.mp4",
+                                                bgm_file_override=None,
+                                                bgm_type="random",
+                                                bgm_volume=0.3,
+                                            )
+        mock_audio.assert_called_once_with("/bgm/random.mp3")
+
+
+class TestOverlayBgmOnVideo(unittest.TestCase):
+    """Tests for _overlay_bgm_on_video() in video.py.
+
+    Uses MoviePy CompositeAudioClip — same approach as generate_video().
+    """
+
+    def test_mixes_bgm_with_video_audio(self):
+        """Should create a CompositeAudioClip from video audio + BGM."""
+        mock_video_audio = MagicMock()
+        mock_video_clip = MagicMock()
+        mock_video_clip.audio = mock_video_audio
+        mock_video_clip.duration = 10.0
+
+        mock_bgm_clip = MagicMock()
+        mock_mixed = MagicMock()
+        mock_mixed.fps = 44100
+        mock_final = MagicMock()
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(
+                vd, "_open_video_clip_quietly", return_value=mock_video_clip
+            ))
+            mock_audio_class = stack.enter_context(patch.object(vd, "AudioFileClip"))
+            mock_audio_class.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_audio_class.return_value.__exit__ = MagicMock(return_value=False)
+            mock_audio_class.return_value.with_effects.return_value = mock_bgm_clip
+
+            stack.enter_context(patch.object(vd, "CompositeAudioClip", return_value=MagicMock()))
+            mock_video_clip.with_audio.return_value = mock_final
+            mock_final.with_effects = MagicMock(return_value=mock_final)
+
+            # Patch CompositeAudioClip at call site
+            with patch("app.services.video.CompositeAudioClip") as mock_composite:
+                mock_composite.return_value = mock_mixed
+                with patch.object(vd, "_write_videofile_with_codec_fallback"):
+                    with patch.object(vd, "_open_video_clip_quietly", return_value=mock_video_clip):
+                        vd._overlay_bgm_on_video(
+                            video_path="video.mp4",
+                            bgm_file="bgm.mp3",
+                            bgm_volume=0.4,
+                            output_path="output.mp4",
+                        )
+        # Verify CompositeAudioClip was used (MoviePy approach, not raw ffmpeg)
+        mock_composite.assert_called_once()
+
+    def test_bgm_effects_include_volume_fadeout_and_loop(self):
+        """BGM should have volume, fadeout, and loop effects."""
+        mock_video_clip = MagicMock()
+        mock_video_clip.audio = MagicMock()
+        mock_video_clip.duration = 10.0
+
+        with patch.object(vd, "_open_video_clip_quietly", return_value=mock_video_clip):
+            with patch("app.services.video.AudioFileClip") as mock_audio:
+                mock_bgm_source = MagicMock()
+                mock_audio.return_value.__enter__ = MagicMock(return_value=mock_bgm_source)
+                mock_audio.return_value.__exit__ = MagicMock(return_value=False)
+                mock_bgm_source.with_effects.return_value = MagicMock()
+                with patch("app.services.video.CompositeAudioClip", return_value=MagicMock()):
+                    mock_video_clip.with_audio.return_value = MagicMock()
+                    with patch.object(vd, "_write_videofile_with_codec_fallback"):
+                        vd._overlay_bgm_on_video(
+                            video_path="video.mp4",
+                            bgm_file="bgm.mp3",
+                            bgm_volume=0.3,
+                            output_path="output.mp4",
+                        )
+        # Verify with_effects was called with a list containing 3 effects
+        effect_call = mock_bgm_source.with_effects.call_args[0][0]
+        self.assertEqual(len(effect_call), 3)  # volume, fadeout, loop
+
+
+class TestScenePipelineFailureModes(unittest.TestCase):
+    """Tests for scene failure handling logic."""
+
+    def test_partial_failure_filters_none_paths(self):
+        """When some scenes return None, only valid paths should be used."""
+        scene_paths = ["/valid/scene1.mp4", None, "/valid/scene3.mp4"]
+        valid_paths = [p for p in scene_paths if p]
+        self.assertEqual(valid_paths, ["/valid/scene1.mp4", "/valid/scene3.mp4"])
+
+    def test_all_scenes_none_yields_empty_list(self):
+        """When all scene videos are None, valid paths list is empty."""
+        scene_paths = [None, None, None]
+        valid_paths = [p for p in scene_paths if p]
+        self.assertEqual(len(valid_paths), 0)
+
+    def test_single_scene_success(self):
+        """Single successful scene should be in valid paths."""
+        scene_paths = ["/valid/scene1.mp4"]
+        valid_paths = [p for p in scene_paths if p]
+        self.assertEqual(len(valid_paths), 1)
+
+    def test_transition_list_shorter_than_scenes(self):
+        """When transition list is shorter than scenes, missing entries use None."""
+        scene_transitions = [None, VideoTransitionMode.fade_in]
+        # Scene 3 has index 2, which is >= len(scene_transitions)
+        transition = (
+            scene_transitions[3]
+            if scene_transitions and 3 < len(scene_transitions)
+            else None
+        )
+        self.assertIsNone(transition)
+
+
+class TestGenerateSceneScripts(unittest.TestCase):
+    """Tests for llm.generate_scene_scripts() JSON parsing and recovery."""
+
+    def _mock_generate(self, response_text):
+        """Helper: mock _generate_response to return response_text."""
+        with patch.object(tm.llm, "_generate_response", return_value=response_text):
+            return tm.llm.generate_scene_scripts(
+                video_subject="test subject",
+                scene_count=2,
+            )
+
+    def test_parses_valid_json(self):
+        response = '{"scenes": [{"scene_id": 1, "script": "Hello"}, {"scene_id": 2, "script": "World"}]}'
+        result = self._mock_generate(response)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["scene_id"], 1)
+        self.assertEqual(result[0]["script"], "Hello")
+        self.assertEqual(result[1]["script"], "World")
+
+    def test_strips_code_fence(self):
+        response = '```json\n{"scenes": [{"scene_id": 1, "script": "Test"}]}\n```'
+        result = self._mock_generate(response)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["script"], "Test")
+
+    def test_returns_empty_on_empty_response(self):
+        result = self._mock_generate("")
+        self.assertEqual(result, [])
+
+    def test_returns_empty_on_invalid_json(self):
+        result = self._mock_generate("not json at all")
+        self.assertEqual(result, [])
+
+    def test_recovers_json_from_text(self):
+        """Should recover JSON embedded in surrounding text."""
+        response = 'Here is the result: {"scenes": [{"scene_id": 1, "script": "OK"}]} hope this helps'
+        result = self._mock_generate(response)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["script"], "OK")
+
+    def test_skips_scenes_with_empty_script(self):
+        response = '{"scenes": [{"scene_id": 1, "script": "Good"}, {"scene_id": 2, "script": ""}]}'
+        result = self._mock_generate(response)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["script"], "Good")
+
+    def test_normalizes_scene_count(self):
+        """Should clamp scene_count to MIN/MAX range."""
+        self.assertEqual(tm.llm._normalize_scene_count(0), 2)
+        self.assertEqual(tm.llm._normalize_scene_count(15), 10)
+        self.assertEqual(tm.llm._normalize_scene_count(5), 5)
+        self.assertEqual(tm.llm._normalize_scene_count(None), 2)
+
+
+class TestGenerateSceneKeywords(unittest.TestCase):
+    """Tests for llm.generate_scene_keywords() JSON parsing."""
+
+    def _mock_generate(self, response_text, scene_scripts=None):
+        if scene_scripts is None:
+            scene_scripts = [
+                {"scene_id": 1, "script": "Hello world"},
+                {"scene_id": 2, "script": "Goodbye world"},
+            ]
+        with patch.object(tm.llm, "_generate_response", return_value=response_text):
+            return tm.llm.generate_scene_keywords(
+                video_subject="test",
+                scene_scripts=scene_scripts,
+                scene_count=len(scene_scripts),
+            )
+
+    def test_parses_valid_json(self):
+        response = '{"scenes": [{"scene_id": 1, "terms": ["greeting", "hello"]}, {"scene_id": 2, "terms": ["farewell"]}]}'
+        result = self._mock_generate(response)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["scene_id"], 1)
+        self.assertEqual(result[0]["terms"], ["greeting", "hello"])
+        self.assertEqual(result[1]["terms"], ["farewell"])
+
+    def test_returns_empty_on_empty_response(self):
+        result = self._mock_generate("")
+        self.assertEqual(result, [])
+
+    def test_returns_empty_when_no_scripts_provided(self):
+        result = tm.llm.generate_scene_keywords(
+            video_subject="test",
+            scene_scripts=[],
+            scene_count=0,
+        )
+        self.assertEqual(result, [])
+
+    def test_skips_scenes_with_empty_terms(self):
+        response = '{"scenes": [{"scene_id": 1, "terms": ["ok"]}, {"scene_id": 2, "terms": []}]}'
+        result = self._mock_generate(response)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["terms"], ["ok"])
+
+
+class TestBuildParamsScenes(unittest.TestCase):
+    """Tests for the UI logic that assembles params.scenes from session state."""
+
+    def _build_params_from_scripts(self, scripts, keywords=None):
+        """Simulate _build_params_scenes logic without Streamlit."""
+        from app.models.schema import SceneConfig
+        if keywords is None:
+            keywords = [""] * len(scripts)
+        scenes = []
+        for i, script in enumerate(scripts):
+            if not script.strip():
+                continue
+            terms_raw = keywords[i] if i < len(keywords) else ""
+            search_terms = (
+                [t.strip() for t in terms_raw.split(",") if t.strip()]
+                if terms_raw.strip() else None
+            )
+            scene = SceneConfig(
+                scene_id=i + 1,
+                script=script.strip(),
+                search_terms=search_terms,
+            )
+            scenes.append(scene)
+        return scenes if len(scenes) >= 2 else None
+
+    def test_two_valid_scripts_produces_scenes(self):
+        scenes = self._build_params_from_scripts(["Script 1", "Script 2"])
+        self.assertIsNotNone(scenes)
+        self.assertEqual(len(scenes), 2)
+        self.assertEqual(scenes[0].script, "Script 1")
+        self.assertEqual(scenes[1].script, "Script 2")
+
+    def test_one_valid_script_returns_none(self):
+        """Below 2 scenes should return None to avoid pipeline errors."""
+        scenes = self._build_params_from_scripts(["Only one", ""])
+        self.assertIsNone(scenes)
+
+    def test_empty_scripts_returns_none(self):
+        scenes = self._build_params_from_scripts(["", ""])
+        self.assertIsNone(scenes)
+
+    def test_keywords_are_parsed(self):
+        scenes = self._build_params_from_scripts(
+            ["S1", "S2"],
+            keywords=["cat, dog", "sun, moon, star"]
+        )
+        self.assertEqual(scenes[0].search_terms, ["cat", "dog"])
+        self.assertEqual(scenes[1].search_terms, ["sun", "moon", "star"])
+
+    def test_empty_keywords_gives_none(self):
+        scenes = self._build_params_from_scripts(["S1", "S2"], keywords=["", ""])
+        self.assertIsNone(scenes[0].search_terms)
+
+    def test_scene_ids_are_one_based(self):
+        scenes = self._build_params_from_scripts(["S1", "S2", "S3"])
+        self.assertEqual(scenes[0].scene_id, 1)
+        self.assertEqual(scenes[1].scene_id, 2)
+        self.assertEqual(scenes[2].scene_id, 3)
+
+
+class TestConcatBgmExplicitDisable(unittest.TestCase):
+    """Verify that bgm_file_override='' explicitly disables BGM."""
+
+    def test_empty_string_override_no_bgm(self):
+        mock_clip = _mock_clip()
+        audio_mock = MagicMock()
+        with patch("app.services.video.os.makedirs"):
+            with patch.object(vd, "_open_video_clip_quietly", return_value=mock_clip):
+                with patch("app.services.video.concatenate_videoclips") as concat_mock:
+                    concat_mock.return_value = mock_clip
+                    with patch("app.services.video.AudioFileClip") as mock_audio:
+                        with patch("app.services.video.CompositeAudioClip"):
+                            with patch.object(vd, "_write_videofile_with_codec_fallback"):
+                                vd.concat_scene_videos_with_transitions(
+                                    scene_video_paths=["s1.mp4"],
+                                    output_file="/fake/output.mp4",
+                                    bgm_file_override="",
+                                    bgm_type="random",
+                                    bgm_volume=0.5,
+                                )
+        # Should NOT load any BGM file
+        mock_audio.assert_not_called()
+
+
+def _generate_test_video(output_path, duration=2, color="red", size="320x240"):
+    """Generate a short test video using MoviePy."""
+    from moviepy import ColorClip
+    color_map = {"red": (255, 0, 0), "green": (0, 255, 0), "blue": (0, 0, 255)}
+    rgb = color_map.get(color, (128, 128, 128))
+    w, h = (int(x) for x in size.split("x"))
+    clip = ColorClip(size=(w, h), color=rgb, duration=duration)
+    clip.write_videofile(output_path, fps=24, codec="libx264", logger=None)
+    clip.close()
+    return os.path.isfile(output_path)
+
+
+def _generate_test_audio(output_path, duration=3):
+    """Generate a short silent MP3 audio file using ffmpeg."""
+    import subprocess
+    from app.utils import utils
+    ffmpeg = utils.get_ffmpeg_binary()
+    result = subprocess.run(
+        [
+            ffmpeg, "-y", "-f", "lavfi",
+            "-i", "anullsrc=r=44100:cl=mono",
+            "-t", str(duration),
+            "-c:a", "libmp3lame", "-b:a", "64k",
+            output_path,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0 and os.path.isfile(output_path)
+
+
+def _write_test_srt(output_path, duration=2):
+    """Write a minimal SRT subtitle file."""
+    content = (
+        "1\n"
+        f"00:00:00,000 --> 00:00:{duration:02d},000\n"
+        "Test subtitle\n"
+        "\n"
+    )
+    Path(output_path).write_text(content, encoding="utf-8")
+
+
+class TestScenePipelineEndToEnd(unittest.TestCase):
+    """End-to-end scene pipeline test with mocked external services.
+
+    Uses real ffmpeg for video/audio processing. Mocks only TTS, LLM,
+    and material download (external APIs). Runs in CI without API keys.
+    """
+
+    def setUp(self):
+        # Use project storage dir for temp files (sandbox-safe)
+        from app.utils import utils
+        self.tmp_dir = utils.storage_dir("test_e2e_clips", create=True)
+        self.task_id = f"e2e-test-{os.getpid()}"
+        # Generate test video clips (2 seconds each, different colors)
+        self.clip1 = os.path.join(self.tmp_dir, "clip1.mp4")
+        self.clip2 = os.path.join(self.tmp_dir, "clip2.mp4")
+        self.clip3 = os.path.join(self.tmp_dir, "clip3.mp4")
+        _generate_test_video(self.clip1, duration=2, color="red")
+        _generate_test_video(self.clip2, duration=2, color="green")
+        _generate_test_video(self.clip3, duration=2, color="blue")
+
+    def tearDown(self):
+        for f in (self.clip1, self.clip2, self.clip3):
+            if os.path.isfile(f):
+                os.remove(f)
+
+    def _make_tts_mock(self, audio_file, duration=3):
+        """Create a mock for voice.tts that generates a real audio file."""
+        def fake_tts(text, voice_name, voice_rate, voice_file, voice_volume=1.0):
+            _generate_test_audio(voice_file, duration=duration)
+            sub_maker = MagicMock()
+            sub_maker.subs = []
+            return sub_maker
+        return fake_tts
+
+    def _make_subtitle_mock(self, subtitle_file, duration=3):
+        """Create a mock for voice.create_subtitle that writes a real SRT."""
+        def fake_create_subtitle(text, sub_maker, subtitle_file):
+            _write_test_srt(subtitle_file, duration=duration)
+        return fake_create_subtitle
+
+    def test_two_scenes_pipeline(self):
+        """Full pipeline: 2 scenes → TTS → materials → combine → concat."""
+        params = VideoParams(
+            video_subject="test",
+            scenes=[
+                SceneConfig(scene_id=1, script="First scene script", search_terms=["nature"]),
+                SceneConfig(scene_id=2, script="Second scene script", search_terms=["city"]),
+            ],
+            video_source="pexels",
+            video_aspect="16:9",
+            video_concat_mode=VideoConcatMode.sequential,
+            video_clip_duration=3,
+            voice_name="test-voice",
+            voice_volume=1.0,
+            voice_rate=1.0,
+            subtitle_enabled=True,
+            bgm_type="none",
+            bgm_volume=0.0,
+            n_threads=2,
+        )
+
+        with patch.object(tm.sm, "state", MagicMock()):
+            with patch.object(tm.voice, "tts", side_effect=self._make_tts_mock("audio.mp3")):
+                with patch.object(tm.voice, "create_subtitle", side_effect=self._make_subtitle_mock("sub.srt")):
+                    with patch.object(
+                        tm.material, "download_videos",
+                        return_value=[self.clip1, self.clip2],
+                    ):
+                        with patch.object(tm.llm, "generate_terms", return_value=["term1"]):
+                            # Process each scene
+                            scene_videos = []
+                            for i, scene in enumerate(params.scenes):
+                                result = tm._generate_single_scene(
+                                    task_id=self.task_id,
+                                    scene=scene,
+                                    params=params,
+                                    scene_index=i + 1,
+                                )
+                                if result:
+                                    scene_videos.append(result)
+
+        self.assertEqual(len(scene_videos), 2, "Both scenes should produce videos")
+        for sv in scene_videos:
+            self.assertTrue(os.path.isfile(sv), f"Scene video should exist: {sv}")
+
+        # Concatenate scenes
+        final_path = os.path.join(self.tmp_dir, "final_e2e.mp4")
+        vd.concat_scene_videos_with_transitions(
+            scene_video_paths=scene_videos,
+            output_file=final_path,
+            scene_transitions=[None, None],
+            bgm_file_override="",
+            bgm_volume=0.0,
+        )
+        self.assertTrue(os.path.isfile(final_path), "Final video should exist")
+
+    def test_three_scenes_with_transitions(self):
+        """3 scenes with fade-in transitions between them."""
+        params = VideoParams(
+            video_subject="test",
+            scenes=[
+                SceneConfig(scene_id=1, script="Scene one"),
+                SceneConfig(scene_id=2, script="Scene two"),
+                SceneConfig(scene_id=3, script="Scene three"),
+            ],
+            video_source="pexels",
+            video_aspect="16:9",
+            video_concat_mode=VideoConcatMode.sequential,
+            video_clip_duration=3,
+            voice_name="test-voice",
+            voice_volume=1.0,
+            voice_rate=1.0,
+            subtitle_enabled=False,
+            bgm_type="none",
+            bgm_volume=0.0,
+            n_threads=2,
+        )
+
+        with patch.object(tm.sm, "state", MagicMock()):
+            with patch.object(tm.voice, "tts", side_effect=self._make_tts_mock("audio.mp3")):
+                with patch.object(
+                    tm.material, "download_videos",
+                    return_value=[self.clip1, self.clip2, self.clip3],
+                ):
+                    with patch.object(tm.llm, "generate_terms", return_value=["term"]):
+                        scene_videos = []
+                        for i, scene in enumerate(params.scenes):
+                            result = tm._generate_single_scene(
+                                task_id=self.task_id,
+                                scene=scene,
+                                params=params,
+                                scene_index=i + 1,
+                            )
+                            if result:
+                                scene_videos.append(result)
+
+        self.assertEqual(len(scene_videos), 3)
+
+        final_path = os.path.join(self.tmp_dir, "final_e2e_transitions.mp4")
+        transitions = [
+            None,
+            VideoTransitionMode.fade_in,
+            VideoTransitionMode.fade_in,
+        ]
+        vd.concat_scene_videos_with_transitions(
+            scene_video_paths=scene_videos,
+            output_file=final_path,
+            scene_transitions=transitions,
+            bgm_file_override="",
+            bgm_volume=0.0,
+        )
+        self.assertTrue(os.path.isfile(final_path))
+
+    def test_scene_failure_skips_and_continues(self):
+        """When one scene fails, the other should still produce output."""
+        params = VideoParams(
+            video_subject="test",
+            scenes=[
+                SceneConfig(scene_id=1, script="Good scene"),
+                SceneConfig(scene_id=2, script=""),  # Empty script → fails
+            ],
+            video_source="pexels",
+            video_aspect="16:9",
+            video_concat_mode=VideoConcatMode.sequential,
+            voice_name="test-voice",
+            voice_volume=1.0,
+            voice_rate=1.0,
+            subtitle_enabled=False,
+            bgm_type="none",
+            bgm_volume=0.0,
+            n_threads=2,
+        )
+
+        with patch.object(tm.sm, "state", MagicMock()):
+            with patch.object(tm.voice, "tts", side_effect=self._make_tts_mock("audio.mp3")):
+                with patch.object(
+                    tm.material, "download_videos",
+                    return_value=[self.clip1],
+                ):
+                    with patch.object(tm.llm, "generate_terms", return_value=["term"]):
+                        scene_videos = []
+                        for i, scene in enumerate(params.scenes):
+                            result = tm._generate_single_scene(
+                                task_id=self.task_id,
+                                scene=scene,
+                                params=params,
+                                scene_index=i + 1,
+                            )
+                            scene_videos.append(result)
+
+        # Scene 1 succeeds, scene 2 fails (empty script)
+        self.assertIsNotNone(scene_videos[0])
+        self.assertIsNone(scene_videos[1])
+
+        # Only the successful scene should be in final paths
+        valid = [v for v in scene_videos if v]
+        self.assertEqual(len(valid), 1)
+
+
+RUN_INTEGRATION_TESTS = os.environ.get("MPT_RUN_INTEGRATION_TESTS", "").lower() in {
+    "1", "true", "yes",
+}
+
+
+class TestScenePipelineIntegration(unittest.TestCase):
+    """Full integration test with real TTS and ffmpeg.
+
+    Skipped in CI. Run locally with:
+        MPT_RUN_INTEGRATION_TESTS=1 python -m unittest test.services.test_scene_pipeline.TestScenePipelineIntegration
+    """
+
+    @unittest.skipUnless(
+        RUN_INTEGRATION_TESTS,
+        "MPT_RUN_INTEGRATION_TESTS not set",
+    )
+    def test_scene_pipeline_with_local_materials(self):
+        """Full scene pipeline: real TTS + local PNG materials + real ffmpeg."""
+        resources_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "resources")
+        task_id = f"scene-integration-{os.getpid()}"
+
+        # Build scene materials from PNG images (same as test_task_local_materials)
+        scene1_materials = [
+            MaterialInfo(provider="local", url=os.path.join(resources_dir, "1.png")),
+            MaterialInfo(provider="local", url=os.path.join(resources_dir, "2.png")),
+        ]
+        scene2_materials = [
+            MaterialInfo(provider="local", url=os.path.join(resources_dir, "3.png")),
+            MaterialInfo(provider="local", url=os.path.join(resources_dir, "4.png")),
+        ]
+
+        params = VideoParams(
+            video_subject="The importance of money",
+            scenes=[
+                SceneConfig(
+                    scene_id=1,
+                    script="Money is not just a medium of exchange. It is a tool for allocating social resources.",
+                    materials=scene1_materials,
+                ),
+                SceneConfig(
+                    scene_id=2,
+                    script="However, money has its limits. It cannot directly buy happiness or genuine relationships.",
+                    materials=scene2_materials,
+                ),
+            ],
+            video_aspect="9:16",
+            video_concat_mode=VideoConcatMode.sequential,
+            video_clip_duration=3,
+            video_source="local",
+            voice_name="zh-CN-XiaoxiaoNeural-Female",
+            voice_volume=1.0,
+            voice_rate=1.0,
+            bgm_type="random",
+            bgm_volume=0.2,
+            subtitle_enabled=True,
+            subtitle_position="bottom",
+            font_name="MicrosoftYaHeiBold.ttc",
+            text_fore_color="#FFFFFF",
+            text_background_color=True,
+            font_size=60,
+            stroke_color="#000000",
+            stroke_width=1.5,
+            n_threads=2,
+        )
+
+        result = tm.start(task_id=task_id, params=params)
+        print(f"Integration test result: {result}")
+        self.assertNotEqual(result.get("state"), "failed", f"Task failed: {result.get('error')}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/services/test_scene_pipeline.py
+++ b/test/services/test_scene_pipeline.py
@@ -1396,6 +1396,194 @@ class TestScenePipelineEndToEnd(unittest.TestCase):
         self.assertEqual(len(valid), 1)
 
 
+class TestScenePipelineFullFlow(unittest.TestCase):
+    """Full pipeline e2e tests via tm.start() with mocked external services.
+
+    Tests the complete orchestration: _run_pipeline → generate_scenes →
+    _generate_single_scene (×N) → concat_scene_videos_with_transitions.
+    Uses real ffmpeg/MoviePy, mocks only TTS/LLM/material APIs.
+    """
+
+    def setUp(self):
+        from app.utils import utils
+        self.tmp_dir = utils.storage_dir("test_e2e_fullflow", create=True)
+        self.task_id = f"fullflow-{os.getpid()}"
+        self.clip1 = os.path.join(self.tmp_dir, "fl_clip1.mp4")
+        self.clip2 = os.path.join(self.tmp_dir, "fl_clip2.mp4")
+        _generate_test_video(self.clip1, duration=2, color="red")
+        _generate_test_video(self.clip2, duration=2, color="blue")
+
+    def tearDown(self):
+        for f in (self.clip1, self.clip2):
+            if os.path.isfile(f):
+                os.remove(f)
+
+    def _mock_tts(self, audio_file, duration=3):
+        def fake_tts(text, voice_name, voice_rate, voice_file):
+            _generate_test_audio(voice_file, duration=duration)
+            sub_maker = MagicMock()
+            sub_maker.subs = []
+            return sub_maker
+        return fake_tts
+
+    def test_full_pipeline_two_scenes(self):
+        """tm.start() with 2 scenes: full orchestration from start to final video."""
+        params = VideoParams(
+            video_subject="test subject",
+            scenes=[
+                SceneConfig(scene_id=1, script="First scene narration", search_terms=["nature"]),
+                SceneConfig(scene_id=2, script="Second scene narration", search_terms=["city"]),
+            ],
+            video_source="pexels",
+            video_aspect="16:9",
+            video_concat_mode=VideoConcatMode.sequential,
+            video_clip_duration=3,
+            voice_name="test-voice",
+            voice_volume=1.0,
+            voice_rate=1.0,
+            subtitle_enabled=False,
+            bgm_type="none",
+            bgm_volume=0.0,
+            n_threads=2,
+        )
+
+        state = MagicMock()
+        with patch.object(tm.sm, "state", state):
+            with patch.object(tm.voice, "tts", side_effect=self._mock_tts("audio.mp3")):
+                with patch.object(
+                    tm.material, "download_videos",
+                    return_value=[self.clip1, self.clip2],
+                ):
+                    with patch.object(tm.llm, "generate_terms", return_value=["term"]):
+                        result = tm.start(task_id=self.task_id, params=params)
+
+        # Task should succeed
+        self.assertNotEqual(
+            result.get("state"), -1,
+            f"Task failed: {result.get('error')}"
+        )
+        # Should have produced a final video
+        final_path = os.path.join(
+            os.path.dirname(self.clip1), "..", "tasks", self.task_id, "final-1.mp4"
+        )
+        # Check via the task directory
+        from app.utils import utils
+        task_dir = utils.task_dir(self.task_id)
+        final_video = os.path.join(task_dir, "final-1.mp4")
+        self.assertTrue(
+            os.path.isfile(final_video),
+            f"Final video should exist at {final_video}"
+        )
+
+    def test_full_pipeline_with_transitions(self):
+        """tm.start() with scene transitions: verify transitions are applied."""
+        params = VideoParams(
+            video_subject="test",
+            scenes=[
+                SceneConfig(scene_id=1, script="Scene one"),
+                SceneConfig(scene_id=2, script="Scene two"),
+            ],
+            video_source="pexels",
+            video_aspect="16:9",
+            video_concat_mode=VideoConcatMode.sequential,
+            video_clip_duration=3,
+            voice_name="test-voice",
+            voice_volume=1.0,
+            voice_rate=1.0,
+            subtitle_enabled=False,
+            scene_transition=VideoTransitionMode.fade_in,
+            bgm_type="none",
+            bgm_volume=0.0,
+            n_threads=2,
+        )
+
+        state = MagicMock()
+        with patch.object(tm.sm, "state", state):
+            with patch.object(tm.voice, "tts", side_effect=self._mock_tts("audio.mp3")):
+                with patch.object(
+                    tm.material, "download_videos",
+                    return_value=[self.clip1, self.clip2],
+                ):
+                    with patch.object(tm.llm, "generate_terms", return_value=["term"]):
+                        result = tm.start(task_id=f"{self.task_id}-trans", params=params)
+
+        self.assertNotEqual(result.get("state"), -1, f"Task failed: {result.get('error')}")
+
+    def test_full_pipeline_all_scenes_fail(self):
+        """When all scenes have empty scripts, task should fail gracefully."""
+        params = VideoParams(
+            video_subject="test",
+            scenes=[
+                SceneConfig(scene_id=1, script=""),
+                SceneConfig(scene_id=2, script=""),
+            ],
+            video_source="pexels",
+            video_aspect="16:9",
+            voice_name="test-voice",
+            voice_volume=1.0,
+            voice_rate=1.0,
+            bgm_type="none",
+            bgm_volume=0.0,
+            n_threads=2,
+        )
+
+        state = MagicMock()
+        with patch.object(tm.sm, "state", state):
+            with patch.object(tm.voice, "tts", side_effect=self._mock_tts("audio.mp3")):
+                # Mock generate_terms to return empty (simulates LLM failure)
+                # so generate_scenes produces scenes with no search terms
+                with patch.object(tm.llm, "generate_terms", return_value=[]):
+                    result = tm.start(task_id=f"{self.task_id}-fail", params=params)
+
+        # Should fail because all scenes have empty scripts and no terms
+        self.assertEqual(result.get("state"), -1)
+
+    def test_full_pipeline_partial_failure(self):
+        """When 1 of 2 scenes has no materials, the other should still produce output."""
+        params = VideoParams(
+            video_subject="test",
+            scenes=[
+                SceneConfig(scene_id=1, script="Good scene with real content"),
+                SceneConfig(scene_id=2, script="Another good scene"),
+            ],
+            video_source="pexels",
+            video_aspect="16:9",
+            video_concat_mode=VideoConcatMode.sequential,
+            video_clip_duration=3,
+            voice_name="test-voice",
+            voice_volume=1.0,
+            voice_rate=1.0,
+            subtitle_enabled=False,
+            bgm_type="none",
+            bgm_volume=0.0,
+            n_threads=2,
+        )
+
+        # Mock download_videos to return clips for scene 1, empty for scene 2
+        call_count = {"n": 0}
+        def mock_download(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return [self.clip1]  # Scene 1 succeeds
+            return []  # Scene 2 fails (no materials)
+
+        state = MagicMock()
+        with patch.object(tm.sm, "state", state):
+            with patch.object(tm.voice, "tts", side_effect=self._mock_tts("audio.mp3")):
+                with patch.object(tm.material, "download_videos", side_effect=mock_download):
+                    with patch.object(tm.llm, "generate_terms", return_value=["term"]):
+                        result = tm.start(task_id=f"{self.task_id}-partial", params=params)
+
+        # Should succeed with 1 scene (the other was skipped)
+        self.assertNotEqual(result.get("state"), -1, f"Task failed: {result.get('error')}")
+        # Should have scene_warnings
+        warnings = result.get("warnings") or []
+        self.assertTrue(
+            any(w.get("code") == "scene_generation_failed" for w in warnings),
+            f"Expected scene_generation_failed warning, got: {warnings}"
+        )
+
+
 RUN_INTEGRATION_TESTS = os.environ.get("MPT_RUN_INTEGRATION_TESTS", "").lower() in {
     "1", "true", "yes",
 }
@@ -1463,7 +1651,7 @@ class TestScenePipelineIntegration(unittest.TestCase):
 
         result = tm.start(task_id=task_id, params=params)
         print(f"Integration test result: {result}")
-        self.assertNotEqual(result.get("state"), "failed", f"Task failed: {result.get('error')}")
+        self.assertNotEqual(result.get("state"), -1, f"Task failed: {result.get('error')}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Scene-Based Video Generation — Core Backend

## Summary

Add scene-based video generation mode where each scene is processed as an independent mini-pipeline (TTS → subtitles → materials → video), then all scenes are concatenated into a final video with transitions and background music.

## Architecture

```
Scene 1: script → TTS(audio) → subtitles → materials → scene video (audio+subs burned in)
Scene 2: script → TTS(audio) → subtitles → materials → scene video (audio+subs burned in)
...
Final:   MoviePy concatenate_videoclips(scenes) + transitions + BGM → final.mp4
```

**Key design decisions:**
- Each scene is a fully self-contained video file with its own audio track
- Concatenation uses MoviePy `concatenate_videoclips(method="compose")` — handles videos with different codecs/resolutions reliably
- BGM is overlaid **once** on the final video via MoviePy `CompositeAudioClip` (same approach as `generate_video()`)
- Scene failures are skipped with warnings, not fatal errors

## Changes

### `app/models/schema.py` (+78 lines)
- `SceneConfig.duration` documented as reserved field (actual duration determined by TTS audio)

### `app/services/llm.py` (+298 lines)
- `generate_scene_scripts()` — generates narration scripts for N scenes in a single LLM call, returns structured JSON
- `generate_scene_keywords()` — generates per-scene search keywords based on scene scripts
- `_normalize_scene_count()` — clamps scene count to supported range (2–10)
- Both functions support retry, code-fence stripping, and regex recovery for malformed JSON

### `app/services/task.py` (+464 lines)
- `_generate_single_scene()` — full mini-pipeline per scene: TTS → subtitles → materials → combine_videos → generate_video
- Scene pipeline in `_run_pipeline()` — iterates scenes, collects results, concatenates with transitions
- `generate_scenes()` — processes scene definitions, generates missing search terms via LLM
- Guard for `stop_at` in scene mode (only `video` is supported)
- BGM generation for provider-based sources (sonilo/elevenlabs) with correct `video_path` and `video_duration`
- `scene_warnings` propagated to `generation_warnings` for failed scenes

### `app/services/video.py` (+270 lines)
- `concat_scene_videos_with_transitions()` — MoviePy-based concatenation with inline transitions and BGM overlay
- `_overlay_bgm_on_video()` — rewritten using MoviePy `CompositeAudioClip` (same as `generate_video`)
- `_apply_scene_transition()` — extended with all 8 transition types (fade_in/out, slide_in/out, zoom_in/out, shuffle)
- `concat_video_clips_with_ffmpeg()` — added `-c:a aac` to preserve audio during concatenation (bug fix)

### `docs/planned_ideas_scenes.md` (+175 lines)
- 13 future ideas: per-scene transitions, parallel processing, i18n, task restore, etc.

### `test/services/test_scene_pipeline.py` (+1658 lines, 84 tests)

| Test Class | Count | Coverage |
|-----------|-------|----------|
| `TestGenerateScenes` | 8 | Scene processing, ID assignment, script fallback, terms generation |
| `TestGenerateSingleScene` | 5 | TTS, subtitles, materials, clip transitions |
| `TestSceneScriptsConcatenation` | 2 | Backward compatibility |
| `TestSceneOrderPreservation` | 1 | Scene ordering |
| `TestSceneTransitionDefaults` | 3 | Transition fallback logic |
| `TestSceneTimeline` | 2 | Audio duration, separate directories |
| `TestSceneConfig` | 5 | Schema validation |
| `TestVideoParamsWithScenes` | 3 | Params with scenes and transitions |
| `TestApplySceneTransition` | 10 | All transition types, zero-duration, unsupported |
| `TestConcatSceneVideosWithTransitions` | 9 | Concatenation, transitions, BGM resolution |
| `TestOverlayBgmOnVideo` | 2 | MoviePy CompositeAudioClip mixing |
| `TestScenePipelineFailureModes` | 4 | Partial failure, empty list, bounds |
| `TestGenerateSceneScripts` | 7 | LLM JSON parsing, retry, regex recovery |
| `TestGenerateSceneKeywords` | 4 | LLM JSON parsing, empty responses |
| `TestBuildParamsScenes` | 6 | UI → params.scenes assembly |
| `TestConcatBgmExplicitDisable` | 1 | bgm_file_override="" disables BGM |
| `TestScenePipelineEndToEnd` | 3 | Real ffmpeg: 2 scenes, 3 scenes + transitions, failure handling |
| `TestScenePipelineFullFlow` | 4 | Full pipeline via tm.start(): success, transitions, all-fail, partial-fail |
| `TestScenePipelineIntegration` | 1 | Real TTS + local materials (skipped in CI) |

## Bug Fixes (found and fixed during development)

| Bug | File | Fix |
|-----|------|-----|
| `-c:a aac` missing in ffmpeg concat → audio dropped on clips 2+ | video.py | Added audio codec specification |
| `_apply_scene_transition` opened clips without audio | video.py | Added `audio=True` |
| Unnecessary LLM script generation in scene mode | task.py | Concatenate scene scripts instead |
| BGM applied per-scene AND on final video (double BGM) | task.py | `bgm_file_override=""` per scene |
| `params.bgm_file` not passed to BGM resolution | video.py | Added `bgm_file` parameter |
| `voice_name` not parsed for non-Edge TTS | task.py | Added `voice.parse_voice_name()` |
| `voice_volume` applied twice (TTS + generate_video) | task.py | Removed from TTS call |
| `shuffle` transition silently ignored in concat | video.py | Added shuffle branch |
| BGM from providers always looped | video.py | Only loop for random/custom |

## Testing

```
84 tests, all passing (1 integration skipped in CI)
├── 80 unit tests (mocked external services)
├── 4 e2e tests (real ffmpeg/MoviePy, mocked TTS/LLM/material)
└── 1 integration test (real TTS, gated behind MPT_RUN_INTEGRATION_TESTS=1)
```

## Follow-up PRs

- **PR 2: CLI** — `--scenes`, `--scenes-file`, `--scene-transition`, `--clip-transition`
- **PR 3: WebUI + i18n** — Scene editor, mode switch, AI buttons, translations for 10 locales
