### PR TITLE
feat(bgm): add preset song option and corresponding translations

### DIFF
--- a/app/services/bgm.py
+++ b/app/services/bgm.py
@@ -300,6 +300,26 @@ def list_bgm_files() -> list[str]:
     return [files_by_name[name] for name in sorted(files_by_name, key=str.lower)]
 
 
+def list_bgm_filenames() -> list[str]:
+    """列出可用背景音乐的展示文件名。"""
+    files_by_name: dict[str, str] = {}
+    for directory in (utils.song_dir(), uploaded_bgm_dir(create=True)):
+        if not os.path.isdir(directory):
+            continue
+        for name in sorted(os.listdir(directory), key=str.lower):
+            if name.startswith(_INTERNAL_UPLOAD_PREFIX):
+                continue
+            if Path(name).suffix.lower() not in SUPPORTED_BGM_EXTENSIONS:
+                continue
+            file_path = os.path.join(directory, name)
+            try:
+                file_security.resolve_path_within_directory(directory, file_path)
+            except ValueError:
+                continue
+            files_by_name[name] = name
+    return sorted(files_by_name.keys(), key=str.lower)
+
+
 def resolve_bgm_file(unsafe_path: str) -> str:
     """
     在用户上传目录和内置歌曲目录中解析 BGM，并拒绝两个白名单之外的路径。

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -5426,6 +5426,7 @@ def _render_background_music_settings(params, elevenlabs_api_key_rendered=False)
     bgm_options = [
         (tr("No Background Music"), ""),
         (tr("Random Background Music"), "random"),
+        (tr("Preset Song"), "preset"),
         (tr("Custom Background Music"), "custom"),
         (tr("Sonilo Background Music"), "sonilo"),
         (tr("ElevenLabs Background Music"), "elevenlabs"),
@@ -5590,6 +5591,25 @@ def _render_background_music_settings(params, elevenlabs_api_key_rendered=False)
             # 上传控件继续保留用户已选择的文件，调高音量后的下一次 rerun 会自动
             # 完整校验；当前任务参数必须清空，避免 0 音量任务保存或解析该文件。
             params.bgm_file = ""
+
+    if params.bgm_type == "preset":
+        available_songs = bgm_service.list_bgm_filenames()
+        if not available_songs:
+            st.warning(tr("No Background Music Available") if "No Background Music Available" in st.session_state else "No songs found in resource/songs.")
+            params.bgm_file = ""
+        else:
+            default_preset_song = _saved_ui_text("preset_song", available_songs[0])
+            selected_song = stable_selectbox(
+                tr("Preset Song"),
+                options=available_songs,
+                default_value=default_preset_song if default_preset_song in available_songs else available_songs[0],
+                key="preset_song_select",
+            )
+            _set_runtime_config("ui", "preset_song", selected_song)
+            if bgm_enabled:
+                params.bgm_file = selected_song
+            else:
+                params.bgm_file = ""
 
     if params.bgm_type == "sonilo":
         if previous_bgm_type != "sonilo":

--- a/webui/i18n/en.json
+++ b/webui/i18n/en.json
@@ -140,6 +140,7 @@
     "Background Music": "Background Music",
     "No Background Music": "No Background Music",
     "Random Background Music": "Random Background Music",
+    "Preset Song": "Preset Song",
     "Custom Background Music": "Custom Background Music",
     "Sonilo Background Music": "Automatic Video-Matched Music (Sonilo AI)",
     "Sonilo API Key": "Sonilo API Key ([Get API Key](https://platform.sonilo.com/))",

--- a/webui/i18n/zh.json
+++ b/webui/i18n/zh.json
@@ -140,6 +140,7 @@
     "Background Music": "背景音乐",
     "No Background Music": "无背景音乐",
     "Random Background Music": "随机背景音乐",
+    "Preset Song": "预设歌曲",
     "Custom Background Music": "自定义背景音乐",
     "Sonilo Background Music": "根据画面自动配乐（Sonilo AI）",
     "Sonilo API Key": "Sonilo API Key（[点击获取](https://platform.sonilo.com/)）",


### PR DESCRIPTION
This pull request adds support for selecting a "Preset Song" as background music in the application's UI. It introduces a new option in the background music settings, allows users to choose from available preset songs, and updates internationalization files accordingly.

**Background music feature enhancements:**

* Added a new "Preset Song" option to the background music type selector in the UI, allowing users to choose from a list of available preset songs.
* Implemented logic to display a dropdown of available preset songs when "Preset Song" is selected, including handling for when no songs are available. The selected song is saved and used as the background music file if background music is enabled.

**Backend and utility updates:**

* Added a new function `list_bgm_filenames()` in `bgm.py` to return a sorted list of available background music filenames for display in the UI.

**Internationalization:**

* Added translations for "Preset Song" in both English (`en.json`) and Chinese (`zh.json`) localization files. [[1]](diffhunk://#diff-14a9e309972d0e6e233c0d17d7f6e69636817bd34b09def7c3eb688f10cbfc82R143) [[2]](diffhunk://#diff-66aa5ef952103e2b24b7edadef726476a2efc045e0808e75faaa370603bc787fR143)