### PR TITLE
fix(material): reclaim temp files orphaned by interrupted cache writes

### DIFF
--- a/app/services/material_cache.py
+++ b/app/services/material_cache.py
@@ -23,6 +23,11 @@ MATERIAL_SEARCH_CACHE_TTL_SECONDS = 24 * 60 * 60
 _CACHE_FORMAT_VERSION = 2
 _CACHE_CLEANUP_INTERVAL_SECONDS = 60 * 60
 _CACHE_FILE_PATTERN = re.compile(r"^[0-9a-f]{64}\.json$")
+# 保存缓存时先写入 NamedTemporaryFile(delete=False)，再用 os.replace 发布。
+# 进程被强制终止（Ctrl+C、容器停止、断电）时 Python 的异常兜底没有机会执行，
+# 会留下一个没有被替换的中间文件；它不匹配上面的缓存文件模式，必须单独识别
+# 才能回收，否则会永久累积在缓存目录里。
+_CACHE_TEMP_FILE_PATTERN = re.compile(r"^\.[0-9a-f]{64}-[a-z0-9_]+\.tmp$")
 
 # API 默认允许多个视频任务并发执行。固定数量的锁分片可以让相同搜索条件共用
 # 一个锁，同时避免按关键词永久保存 Lock 导致内存持续增长。它只负责合并当前
@@ -386,11 +391,12 @@ def cleanup_expired_material_search_cache(
     force: bool = False,
 ) -> int:
     """
-    低频清理没有再次被查询到的过期搜索缓存。
+    低频清理没有再次被查询到的过期搜索缓存，以及中断写入遗留的临时文件。
 
     正常写入路径每小时最多扫描一次目录，避免每次搜索都产生线性目录遍历；
-    ``force`` 仅供测试或显式维护调用。只删除 SHA-256 命名的 JSON 文件，不会
-    触碰用户放入目录的其它文件。
+    ``force`` 仅供测试或显式维护调用。只删除 SHA-256 命名的 JSON 缓存文件和本
+    模块自己生成的 ``.tmp`` 中间文件，不会触碰用户放入目录的其它文件。两者共用
+    同一套过期判定，因此仍在写入中的临时文件不会被并发清理误删。
     """
     global _last_cleanup_monotonic
 
@@ -420,7 +426,10 @@ def cleanup_expired_material_search_cache(
     failed_count = 0
     with entries:
         for entry in entries:
-            if not _CACHE_FILE_PATTERN.fullmatch(entry.name):
+            if not (
+                _CACHE_FILE_PATTERN.fullmatch(entry.name)
+                or _CACHE_TEMP_FILE_PATTERN.fullmatch(entry.name)
+            ):
                 continue
             try:
                 if not entry.is_file(follow_symlinks=False):

--- a/test/services/test_material_cache.py
+++ b/test/services/test_material_cache.py
@@ -592,6 +592,55 @@ class TestMaterialSearchCache(unittest.TestCase):
         self.assertTrue(fresh_path.exists())
         self.assertTrue(unrelated_path.exists())
 
+    def test_cleanup_removes_orphaned_temp_files(self):
+        """
+        进程被强制终止时，NamedTemporaryFile(delete=False) 留下的中间文件没有
+        机会被 os.replace 消费，也不会触发异常兜底删除。它必须和过期缓存一起
+        回收，否则每次异常中断都会在缓存目录里永久累积一个残留文件。
+        """
+        orphan_path = Path(self.temp_dir.name) / (
+            f".{self._cache_path().stem}-m429jzwe.tmp"
+        )
+        orphan_path.write_text('{"version":2,"items":[]}', encoding="utf-8")
+        unrelated_path = Path(self.temp_dir.name) / "notes.tmp"
+        unrelated_path.write_text("keep", encoding="utf-8")
+
+        now = 2_000_000_000.0
+        stale_mtime = now - material_cache.MATERIAL_SEARCH_CACHE_TTL_SECONDS - 1
+        os.utime(orphan_path, (stale_mtime, stale_mtime))
+        os.utime(unrelated_path, (stale_mtime, stale_mtime))
+
+        deleted = material_cache.cleanup_expired_material_search_cache(
+            now=now,
+            force=True,
+        )
+
+        self.assertEqual(deleted, 1)
+        self.assertFalse(orphan_path.exists())
+        # 前缀不匹配的其它文件属于用户，不能被清理逻辑删除。
+        self.assertTrue(unrelated_path.exists())
+
+    def test_cleanup_keeps_recent_temp_files(self):
+        """
+        并发搜索时另一个进程可能正在写临时文件。清理必须复用缓存的过期判定，
+        让尚未超期的中间文件保持原样，避免删掉正在等待 os.replace 的文件。
+        """
+        in_flight_path = Path(self.temp_dir.name) / (
+            f".{self._cache_path().stem}-m429jzwe.tmp"
+        )
+        in_flight_path.write_text('{"version":2,"items":', encoding="utf-8")
+
+        now = 2_000_000_000.0
+        os.utime(in_flight_path, (now - 1, now - 1))
+
+        deleted = material_cache.cleanup_expired_material_search_cache(
+            now=now,
+            force=True,
+        )
+
+        self.assertEqual(deleted, 0)
+        self.assertTrue(in_flight_path.exists())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`save_material_search_cache()` publishes a cache entry by writing a `NamedTemporaryFile(delete=False)` and then calling `os.replace()`. The in-process failure path is handled: the `except` block unlinks the temporary file if anything raises.

That fallback does **not** run when the process is killed outright — `Ctrl+C` during the write, `docker stop`, an OOM kill, or a power loss. In those cases an intermediate file is left behind in `storage/cache_material_search/`:

```
.39c0a7e474a1d1c912c518fa30286705ba8374eea69dcfcdf338d2dd70096ef4-m429jzwe.tmp
```

`cleanup_expired_material_search_cache()` is the only thing that prunes this directory, and its filename filter is `^[0-9a-f]{64}\.json$`. A leading-dot `.tmp` file never matches it, so the orphan is never reclaimed and accumulates for the lifetime of the storage directory.

Reproduced on the pre-patch code by simulating a hard kill (creating the intermediate file directly, with an mtime older than the TTL) and then calling the public cleanup entry point:

```
cleanup returned: 0
dir contents: ['.39c0a7e4...ef4-deadbeef.tmp', '39c0a7e4...ef4.json']
orphan still present: True
```

## Solution

Recognise the module's own intermediate files in the cleanup scan, reusing the expiry rule that is already applied to cache files.

Reusing the same TTL is the deliberate choice here: a temporary file lives for milliseconds in normal operation, so anything older than `MATERIAL_SEARCH_CACHE_TTL_SECONDS` cannot belong to a concurrent writer. This keeps the change free of any new timing constant and preserves the guarantee that a write in flight is never deleted by a parallel cleanup.

## Changes

`app/services/material_cache.py`

- Add `_CACHE_TEMP_FILE_PATTERN` (`^\.[0-9a-f]{64}-[a-z0-9_]+\.tmp$`) next to `_CACHE_FILE_PATTERN`. The `.<64-hex digest>-` prefix is generated by this module only, so the filter stays as narrow as the existing one and still cannot match a file a user placed in the directory.
- Let `cleanup_expired_material_search_cache()` match either pattern before the existing age check. No change to the deletion rule, the returned count semantics, or any public signature.

`test/services/test_material_cache.py`

- `test_cleanup_removes_orphaned_temp_files` — happy path: a stale intermediate file is reclaimed, while a stale `notes.tmp` that does not carry the module prefix is left untouched.
- `test_cleanup_keeps_recent_temp_files` — boundary: an intermediate file written moments ago (a concurrent writer that has not reached `os.replace` yet) is preserved.

## Testing

```
$ python -X utf8 -m pytest -q test/services/test_material_cache.py
21 passed
```

- The happy-path test fails on the pre-patch code (`AssertionError: 0 != 1`) and passes after the change, so it is a genuine regression test rather than a tautology.
- The boundary test passes both before and after by design — it is a guard that the new filter does not over-delete.

Full local suite:

```
$ python -X utf8 -m pytest -q test
1161 passed, 19 skipped, 1 failed
```

The single failure is `test_webui_headless_task_actions.py::test_headless_open_folder_shows_host_mapped_path`, which patches `sys.platform` to `linux` and then lets `moviepy` import `numpy` on a real Windows host, where `numpy`'s `hugepage_setup()` calls `os.uname()`. It is unrelated to this change: it fails identically on a clean `main` checkout, and it does not reproduce on the Linux runners that the test targets.

Windows smoke subset used by CI (`test_config`, `test_state`, `test_task`, `test_task_manager`, `test_upload_post`, `test_controller_video`, `test_webui_task`):

```
152 passed, 4 skipped
```

Lint gate, executed with the version pinned in `uv.lock`:

```
$ ruff check app cli.py main.py webui test   # ruff 0.15.21
All checks passed!
```

## Notes for Reviewer

- **Scope:** 2 files, +62 / −4 lines. No new dependency, no new configuration key, no change to any public signature or return type.
- **Overlap with my earlier work in this repo:** my only previous PR here is [#1246](https://github.com/harry0703/MoneyPrinterTurbo/pull/1246) (`docs(readme): add Fish Audio to EN/JA TTS provider lists`), which touched `README-en.md` and `README-ja.md`. This PR touches neither file, and no file in this PR is currently modified by an open pull request.
- **Not addressed here:** if a temporary file is created and the process survives but `os.replace` fails with an unexpected error, the existing `except` block already unlinks it. This change covers only the hard-termination case, which is the one that leaves an unrecoverable orphan.
