### PR TITLE
feat: trim long TTS silence gaps and shift subtitles

### DIFF
--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -155,6 +155,9 @@ class VideoParams(BaseModel):
     font_size: int = 60
     stroke_color: Optional[str] = "#000000"
     stroke_width: float = 1.5
+    # Shorten long inter-sentence TTS silences (audio + subtitles shift).
+    # When off, the legacy behavior is kept as-is.
+    trim_silence: bool = True
     n_threads: Optional[int] = 2
     paragraph_number: int = Field(default=1, ge=1, le=10)
     video_script_prompt: str = Field(default="", max_length=2000)

--- a/app/services/silence.py
+++ b/app/services/silence.py
@@ -1,0 +1,158 @@
+"""Trim long TTS silence gaps between sentences and shift subtitles.
+
+Root cause: Edge TTS leaves ~1.2s of silence after each period; with
+short-sentence scripts a 39s video can contain ~6s of dead air
+("talks, waits, continues" feeling).
+
+Method: gaps between subtitle cues are pure silence (TTS). The excess
+above the threshold is cut from the audio, and all later cue timestamps
+are shifted back by the same amount — sync is preserved. On any error
+the original files are left untouched and the pipeline continues as-is.
+"""
+
+import os
+import re
+from contextlib import ExitStack
+
+from loguru import logger
+
+# Inter-cue gaps longer than this are trimmed (seconds).
+MAX_GAP_SECONDS = 0.6
+# This much silence is kept from a trimmed gap (natural breath, seconds).
+KEEP_GAP_SECONDS = 0.3
+
+
+def _srt_to_seconds(stamp: str) -> float:
+    m = re.match(r"(\d+):(\d+):(\d+)[,.](\d+)", str(stamp or "").strip())
+    if not m:
+        raise ValueError(f"bad srt timestamp: {stamp!r}")
+    h, mi, s, ms = (int(g) for g in m.groups())
+    return h * 3600 + mi * 60 + s + ms / 1000.0
+
+
+def _seconds_to_srt(t: float) -> str:
+    t = max(0.0, float(t))
+    h = int(t // 3600)
+    m = int((t % 3600) // 60)
+    s = int(t % 60)
+    ms = int(round((t - int(t)) * 1000))
+    if ms >= 1000:
+        ms -= 1000
+        s += 1
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+def plan_cuts(subtitle_path: str) -> list[tuple[float, float]]:
+    """Compute (cut_start, cut_end) ranges to remove. Pure function."""
+    from app.services import subtitle as subtitle_service
+
+    cues = subtitle_service.file_to_subtitles(subtitle_path)
+    if len(cues) < 2:
+        return []
+    times: list[tuple[float, float]] = []
+    for _idx, timerange, _text in cues:
+        try:
+            parts = str(timerange).split("-->")
+            times.append((_srt_to_seconds(parts[0]), _srt_to_seconds(parts[1])))
+        except Exception:
+            return []
+    cuts: list[tuple[float, float]] = []
+    for (_ps, pe), (ns, _ne) in zip(times, times[1:]):
+        gap = ns - pe
+        if gap > MAX_GAP_SECONDS:
+            cuts.append((pe + KEEP_GAP_SECONDS, ns))
+    return [(s, e) for s, e in cuts if e > s]
+
+
+def shift_cues(subtitle_path: str, cuts: list[tuple[float, float]]) -> list[tuple[int, str, str]]:
+    """Return cue timestamps shifted as if the cuts were applied."""
+    from app.services import subtitle as subtitle_service
+
+    cues = subtitle_service.file_to_subtitles(subtitle_path)
+
+    def shifted(t: float) -> float:
+        off = 0.0
+        for cs, ce in cuts:
+            if t >= ce:
+                off += ce - cs
+            elif t > cs:
+                off += t - cs
+        return t - off
+
+    out = []
+    for idx, timerange, text in cues:
+        parts = str(timerange).split("-->")
+        s = _seconds_to_srt(shifted(_srt_to_seconds(parts[0])))
+        e = _seconds_to_srt(shifted(_srt_to_seconds(parts[1])))
+        out.append((idx, f"{s} --> {e}", text))
+    return out
+
+
+def trim_silences(audio_file: str, subtitle_path: str) -> tuple[str, float] | tuple[None, None]:
+    """Trim silences and shift the SRT. Returns (audio_path, duration).
+
+    On success the trimmed audio + updated SRT are in place. On any
+    problem returns (None, None) — the caller continues with the original.
+    """
+    try:
+        if not audio_file or not os.path.exists(audio_file):
+            return (None, None)
+        if not subtitle_path or not os.path.exists(subtitle_path):
+            return (None, None)
+        cuts = plan_cuts(subtitle_path)
+        if not cuts:
+            return (None, None)
+
+        from moviepy import AudioFileClip, concatenate_audioclips
+
+        with ExitStack() as stack:
+            clip = stack.enter_context(AudioFileClip(audio_file))
+            total = float(clip.duration or 0)
+            if total <= 0:
+                return (None, None)
+            # Kept segments: [0, cut1_s], [cut1_e, cut2_s], ..., [cutN_e, total]
+            bounds = [0.0]
+            for cs, ce in cuts:
+                bounds += [cs, ce]
+            bounds.append(total)
+            segments = []
+            for s, e in zip(bounds[::2], bounds[1::2]):
+                s = max(0.0, min(s, total))
+                e = max(0.0, min(e, total))
+                if e - s > 0.05:
+                    segments.append(clip.subclipped(s, e))
+            if not segments:
+                return (None, None)
+            joined = concatenate_audioclips(segments)
+            tmp_audio = audio_file + ".trimmed.mp3"
+            joined.write_audiofile(tmp_audio, logger=None)
+            duration = float(joined.duration or 0)
+            try:
+                joined.close()
+            except Exception:
+                pass
+
+        if not duration or not os.path.exists(tmp_audio):
+            return (None, None)
+        os.replace(tmp_audio, audio_file)
+
+        shifted = shift_cues(subtitle_path, cuts)
+        with open(subtitle_path, "w", encoding="utf-8") as f:
+            for i, timerange, text in shifted:
+                f.write(f"{i}\n{timerange}\n{text.strip()}\n\n")
+
+        saved = sum(ce - cs for cs, ce in cuts)
+        logger.info(
+            f"silence trimmed: cuts={len(cuts)}, saved={saved:.2f}s, "
+            f"new_duration={duration:.2f}s"
+        )
+        return (audio_file, duration)
+    except Exception as e:
+        logger.warning(f"silence trim failed, keeping original: {type(e).__name__}: {e}")
+        try:
+            tmp = (audio_file or "") + ".trimmed.mp3"
+            if tmp and os.path.exists(tmp):
+                os.remove(tmp)
+        except Exception:
+            pass
+        return (None, None)

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -1470,6 +1470,18 @@ def _run_pipeline(
         )
         return {"subtitle_path": subtitle_path}
 
+    # 4b. Trim TTS silence gaps: inter-sentence gaps > 0.6s shrink to 0.3s,
+    # shifting subtitle timings. Failures are skipped silently.
+    if getattr(params, "trim_silence", True):
+        try:
+            from app.services import silence as silence_service
+
+            trimmed = silence_service.trim_silences(audio_file, subtitle_path)
+            if trimmed and trimmed[0] and trimmed[1]:
+                audio_file, audio_duration = trimmed
+        except Exception as e:
+            logger.warning(f"silence trim skipped: {type(e).__name__}")
+
     sm.state.update_task(task_id, state=const.TASK_STATE_PROCESSING, progress=40)
 
     # 5. Get video materials

--- a/test/services/test_silence.py
+++ b/test/services/test_silence.py
@@ -1,0 +1,83 @@
+import sys
+import unittest
+from pathlib import Path
+
+# add project root to python path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from app.services import silence as silence_service
+
+SRT = """1
+00:00:00,100 --> 00:00:00,938
+Nvidia
+
+2
+00:00:01,125 --> 00:00:04,650
+a blockbuster deal
+
+3
+00:00:05,812 --> 00:00:06,575
+chip giant
+"""
+
+
+class TestSilencePlanning(unittest.TestCase):
+    def _write_srt(self, tmp_path, content=SRT):
+        p = tmp_path / "subtitle.srt"
+        p.write_text(content, encoding="utf-8")
+        return str(p)
+
+    def test_timestamp_roundtrip(self):
+        self.assertAlmostEqual(silence_service._srt_to_seconds("00:00:04,650"), 4.65)
+        self.assertEqual(silence_service._seconds_to_srt(4.65), "00:00:04,650")
+
+    def test_plan_cuts_finds_long_gap(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_srt(Path(tmp))
+            cuts = silence_service.plan_cuts(path)
+            # cue2 end 4.650 -> cue3 start 5.812 = 1.162s gap > 0.6
+            self.assertEqual(len(cuts), 1)
+            self.assertAlmostEqual(cuts[0][0], 4.65 + 0.3, places=2)
+            self.assertAlmostEqual(cuts[0][1], 5.812, places=2)
+
+    def test_plan_cuts_empty_for_tight_subs(self):
+        import tempfile
+
+        tight = (
+            "1\n00:00:00,000 --> 00:00:01,000\nA\n\n"
+            "2\n00:00:01,200 --> 00:00:02,000\nB\n\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_srt(Path(tmp), tight)
+            self.assertEqual(silence_service.plan_cuts(path), [])
+
+    def test_shift_cues_moves_later_cues(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_srt(Path(tmp))
+            cuts = silence_service.plan_cuts(path)
+            shifted = silence_service.shift_cues(path, cuts)
+            # cue1-2 unchanged, cue3 shifts back
+            self.assertTrue(shifted[0][1].startswith("00:00:00,100"))
+            self.assertTrue(shifted[1][1].startswith("00:00:01,125"))
+            saved = cuts[0][1] - cuts[0][0]
+            self.assertIn("00:00:05,812", SRT)  # original
+            new_start = shifted[2][1].split(" --> ")[0]
+            self.assertAlmostEqual(
+                silence_service._srt_to_seconds(new_start),
+                5.812 - saved,
+                places=2,
+            )
+
+    def test_trim_missing_files_returns_none(self):
+        self.assertEqual(
+            silence_service.trim_silences("/nonexistent/audio.mp3", "/nonexistent/sub.srt"),
+            (None, None),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Edge TTS leaves ~1.2s pauses after each sentence, so short-sentence scripts get seconds of dead air. This trims inter-cue gaps over 0.6s down to 0.3s and shifts later subtitle cues back so audio and subtitles stay in sync. Any failure keeps the original files and the pipeline continues. New trim_silence flag on VideoParams (default true). Tests: test/services/test_silence.py (5 passed).