### PR TITLE
Fix webui.sh port check breaking when project path contains spaces

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -17,15 +17,15 @@ MPT_WEBUI_HOST="${MPT_WEBUI_HOST:-127.0.0.1}"
 MPT_WEBUI_PORT="${MPT_WEBUI_PORT:-8501}"
 
 if [ -x "$CURRENT_DIR/.venv/bin/python" ]; then
-  PORT_CHECK_CMD="$CURRENT_DIR/.venv/bin/python"
   set -- "$CURRENT_DIR/.venv/bin/python" -m streamlit
+  find_port() { find_available_port "$CURRENT_DIR/.venv/bin/python"; }
 elif command -v uv >/dev/null 2>&1; then
-  PORT_CHECK_CMD="uv run python"
   set -- uv run streamlit
+  find_port() { find_available_port uv run python; }
 elif command -v streamlit >/dev/null 2>&1; then
   echo "***** Warning: using streamlit from PATH. If dependencies fail, run 'uv sync --frozen' first. *****"
-  PORT_CHECK_CMD="python3"
   set -- streamlit
+  find_port() { find_available_port python3; }
 else
   echo "***** Neither project Python, uv, nor streamlit was found. Please install dependencies first. *****"
   exit 1
@@ -55,8 +55,7 @@ PY
 }
 
 # 用 Python 做端口探测，避免依赖 lsof/nc 在不同 macOS/Linux 发行版上的差异。
-# shellcheck disable=SC2086
-SELECTED_WEBUI_PORT=$(find_available_port $PORT_CHECK_CMD)
+SELECTED_WEBUI_PORT=$(find_port)
 
 if [ -z "$SELECTED_WEBUI_PORT" ]; then
   echo "***** No available WebUI port found in 8501-8599 for $MPT_WEBUI_HOST. *****"


### PR DESCRIPTION
## What changed

`webui.sh`'s port probe called `find_available_port $PORT_CHECK_CMD` with an **unquoted** variable holding the venv's python path. When the project directory path contains spaces (e.g. a folder named `My Project/MoneyPrinterTurbo`), shell word-splitting breaks that single path into several bogus arguments, so the Python port-probe script never actually runs and `webui.sh` fails with:

```
***** No available WebUI port found in 8501-8599 for 127.0.0.1. *****
```

even though port 8501 is free.

## Why

Ran into this while setting up MoneyPrinterTurbo locally in a folder with spaces in its path. `webui.sh` worked fine when invoking the venv's `streamlit` binary directly, which confirmed the port-check subshell itself was the broken part.

## Fix

Replaced the single `PORT_CHECK_CMD` string with a small `find_port()` wrapper function defined in each of the three python/uv/streamlit detection branches. Each wrapper calls `find_available_port` with its arguments already correctly quoted/split (the venv path as one argument, `uv run python` as three), so paths with spaces are no longer mangled by word-splitting.

## Testing

- `sh -n webui.sh` — syntax OK
- Ran `./webui.sh` from a project directory with spaces in its path: previously failed with "No available WebUI port found"; after the fix it correctly reports `WebUI address: http://127.0.0.1:8501` and Streamlit starts and serves (verified with `curl` returning HTTP 200).
- Ran `./webui.sh` from a path without spaces as a regression check: still works as before.

No functional changes for users on paths without spaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)