### PR TITLE
docs(readme): point one-click package users at the release Assets

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -287,6 +287,11 @@ Download the latest Windows one-click package from GitHub Releases, then extract
 
 - [Download the latest Windows one-click package](https://github.com/harry0703/MoneyPrinterTurbo/releases/latest)
 
+> Download the `.7z` archive from the **Assets** section of that page. The
+> auto-generated `Source code (zip)` / `Source code (tar.gz)` archives contain
+> source code only: after extracting them you get `webui.bat` but no `start.bat`
+> or `update.bat`.
+
 After downloading, it is recommended to **double-click** `update.bat` first to update to the **latest code**, then double-click `start.bat` to launch
 
 After launching, the browser will open automatically (if it opens blank, it is recommended to use **Chrome** or **Edge**)

--- a/README-ja.md
+++ b/README-ja.md
@@ -266,6 +266,10 @@ GitHub Releases から最新の Windows 用ワンクリックパッケージを�
 
 - [最新の Windows 用ワンクリックパッケージをダウンロード](https://github.com/harry0703/MoneyPrinterTurbo/releases/latest)
 
+> 同ページの **Assets** から `.7z` ファイルをダウンロードしてください。GitHub が
+> 自動生成する `Source code (zip)` / `Source code (tar.gz)` はソースコードのみで、
+> 展開しても `webui.bat` だけが現れ、`start.bat` と `update.bat` は含まれません。
+
 ダウンロード後は、まず `update.bat` を**ダブルクリック**して**最新のコード**に更新し、その後 `start.bat` をダブルクリックして起動することを推奨します
 
 起動するとブラウザーが自動的に開きます（真っ白な画面になる場合は **Chrome** または **Edge** の利用を推奨します）

--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@
 
 - [下载最新 Windows 一键启动包](https://github.com/harry0703/MoneyPrinterTurbo/releases/latest)
 
+> 请在页面下方的 **Assets** 区域下载 `.7z` 压缩包。GitHub 自动生成的
+> `Source code (zip)` / `Source code (tar.gz)` 只是源码，解压后只有 `webui.bat`，
+> 不含 `start.bat` 和 `update.bat`。
+
 下载后，建议先**双击执行** `update.bat` 更新到**最新代码**，然后双击 `start.bat` 启动
 
 启动后，会自动打开浏览器（如果打开是空白，建议换成 **Chrome** 或者 **Edge** 打开）


### PR DESCRIPTION
## Problem

`README.md` (and the EN/JA translations) tell Windows users to download the one-click package, link to the `releases/latest` page, and then — on the very next line — instruct them to double-click `update.bat` and `start.bat`.

That page also lists GitHub's auto-generated **Source code (zip)** and **Source code (tar.gz)** archives. A user who picks one of those extracts a directory containing only `webui.bat`, and then finds neither script the next line tells them to run, which reads like the download link is wrong. That is issue #1337, where the reporter wrote *"沒有 update.bat 也沒有 start.bat 只有 webui.bat，請問連結是否給錯"* and said they had searched every release without finding the right file.

Checked against the repository and the releases API:

- `git ls-files` tracks exactly one `.bat` file, `webui.bat`. There is no `start.bat` and no `update.bat` anywhere in the tree, so no source archive can contain them.
- The current release (`v1.3.6`) publishes exactly one asset: `MoneyPrinterTurbo-Portable-Windows-1.3.6.7z` (944 MB, 8740 downloads). The one-click package lives in the release **Assets** section as a `.7z`, which the README never says.

## Solution

Add a short note directly under the download link that names the **Assets** section, names the `.7z` archive, and states what the auto-generated source archives do and do not contain. The clarification is added to all three localized READMEs so they stay in step.

A direct link was considered and rejected: `releases/latest/download/<asset>` requires the exact asset name, and this asset embeds its version (`...-Windows-1.3.6.7z`), so such a link would break on every release. Pointing at the Assets area keeps the existing link valid.

## Changes

Three README files, 13 inserted lines, no deletions, no rewording of existing text:

- `README.md` — note added under the "下载最新 Windows 一键启动包" link
- `README-en.md` — same note under "Download the latest Windows one-click package"
- `README-ja.md` — same note under "最新の Windows 用ワンクリックパッケージをダウンロード"

## Testing

Documentation-only change; `git diff --stat` reports `3 files changed, 13 insertions(+)` and nothing else.

- No source or test file reads these documents — verified with `grep -rn "README" test/ app/ webui/ cli.py main.py` (the only hit is a user-facing FAQ link string in `app/services/subtitle.py`, which is untouched).
- CI is unaffected: `compileall`, `ruff check` and `pytest` operate on Python sources only, and this repository has no Markdown lint gate.
- Full local suite still run for completeness, on this branch:

```
$ python -X utf8 -m pytest -q test
1 failed, 1177 passed, 19 skipped, 9652 subtests passed
```

The single failure is `test/services/test_webui_headless_task_actions.py::test_headless_open_folder_shows_host_mapped_path`, which patches `sys.platform` to `linux` and then lets `moviepy` import `numpy` on a Windows host, where `numpy`'s `hugepage_setup()` calls `os.uname()`. It fails identically on a clean `main` checkout and is unrelated to this change.

Markdown line endings were checked before committing: each file stays CRLF throughout (`* text=auto` in `.gitattributes` normalizes to LF in the repository), and the inserted lines add exactly 4/5/4 CR-terminated lines, matching their file.

## Notes for Reviewer

- **Scope:** 3 files, +13 / −0. No source, test, config, or dependency changes.
- **Overlap with open pull requests:** no open PR modifies the lines involved. The nearest open hunks are `README.md` line 256, `README-en.md` line 233 and `README-ja.md` line 231; this change sits at lines 287/287/266 respectively, so the edits do not textually conflict.
- **Overlap with my earlier work here:** my previous PRs are [#1246](https://github.com/harry0703/MoneyPrinterTurbo/pull/1246) (Fish Audio TTS provider lists) and [#1345](https://github.com/harry0703/MoneyPrinterTurbo/pull/1345) (material cache temp files, merged). #1246 also touched `README-en.md`/`README-ja.md`, but in the TTS provider list section, far from this one.
- If you would rather keep the Windows section terse, the alternative is to rename the release asset to a version-independent name so `releases/latest/download/<asset>` can be linked directly — I did not make that call here since it changes your release process.
