### PR TITLE
fix(tts): handle non-finite voice rates

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -638,7 +638,7 @@ def convert_rate_to_percent(rate: float) -> str:
         rate = float(rate)
     except (TypeError, ValueError):
         rate = 1.0
-    if rate <= 0:
+    if not math.isfinite(rate) or rate <= 0:
         rate = 1.0
     percent = round((rate - 1.0) * 100)
     if percent >= 0:

--- a/test/services/test_voice.py
+++ b/test/services/test_voice.py
@@ -1352,6 +1352,8 @@ class TestVoiceService(unittest.TestCase):
         self.assertEqual(vs.convert_rate_to_percent(0.0), "+0%")
         self.assertEqual(vs.convert_rate_to_percent(None), "+0%")
         self.assertEqual(vs.convert_rate_to_percent(""), "+0%")
+        self.assertEqual(vs.convert_rate_to_percent(float("nan")), "+0%")
+        self.assertEqual(vs.convert_rate_to_percent(float("inf")), "+0%")
 
 
 class TestElevenLabsVoice(unittest.TestCase):


### PR DESCRIPTION
## Summary
- treat NaN and infinite voice rates as invalid input
- fall back to the normal +0% TTS rate instead of raising during rounding
- add regression coverage for both non-finite float values

## Why
Voice rate fields accept floats. NaN and infinity pass the existing non-positive guard, then round() raises ValueError or OverflowError and aborts voice generation. This keeps the existing invalid-input fallback behavior consistent for all unusable rates.

## Testing
- uv run python -X utf8 -m pytest -q test/services/test_voice.py
- 59 passed, 3 skipped, 2 subtests passed