### PR TITLE
chore: add Vibe Coding Project Structure scaffold for AI coding agents

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,7 @@
+---
+name: code-reviewer
+description: Reviews code for correctness, readability, and maintainability. Invoke after a non-trivial change or before committing.
+tools: Read, Grep, Bash
+---
+
+Review the diff or file given. Report findings as `file:line: problem — fix`, most severe first. No praise, no scope creep, no style nits unless they change meaning.

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -1,0 +1,7 @@
+---
+name: security-auditor
+description: Focused security pass over recent changes or a named file/directory. Use for anything touching auth, payments, user input parsing, or dependency updates.
+tools: Read, Grep, Bash
+---
+
+Check for injection (SQL/command/XSS), broken auth/authz, secrets in code, unsafe deserialization, and dependency CVEs. Report only exploitable, concrete findings with `file:line` and a fix.

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,0 +1,3 @@
+Fix issue: $ARGUMENTS
+
+Steps: locate root cause, apply the narrowest fix, run tests, report file:line changed.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,1 @@
+Review current diff (`git diff`) for bugs, simplification, efficiency. One finding per line, `file:line` format, most severe first.

--- a/.claude/hooks/validate-bash.sh
+++ b/.claude/hooks/validate-bash.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash — blocks obviously destructive commands.
+# Wired into .claude/settings.json under "hooks".
+#
+# Uses python3 instead of jq to read tool_input.command: this project already
+# requires Python 3.11+, but jq isn't guaranteed to be installed, especially
+# on the Windows machines this project's webui.bat/webui.sh split targets.
+set -euo pipefail
+
+cmd=$(python3 -c 'import json, sys; print(json.load(sys.stdin).get("tool_input", {}).get("command", ""))')
+
+if echo "$cmd" | grep -qE 'rm -rf /(\s|$)|:\(\)\{ :\|:& \};:'; then
+  echo "Blocked: destructive command detected" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/rules/api-conventions.md
+++ b/.claude/rules/api-conventions.md
@@ -1,0 +1,7 @@
+# API conventions
+
+- Never send secrets, tokens, or user PII to unrelated third-party endpoints.
+- Prefer existing MCP connectors over raw curl when one fits.
+- Validate at system boundaries (user input, external APIs) only — trust internal code.
+- Sanitize error messages that might embed credentials (e.g. a custom `base_url` with embedded userinfo or a query-string token) before returning them from a FastAPI endpoint or the WebUI — see `_sanitize_error_message` in `app/services/llm.py` for the existing pattern.
+- New LLM/TTS/material providers: add one entry to the relevant registry (e.g. `app/models/llm_provider.py`) rather than hardcoding a new branch in the WebUI; only add an adapter branch in the service layer when the protocol genuinely differs from the existing OpenAI-compatible path.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,6 @@
+# Code style
+
+- No comments unless explaining non-obvious WHY. This repo already follows that closely — many existing comments are in Chinese explaining a subtle constraint or past bug; match that pattern in adjacent code rather than translating it or adding narrative comments elsewhere.
+- Prefer editing existing files over new ones.
+- No premature abstraction — 3 similar lines beats a helper for 1 use case.
+- Match existing formatting/linting config in the repo (`ruff` — see `pyproject.toml`).

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,7 @@
+# Testing
+
+- Run `pytest test/` before reporting a task done.
+- New behavior gets a test; bug fixes get a regression test where practical.
+- No mocked-only tests for anything touching real DB/API when integration risk exists.
+- Adding an LLM/TTS/material provider: add a registry-level test (required fields, adapter selection) and, where practical, an adapter test using a fake client — see `test/services/test_llm.py` for the existing pattern per provider.
+- WebUI behavior (Streamlit) is tested via `streamlit.testing.v1.AppTest` in `test/services/test_webui_*.py`, not by running the app manually.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status)",
+      "Bash(git diff)",
+      "Bash(git log)"
+    ],
+    "deny": []
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-bash.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -1,0 +1,15 @@
+---
+description: Project-wide conventions for Cursor
+globs:
+alwaysApply: true
+---
+
+# Project rules
+
+Canonical instructions live in `AGENTS.md` at repo root — read that first.
+
+- Prefer editing existing files over creating new ones.
+- No premature abstraction.
+- Match existing code style in the file being edited.
+- Run `pytest test/` before considering a change done.
+- Never commit secrets, `.env` files, or `config.toml`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,9 @@
+# GitHub Copilot instructions
+
+Canonical instructions live in `AGENTS.md` at repo root — follow that.
+
+Summary for quick reference:
+- Prefer editing existing files over creating new ones.
+- No premature abstraction; match existing style.
+- Write/run tests (`pytest test/`) for new behavior.
+- Never suggest hardcoded secrets or committing `.env`/`config.toml`.

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,15 @@ htmlcov/
 
 # Claude Code 订阅令牌（docker compose 自动读取），禁止提交
 .env
+
+# Vibe Coding scaffold — personal/local overrides, never commit
+CLAUDE.local.md
+.claude/settings.local.json
+
+# Real MCP config (may contain tokens/paths) — commit .mcp.json.example instead
+.mcp.json
+
+# Additional secret file patterns
+.env.*
+*.pem
+*.key

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    }
+  }
+}

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,9 @@
+# Windsurf rules
+
+Canonical instructions live in AGENTS.md at repo root — follow that.
+
+Summary:
+- Prefer editing existing files over creating new ones.
+- No premature abstraction; match existing style.
+- Write/run tests (`pytest test/`) for new behavior.
+- Never hardcode secrets or commit `.env`/`config.toml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS.md
+
+Universal instructions for any AI coding agent working in this repo (OpenAI Codex CLI, Aider, Continue, Zed, Cursor, etc). Claude Code reads `CLAUDE.md` instead but should stay consistent with this file.
+
+## Project overview
+
+MoneyPrinterTurbo generates short videos from a topic or keywords: it writes the script, synthesizes voiceover, matches or generates video/image material, produces subtitles and background music, and composes the final clip. It's used through a Streamlit WebUI, a FastAPI REST API, or a CLI, and can auto-publish finished videos to TikTok/Instagram/YouTube Shorts.
+
+## Tech stack
+
+- **Language/runtime:** Python 3.11+
+- **API:** FastAPI + uvicorn (`main.py`)
+- **WebUI:** Streamlit (`webui/Main.py`), with per-locale strings in `webui/i18n/*.json`
+- **Video/audio:** MoviePy + FFmpeg for composition; `faster-whisper` for subtitle timing
+- **LLM/TTS/material providers:** many interchangeable providers behind small registries — see Directory map
+- **Package/env management:** `uv` (dependencies in `pyproject.toml`, pinned in `uv.lock`)
+- **Tests/lint:** `pytest` + `coverage`, `ruff`
+- **Deployment:** Docker (`Dockerfile`, `Dockerfile.gpu`, `docker-compose*.yml`)
+
+## Setup
+
+```bash
+uv sync                      # install deps (or: pip install -e . && pip install pytest ruff coverage)
+cp config.example.toml config.toml
+python main.py                # start the FastAPI server
+./webui.sh                    # start the Streamlit WebUI (webui.bat on Windows)
+```
+
+## Commands
+
+| Task | Command |
+|---|---|
+| Install | `uv sync` |
+| Dev server (API) | `python main.py` |
+| Dev server (WebUI) | `./webui.sh` (Windows: `webui.bat`) |
+| Test | `pytest test/` |
+| Lint | `ruff check .` |
+| Build (Docker) | `docker build -t moneyprinterturbo .` |
+
+## Conventions
+
+- Prefer editing existing files over creating new ones.
+- No premature abstraction — don't build for hypothetical future requirements.
+- Match existing code style in the file you're editing over imposing a new one; many existing comments are in Chinese explaining non-obvious *why* — follow that pattern in adjacent code rather than translating it.
+- Write tests for new behavior; run `pytest test/` before calling a task done.
+- Don't commit secrets, `.env` files, `config.toml`, or credentials.
+- Adding an LLM/TTS/material provider almost always means adding one registry entry plus locale strings, not new branching logic — see Directory map.
+
+## Boundaries
+
+- Ask before: deleting data, force-pushing, changing CI/CD, upgrading major dependencies.
+- Never: commit directly to `main`/`master` without review, disable tests to make CI pass, hardcode secrets.
+
+## Directory map
+
+- `app/models/llm_provider.py` — the LLM provider registry (single source of truth: id, adapter, default model/URL, required fields); `app/services/llm.py` implements the adapters and script/keyword/social-metadata generation.
+- `app/services/voice.py` — TTS providers; `app/services/material.py` — stock/AI video and image sourcing; `app/services/video.py` — composition; `app/services/subtitle.py` — subtitle generation.
+- `app/controllers/v1/` — FastAPI route handlers; `app/models/schema.py` — Pydantic request/response models.
+- `webui/Main.py` — the Streamlit app; `webui/i18n/en.json` and `webui/i18n/zh.json` are the two fully-maintained locales (other locales fall back to English for supplementary strings — see `ENGLISH_FALLBACK_KEYS` in `test/services/test_webui_i18n.py`).
+- `cli.py` — CLI entrypoint; `main.py` — FastAPI entrypoint.
+- `test/services/` — the pytest suite (one file per service/feature area).
+- `docs/skill/` — a standalone installer/runner script (`mpt_agent.py`) that lets an AI agent install and drive this project as a packaged "Skill", independent of this repo's own dev tooling.
+- `config.example.toml` — config template; real config lives in a gitignored `config.toml`.

--- a/CLAUDE.local.md.example
+++ b/CLAUDE.local.md.example
@@ -1,0 +1,8 @@
+# CLAUDE.local.md (example — copy to CLAUDE.local.md, gitignored)
+
+Personal overrides for this machine/session. Not shared with the team.
+
+Examples:
+- Local paths or ports that differ from the shared setup.
+- Personal shorthand or reminders for this project.
+- Temporary debugging notes.


### PR DESCRIPTION
## Summary
- Adds cross-platform AI coding-agent instructions: `AGENTS.md` as the canonical source (read by Codex CLI, Aider, Continue, Zed, Cursor), plus thin adapter files for Cursor (`.cursor/rules/project.mdc`), GitHub Copilot (`.github/copilot-instructions.md`), and Windsurf (`.windsurfrules`) that all point back to it.
- Adds a Claude Code setup under `.claude/`: modular rules (code style, testing, API/provider conventions), two slash commands (`review`, `fix-issue`), two sub-agents (`code-reviewer`, `security-auditor`), and a `PreToolUse` hook that blocks obviously destructive Bash commands (`rm -rf /`, fork bombs).
- `AGENTS.md` is filled in with this project's actual stack, install/test/lint commands, and a directory map (LLM provider registry, WebUI i18n conventions, `docs/skill/`, etc.) rather than left as a generic template.
- Based on [Vibe Coding Project Structure by ePipra](https://github.com/epipra/Vibe-Coding-Project-Structure-by-ePipra) (MIT), adapted for this repo.
- `.claude/hooks/validate-bash.sh`'s JSON parsing uses `python3` instead of `jq`, since `jq` isn't guaranteed to be installed — notably on the Windows machines this project's `webui.bat`/`webui.sh` split already accounts for — while Python 3.11+ is already a hard requirement here.
- `CLAUDE.md` itself is intentionally *not* added/committed, matching this repo's existing `.gitignore` rule for it (contributors who use Claude Code can still create their own local copy).
- `.gitignore` gains a few small, standard entries for the scaffold's own local-only files (`CLAUDE.local.md`, `.claude/settings.local.json`, `.mcp.json`, `.env.*`, `*.pem`, `*.key`).

No application code is touched — this is purely dev-tooling/config for contributors who use an AI coding agent; everyone else is unaffected.

## Test plan
- [x] Verified `.claude/settings.json` and `.mcp.json.example` are valid JSON
- [x] Verified the Bash hook: benign commands pass, `rm -rf /` and the fork-bomb pattern are both blocked
- [x] Confirmed `CLAUDE.md` is excluded by the existing `.gitignore` rule (`git check-ignore` succeeds)
- N/A automated tests — no `app`/`webui`/`cli` code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)