### PR TITLE
feat(video): log concat progress while ffmpeg is running

### DIFF
--- a/app/services/video.py
+++ b/app/services/video.py
@@ -7,6 +7,8 @@ import gc
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 import unicodedata
 from contextlib import ExitStack, redirect_stdout
 from functools import lru_cache
@@ -82,6 +84,9 @@ _MIN_MATERIAL_DIMENSION = 480
 # 既能放行仅仅因为取整而略低于阈值的素材，也仍然能挡住真正的低清素材。
 _MIN_DIMENSION_TOLERANCE = 10
 _DEFAULT_VIDEO_CODEC = "libx264"
+# ffmpeg 串联片段期间没有阶段日志，`subprocess.run` 又阻塞到进程退出，耗时拼接在
+# 日志上表现为“无输出”。这里按间隔记录存活信息，便于区分编码中与已经卡死。
+_FFMPEG_CONCAT_HEARTBEAT_SECONDS = 30.0
 _SUBTITLE_SPRING_DURATION_SECONDS = 0.18
 _MIN_SUBTITLE_SPRING_SCALE = 0.05
 _MAX_SUBTITLE_SPRING_SCALE = 1.35
@@ -436,6 +441,42 @@ def _format_ffmpeg_concat_path(file_path: str) -> str:
     return _escape_ffmpeg_concat_path(absolute_path.replace("\\", "/"))
 
 
+def _describe_concat_output_progress(output_file: str) -> str:
+    """返回输出文件当前大小的可读描述，用于拼接心跳日志。"""
+    try:
+        size = os.path.getsize(output_file)
+    except OSError:
+        # 输出文件尚未创建时同样要安全降级，不能影响拼接本身。
+        return "output size not available"
+    return f"output size: {size / (1024 * 1024):.2f} MB"
+
+
+def _run_concat_with_heartbeat(command: list[str], output_file: str):
+    """
+    阻塞等待 ffmpeg 完成，期间按间隔记录存活日志。
+
+    ffmpeg 串联片段时没有阶段日志，`subprocess.run` 又把输出缓冲到进程退出，耗时拼接
+    在日志上表现为“无输出”。记录已等待时长与输出文件大小，便于区分仍在编码与已经卡死。
+    """
+    started_at = time.monotonic()
+    stop_event = threading.Event()
+
+    def log_heartbeat() -> None:
+        while not stop_event.wait(_FFMPEG_CONCAT_HEARTBEAT_SECONDS):
+            logger.info(
+                "ffmpeg concat still running: "
+                f"elapsed={time.monotonic() - started_at:.0f}s, "
+                f"{_describe_concat_output_progress(output_file)}"
+            )
+
+    reporter = threading.Thread(target=log_heartbeat, daemon=True)
+    reporter.start()
+    try:
+        return subprocess.run(command, capture_output=True, text=True, check=False)
+    finally:
+        stop_event.set()
+
+
 def concat_video_clips_with_ffmpeg(
     clip_files: List[str],
     output_file: str,
@@ -473,13 +514,8 @@ def concat_video_clips_with_ffmpeg(
     def run_concat(codec: str):
         command = build_command(codec)
         # 使用 ffmpeg 只做一次串联与编码，避免 MoviePy 逐段合并时反复重编码，
-        # 从而降低画质劣化与颜色偏移风险。
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        # 从而降低画质劣化与颜色偏移风险。阻塞等待期间由心跳日志体现任务仍在运行。
+        result = _run_concat_with_heartbeat(command, output_file)
         if result.returncode != 0:
             error_message = (result.stderr or result.stdout or "").strip()
             raise RuntimeError(error_message or "ffmpeg concat failed")

--- a/test/services/test_video.py
+++ b/test/services/test_video.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import sys
 import tempfile
+import time
 import types
 import unittest
 from contextlib import redirect_stdout
@@ -983,6 +984,59 @@ class TestVideoService(unittest.TestCase):
         command = run.call_args.args[0]
         self.assertEqual(command[command.index("-t") + 1], "10.000")
         self.assertLess(command.index("-t"), command.index(output_file))
+
+    def test_concat_video_clips_logs_heartbeat_while_ffmpeg_runs(self):
+        """
+        拼接时 subprocess.run 会阻塞到 ffmpeg 退出，期间项目不再产生任何日志，用户
+        无法区分仍在编码与已经卡死（issue #1342）。等待期间必须记录存活信息。
+        """
+
+        def slow_run(command, capture_output, text, check):
+            # 模拟一次耗时拼接：这段窗口内心跳线程应至少记录一次存活日志。
+            time.sleep(0.2)
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            clip_file = os.path.join(temp_dir, "clip.mp4")
+            output_file = os.path.join(temp_dir, "combined.mp4")
+            Path(clip_file).write_bytes(b"fake")
+            Path(output_file).write_bytes(b"x" * 2048)
+
+            with patch.object(vd, "_FFMPEG_CONCAT_HEARTBEAT_SECONDS", 0.02):
+                with patch.object(vd.subprocess, "run", side_effect=slow_run):
+                    with patch.object(vd.logger, "info") as info_mock:
+                        vd.concat_video_clips_with_ffmpeg(
+                            clip_files=[clip_file],
+                            output_file=output_file,
+                            threads=1,
+                            output_dir=temp_dir,
+                        )
+
+        heartbeats = [
+            str(call.args[0])
+            for call in info_mock.call_args_list
+            if "still running" in str(call.args[0])
+        ]
+        self.assertTrue(heartbeats, "耗时拼接期间必须记录存活日志")
+        self.assertRegex(heartbeats[0], r"elapsed=\d+s, output size: 0\.00 MB")
+
+    def test_concat_video_clips_heartbeat_tolerates_missing_output_file(self):
+        """
+        拼接刚开始时输出文件尚未创建，心跳描述必须安全降级；若探测文件大小的异常
+        穿透到拼接调用，本可正常完成的任务会变成失败。
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.assertIn(
+                "not available",
+                vd._describe_concat_output_progress(
+                    os.path.join(temp_dir, "absent.mp4")
+                ),
+            )
+            existing = os.path.join(temp_dir, "present.mp4")
+            Path(existing).write_bytes(b"x" * 2048)
+            self.assertIn(
+                "output size: 0.00 MB", vd._describe_concat_output_progress(existing)
+            )
 
     def test_prioritize_unique_source_clips_uses_each_source_before_reuse(self):
         """


### PR DESCRIPTION
## Problem

`combine_videos` 的拼接阶段只输出两行日志，之后 ffmpeg 的全部输出都会被
`concat_video_clips_with_ffmpeg` 内的 `subprocess.run(capture_output=True)`
缓冲到进程退出：

```
| INFO | video.py:805 combine_videos - starting clip merging process
| INFO | video.py:811 combine_videos - concatenating 32 clips with ffmpeg
```

片段较多或编码较慢时（例如 32 段），日志会长时间停在这里。用户无法判断任务仍在
编码还是已经卡死 —— issue #1342 的用户正是因此等待了 12 小时，维护者在回复中也
只能额外索要任务管理器截图来判断 ffmpeg 是否还活着：

> 不过目前拼接阶段没有实时输出 FFmpeg 进度，日志仍可能停在同一行，因此任务管理器截图也很有帮助。

## Solution

在等待 ffmpeg 期间用守护线程按固定间隔记录一次存活日志，带上已等待时长与输出文件
当前大小：

```
| INFO | ffmpeg concat still running: elapsed=30s, output size: 18.42 MB
```

- **输出文件大小持续增长** → ffmpeg 仍在写出内容，属于正常慢编码；
- **长时间不增长** → 提示进程可能已卡住。

选这个做法而不是解析 ffmpeg 进度，原因有二：本项目有意保持 ffmpeg 输出安静
（`_open_video_clip_quietly` 专门屏蔽了 MoviePy 的探测噪声），直接放开会污染终端；
而解析 `-progress` 需要改变现有 ffmpeg 调用方式并连带改动多个既有测试。心跳方式
完全不改动 `subprocess.run` 的调用形态，零侵入。

## Changes

`app/services/video.py`

- 新增 `_FFMPEG_CONCAT_HEARTBEAT_SECONDS = 30.0`（心跳间隔）。
- 新增 `_describe_concat_output_progress()`：返回输出文件大小的可读描述，文件不存在
  时安全降级为 `output size not available`，不影响拼接本身。
- 新增 `_run_concat_with_heartbeat()`：阻塞等待 ffmpeg，期间记录存活日志。
- `concat_video_clips_with_ffmpeg.run_concat` 改用上述辅助函数。**ffmpeg 进程调用
  方式、编解码器回退逻辑、错误消息来源（stderr）全部保持不变。**

`test/services/test_video.py`

- `test_concat_video_clips_logs_heartbeat_while_ffmpeg_runs`（happy path）：耗时拼接
  期间必须记录含 `elapsed=` 与 `output size:` 的存活日志。
- `test_concat_video_clips_heartbeat_tolerates_missing_output_file`（边界）：输出文件
  尚未创建时描述安全降级，已存在时报告真实大小。

## Testing

- `pytest -q test/services/test_video.py` → **52 passed, 44 subtests passed**
- 两个新增测试在改动前**失败**（`_FFMPEG_CONCAT_HEARTBEAT_SECONDS` 与
  `_describe_concat_output_progress` 尚不存在），确认为真实回归测试而非凑数。
- 全量 `pytest -q test` → **1 failed, 1179 passed, 19 skipped, 9652 subtests passed**
  （该失败与本改动无关，见下；`passed` 由改动前的 1177 增至 1179，即新增的两个测试）
- 复刻 CI 门禁：`compileall` 通过；与 `uv.lock` 锁定版本一致的 ruff 0.15.21
  → `All checks passed!`

**一个与本次改动无关的既有失败**：本机运行的
`test/services/test_webui_headless_task_actions.py::test_headless_open_folder_shows_host_mapped_path`
会失败 —— 该测试 patch `sys.platform = "linux"` 后重新执行 `webui/Main.py`，触发
numpy 的 `hugepage_setup()` 走 Linux 分支并调用 `os.uname()`，而真实操作系统是
Windows，没有该属性。在未改动的干净 `main` 上同样失败，属本机环境产物。

## Notes for Reviewer

- 这是**可观测性改进，不是 #1342 的完整修复**。ffmpeg 为何卡住仍需复现日志才能定位；
  本 PR 让下一次复现时日志能直接体现进度是否仍在推进。
- **与现有 open PR 的冲突**：`app/services/video.py` 当前有 5 个 open PR
  （#1210 / #1297 / #1304 / #1331 / #1332）。已逐个核对它们的 hunk 范围，本改动只落在
  `_format_ffmpeg_concat_path` 之后的辅助函数区与 `concat_video_clips_with_ffmpeg` 内部的
  `run_concat`，最近的重叠候选是 #1297（545/555 行）与 #1331（555 行），**均不与本改动
  所在区域重叠**。
- 我此前在本仓库的两个 PR（#1345、#1349，均已合并）改动的是
  `app/services/material_cache.py`、`test/services/test_material_cache.py` 与 `README*.md`，
  与本 PR **无文件重叠**。
- 心跳间隔默认 30 秒：足够稀疏以免刷屏，又能在典型卡死场景下较快体现。如需调整，改
  `_FFMPEG_CONCAT_HEARTBEAT_SECONDS` 即可。
