### PR TITLE
fix(docker): migrate base image from EOL Debian 11 (bullseye) to Debian 12 (bookworm)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-bookworm
 
 # Set the working directory in the container
 WORKDIR /MoneyPrinterTurbo
@@ -23,7 +23,7 @@ RUN set -u; \
     write_debian_sources() { \
         main_url="$1"; \
         security_url="$2"; \
-        printf 'deb %s bullseye main\ndeb %s bullseye-updates main\ndeb %s bullseye-security main\n' \
+        printf 'deb %s bookworm main\ndeb %s bookworm-updates main\ndeb %s bookworm-security main\n' \
             "$main_url" "$main_url" "$security_url" > /etc/apt/sources.list; \
         rm -rf /var/lib/apt/lists/*; \
     }; \
@@ -40,8 +40,8 @@ RUN set -u; \
             fi; \
             echo "Attempt $attempt failed" >&2; \
             if [ "$attempt" -lt 3 ]; then \
-                echo "Retrying in 5 seconds..." >&2; \
-                sleep 5; \
+                echo "Retrying in 10 seconds..." >&2; \
+                sleep 10; \
             fi; \
             attempt=$((attempt + 1)); \
         done; \
@@ -56,13 +56,13 @@ RUN set -u; \
             write_debian_sources \
                 "https://mirrors.tuna.tsinghua.edu.cn/debian" \
                 "https://mirrors.tuna.tsinghua.edu.cn/debian-security"; \
-            if ! install_system_dependencies; then \
+            if ! retry_system_dependencies; then \
                 echo "Tsinghua mirror failed, switching to default Debian mirror" >&2; \
                 write_debian_sources \
                     "https://deb.debian.org/debian" \
                     "https://deb.debian.org/debian-security"; \
-                if ! install_system_dependencies; then \
-                    echo "Failed to install system dependencies from all configured mirrors" >&2; \
+                if ! retry_system_dependencies; then \
+                    echo "All mirrors failed" >&2; \
                     exit 1; \
                 fi; \
             fi; \
@@ -73,7 +73,7 @@ RUN set -u; \
             "https://deb.debian.org/debian" \
             "https://deb.debian.org/debian-security"; \
         if ! retry_system_dependencies; then \
-            echo "Failed to install system dependencies from the default Debian mirror" >&2; \
+            echo "Default Debian mirror failed" >&2; \
             exit 1; \
         fi; \
     fi; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        DOCKER_BUILD_MIRROR: default
     container_name: "moneyprinterturbo-webui"
     ports:
       - "127.0.0.1:8501:8501"
@@ -16,6 +18,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        DOCKER_BUILD_MIRROR: default
     container_name: "moneyprinterturbo-api"
     ports:
       - "127.0.0.1:8080:8080"


### PR DESCRIPTION
## Problem

Debian 11 "bullseye" reached the end of its LTS support on 2026-08-31. As a result, `deb.debian.org/debian-security` has started dropping some bullseye-security package files (observed on arm64: `libtiff5`, `libavfilter7`, `libgbm1`), which breaks `docker compose build` with 404 errors while installing `git`/`ffmpeg`.

`archive.debian.org`, the usual fallback for EOL Debian releases, does not (yet) host an archived bullseye-security tree either, so pointing apt at it cannot satisfy the security-patched dependency versions that `git`/`ffmpeg` need there — apt fails with "you have held broken packages" instead.

This currently breaks a fresh `docker compose up -d --build` for anyone building the image today.

## Fix

- Bump the base image from `python:3.11-slim-bullseye` to `python:3.11-slim-bookworm` (Debian 12, currently fully supported with live mirrors).
- Update the mirror fallback chain (Aliyun -> Tsinghua -> official Debian mirrors) to use bookworm's suites.
- Add a retry loop at every mirror tier instead of only the first one, for resilience against transient CDN hiccups.
- Set `DOCKER_BUILD_MIRROR: default` as a build arg in `docker-compose.yml`, since users outside China otherwise waste build time waiting on mirrors they can't reach before falling through to the official Debian mirror.

## Testing

`docker compose build --no-cache` succeeds for both the `webui` and `api` services on Apple Silicon (arm64) macOS with Docker Desktop, and the WebUI comes up correctly at `http://127.0.0.1:8501`.
