### PR TITLE
feat: two-lane stock terms with safe fallback

### DIFF
--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -112,7 +112,10 @@ class VideoParams(BaseModel):
     video_transition_mode: Optional[VideoTransitionMode] = None
     video_clip_duration: int = Field(default=5, ge=1)
     video_clip_speed: Optional[float] = 1.0
-    match_materials_to_script: bool = False
+    # Two-lane: generic stock backgrounds ordered by script; proper nouns
+    # and charts go to overlays instead of stock search. Opt out if the
+    # legacy global-theme terms are preferred.
+    match_materials_to_script: bool = True
     video_count: int = Field(default=1, ge=1)
 
     video_source: Optional[str] = "pexels"

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -631,6 +631,18 @@ def generate_terms(
             '"search term 4", "search term 5"]'
         )
 
+    # Two-lane: stock clips are atmospheric backgrounds; specific facts go to
+    # overlays. Stock pools have no brand/logo/person/chart footage, so a term
+    # with a proper noun returns generic irrelevant results. Stock terms must
+    # be filmable generic scenes; proper nouns belong to overlays.
+    two_lane_rule = (
+        "7. STOCK-SAFE RULE (two-lane): each term must describe a generic "
+        "filmable scene (place, object, activity), never a brand, product, "
+        "person name, logo, chart, number or meme — those have no stock "
+        "footage and are shown as overlay graphics instead. "
+        "Example: instead of 'Hugging Face', write 'programmers office'; "
+        "instead of 'Jensen Huang', write 'chip factory engineer'."
+    )
     prompt = f"""
 # Role: Video Search Terms Generator
 
@@ -644,6 +656,7 @@ def generate_terms(
 4. the search terms must be related to the subject of the video.
 5. reply with english search terms only.
 {ordering_rule}
+{two_lane_rule}
 
 ## Output Example:
 {output_example}
@@ -702,6 +715,58 @@ Please note that you must use English for generating video search terms; Chinese
 
     logger.success(f"completed: \n{search_terms}")
     return search_terms
+
+
+def suggest_replacement_terms(empty_terms: List[str] | str, app_config=None) -> List[str]:
+    """Suggest one generic replacement scene per empty stock query.
+
+    Single attempt only. Returns an empty list on any error; the caller
+    continues with the candidates it already has.
+    """
+    if isinstance(empty_terms, str):
+        empties = [empty_terms]
+    else:
+        empties = [str(t) for t in (empty_terms or [])]
+    empties = [t.strip()[:80] for t in empties if t.strip()][:8]
+    if not empties:
+        return []
+    listed = "\n".join(f"- {t}" for t in empties)
+    prompt = f"""
+# Role: Stock Footage Query Repair
+
+## Goal
+These stock-video search queries returned ZERO footage. Propose exactly ONE generic, filmable replacement scene per query.
+
+## Hard Constraints
+1. Return ONLY a minified JSON array of strings, no other text.
+2. Each replacement: 1-3 English words, a generic filmable scene (place, object, activity).
+3. NEVER reuse brand, product, person, logo, chart or meme terms — they have no stock footage.
+4. Same order and count as the input list ({len(empties)} items).
+
+## Empty queries
+{listed}
+
+## Output Example
+["server room", "business handshake"]
+""".strip()
+    logger.info(f"requesting replacement terms for {len(empties)} empty queries")
+    for i in range(_max_retries):
+        try:
+            if app_config is None:
+                response = _generate_response(prompt=prompt)
+            else:
+                response = _generate_response(prompt=prompt, app_config=app_config)
+            if isinstance(response, str) and response.startswith("Error:"):
+                logger.error(f"failed to suggest replacements: {response}")
+                return []
+            data = json.loads(_strip_code_fence(response))
+            if not isinstance(data, list):
+                raise ValueError("replacements response is not a JSON array")
+            out = [str(t).strip()[:60] for t in data if str(t).strip()][: len(empties)]
+            return out
+        except Exception as e:
+            logger.warning(f"failed to suggest replacements (try {i + 1}): {e}")
+    return []
 
 
 # =============================================================================

--- a/app/services/material.py
+++ b/app/services/material.py
@@ -1767,6 +1767,7 @@ def download_videos(
 
     valid_video_items = []
     valid_video_urls = []
+    empty_terms: List[str] = []
     found_duration = 0.0
     for search_term in search_terms:
         video_items = search_videos(
@@ -1776,8 +1777,21 @@ def download_videos(
         )
         logger.info(f"found {len(video_items)} videos for '{search_term}'")
 
+        if not video_items:
+            empty_terms.append(search_term)
         for item in video_items:
             if item.url not in valid_video_urls:
+                valid_video_items.append(item)
+                valid_video_urls.append(item.url)
+                found_duration += item.duration
+
+    # Replacement net: if some terms came back empty and the duration is
+    # still short, ask the LLM once for generic alternatives and add hits.
+    if empty_terms and found_duration <= audio_duration:
+        for term, items in _search_replacement_candidates(
+            empty_terms, search_videos, video_aspect, max_clip_duration, set(valid_video_urls)
+        ):
+            for item in items:
                 valid_video_items.append(item)
                 valid_video_urls.append(item.url)
                 found_duration += item.duration
@@ -1834,6 +1848,52 @@ def download_videos(
     logger.success(f"downloaded {len(video_paths)} videos")
     _persist_material_sources(task_id, material_sources)
     return video_paths
+
+
+def _search_replacement_candidates(
+    empty_terms: List[str],
+    search_videos: Callable,
+    video_aspect: VideoAspect,
+    max_clip_duration: int,
+    valid_video_urls: set,
+) -> list[tuple[str, list]]:
+    """One round of LLM replacement terms + search for empty queries.
+
+    Returns an empty list on any error; the pipeline continues with the
+    candidates it already has.
+    """
+    if not empty_terms:
+        return []
+    try:
+        from app.services import llm as llm_service
+
+        replacements = llm_service.suggest_replacement_terms(empty_terms)
+    except Exception as e:
+        logger.warning(f"replacement terms skipped: {type(e).__name__}")
+        return []
+    groups: list[tuple[str, list]] = []
+    for original, replacement in zip(empty_terms, replacements):
+        term = (replacement or "").strip()
+        if not term:
+            continue
+        try:
+            items = search_videos(
+                search_term=term,
+                minimum_duration=max_clip_duration,
+                video_aspect=video_aspect,
+            )
+        except Exception as e:
+            logger.warning(f"replacement search failed: term={term!r}, error={type(e).__name__}")
+            continue
+        logger.info(
+            f"found {len(items)} videos for replacement '{term}' (was '{original}')"
+        )
+        term_items = [it for it in items if it.url not in valid_video_urls]
+        for it in term_items:
+            valid_video_urls.add(it.url)
+        if term_items:
+            groups.append((term, term_items))
+    return groups
 
 
 def _download_videos_wavespeed_on_demand(
@@ -2261,6 +2321,7 @@ def _download_videos_by_script_order(
     logger.info("downloading videos with script-order material matching")
     candidate_groups = []
     valid_video_urls = set()
+    empty_terms: List[str] = []
     found_duration = 0.0
 
     for search_term in search_terms:
@@ -2281,6 +2342,17 @@ def _download_videos_by_script_order(
 
         if term_items:
             candidate_groups.append((search_term, term_items))
+        else:
+            empty_terms.append(search_term)
+
+    # Replacement net (ordered mode): empty terms get generic replacement
+    # groups, keeping the round-robin order intact.
+    if empty_terms and found_duration <= audio_duration:
+        for term, items in _search_replacement_candidates(
+            empty_terms, search_videos, video_aspect, max_clip_duration, valid_video_urls
+        ):
+            candidate_groups.append((term, items))
+            found_duration += sum(it.duration for it in items)
 
     logger.info(
         f"found total ordered video candidates: {sum(len(items) for _, items in candidate_groups)}, "

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -308,6 +308,50 @@ def generate_script(task_id, params):
     return video_script
 
 
+def _terms_look_english(terms) -> bool:
+    """Stock terms must be short English; other languages/sentences fail."""
+    if not terms or not isinstance(terms, list):
+        return False
+    bad = sum(1 for t in terms if _is_bad_term(t))
+    return bad <= len(terms) // 2
+
+
+_TR_STOPWORDS = frozenset({
+    "ve", "ile", "için", "gibi", "daha", "çok", "bir", "bu", "şu", "o",
+    "da", "de", "ki", "ne", "hem", "veya", "ya", "ise", "diye", "kadar",
+    "sonra", "önce", "karşı", "arasında", "olarak", "olan", "içinde",
+})
+
+
+def _is_bad_term(term) -> bool:
+    """Non-English characters, stopwords, sentence length, or empty?"""
+    s = str(term or "").strip()
+    if not s:
+        return True
+    if any(c in "ğüşöçıİĞÜŞÖÇ" for c in s):
+        return True
+    words = s.split()
+    if len(words) > 3 or len(words) == 0:
+        return True
+    lowered = [w.strip(".,!?:;()\"'").lower() for w in words]
+    if any(w in _TR_STOPWORDS for w in lowered):
+        return True
+    return False
+
+
+def _dedup_terms(terms) -> list:
+    seen: set[str] = set()
+    out = []
+    for t in terms or []:
+        # The model sometimes wraps terms like "['term']"; clean that up.
+        cleaned = str(t or "").strip().strip("[]\"'’‘").strip()
+        key = cleaned.lower()
+        if key and key not in seen:
+            seen.add(key)
+            out.append(cleaned)
+    return out
+
+
 def generate_terms(task_id, params, video_script):
     logger.info("\n\n## generating video terms")
     video_terms = params.video_terms
@@ -321,6 +365,21 @@ def generate_terms(task_id, params, video_script):
             amount=8 if params.match_materials_to_script else 5,
             match_script_order=params.match_materials_to_script,
         )
+        # Language/shape guard: the model sometimes returns non-English,
+        # duplicated, or sentence-like terms, which yield generic results
+        # from stock APIs. Drop the bad ones and request one round of
+        # generic replacements.
+        if video_terms:
+            video_terms = _dedup_terms(video_terms)
+            bad_terms = [t for t in video_terms if _is_bad_term(t)]
+            if bad_terms:
+                logger.warning(f"dropping non-stock-safe terms: {bad_terms!r}")
+                good = [t for t in video_terms if not _is_bad_term(t)]
+                try:
+                    replacements = llm.suggest_replacement_terms(bad_terms)
+                except Exception:
+                    replacements = []
+                video_terms = _dedup_terms(good + [r for r in replacements if r and not _is_bad_term(r)])
     else:
         if isinstance(video_terms, str):
             video_terms = [term.strip() for term in re.split(r"[,，]", video_terms)]

--- a/test/services/test_stock_terms.py
+++ b/test/services/test_stock_terms.py
@@ -1,0 +1,69 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# add project root to python path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from app.services import llm
+from app.services import task as task_service
+
+
+class TestTwoLaneTermsPrompt(unittest.TestCase):
+    def test_stock_safe_rule_in_prompt(self):
+        captured = {}
+
+        def fake_generate(prompt, app_config=None):
+            captured["prompt"] = prompt
+            return '["server room"]'
+
+        with patch.object(llm, "_generate_response", side_effect=fake_generate):
+            terms = llm.generate_terms("Nvidia buys Hugging Face", "script", amount=2)
+        self.assertIn("STOCK-SAFE RULE", captured.get("prompt", ""))
+        self.assertIn("never a brand", captured.get("prompt", ""))
+        self.assertEqual(terms, ["server room"])
+
+
+class TestReplacementTerms(unittest.TestCase):
+    def test_empty_input_no_llm_call(self):
+        with patch.object(llm, "_generate_response") as gen:
+            self.assertEqual(llm.suggest_replacement_terms([]), [])
+            gen.assert_not_called()
+
+    def test_replacements_parsed(self):
+        with patch.object(
+            llm, "_generate_response", return_value='["server room", "business handshake"]'
+        ):
+            out = llm.suggest_replacement_terms(["Hugging Face", "Jensen Huang"])
+        self.assertEqual(out, ["server room", "business handshake"])
+
+    def test_provider_error_returns_empty(self):
+        with patch.object(
+            llm, "_generate_response", return_value="Error: boom"
+        ):
+            self.assertEqual(llm.suggest_replacement_terms(["x"]), [])
+
+
+class TestTermGuards(unittest.TestCase):
+    def test_bad_terms_rejected(self):
+        self.assertTrue(task_service._is_bad_term(""))
+        self.assertTrue(task_service._is_bad_term("çip devi"))
+        self.assertTrue(task_service._is_bad_term("chip giant weekly duel report"))
+        self.assertFalse(task_service._is_bad_term("server room"))
+
+    def test_dedup_cleans_wrapped_terms(self):
+        self.assertEqual(
+            task_service._dedup_terms(["['server room']", "server room", "chip factory"]),
+            ["server room", "chip factory"],
+        )
+
+    def test_terms_look_english(self):
+        self.assertFalse(task_service._terms_look_english(["çip devi", "çok büyük"]))
+        self.assertTrue(
+            task_service._terms_look_english(["chip factory", "server room", "AI race"])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stock pools have no brand, person, logo, or chart footage, so proper-noun search terms return generic irrelevant clips. This makes search terms stock-safe and adds a fallback net. Two lanes: generic filmable scenes go to stock search, specific facts go to overlays. Changes: STOCK-SAFE rule in the term prompt, bad-term guard with dedup plus one round of LLM replacements in generate_terms, replacement-candidate retry in material download (both plain and script-order modes), match_materials_to_script default true (opt out any time). All fallbacks are fail-safe and keep existing candidates on error. Tests: test/services/test_stock_terms.py (7 passed), test_schema and test_task green.