### PR TITLE
fix(skill): support the openai_image material source in the agent helper

### DIFF
--- a/docs/skill/mpt_agent.py
+++ b/docs/skill/mpt_agent.py
@@ -32,6 +32,9 @@ SUPPORTED_SOURCES = {
     "volcengine_seedance",
     "ofox",
     "metaso_minimax",
+    # Keep this list aligned with ``_CLI_VIDEO_SOURCES`` in cli.py. A source that
+    # the CLI accepts must not be rejected here as unsupported.
+    "openai_image",
     "local",
 }
 VOLCENGINE_ARK_API_KEY_URL = (
@@ -382,6 +385,13 @@ def missing_config(config_path: Path, cli_args: list[str]) -> tuple[str, list[st
             missing.append("metaso_minimax_api_key")
         if not has_cli_option(cli_args, "--confirm-metaso-minimax-charge"):
             missing.append("confirm_metaso_minimax_charge")
+    elif source == "openai_image":
+        # 与运行时的 is_openai_image_enabled() 保持一致：文生图素材源只要求端点
+        # 与模型名。完全本地的 ComfyUI/SD 网关允许不配置 API Key，因此这里不
+        # 能把 openai_image_api_keys 当作必填项。
+        for field in ("openai_image_base_url", "openai_image_model"):
+            if not _has_configured_value(_plain_config_value(text, field)):
+                missing.append(field)
     elif source != "local":
         value = _plain_config_value(text, f"{source}_api_keys")
         if not _has_configured_value(value):
@@ -416,6 +426,12 @@ def report_missing_config(provider: str, missing: list[str]) -> int:
         print(
             "OPENAI_COMPATIBLE_REQUIRED="
             "API key, API base URL, model name"
+        )
+    if any(field.startswith("openai_image_") for field in missing):
+        print(
+            "OPENAI_IMAGE_REQUIRED="
+            "openai_image_base_url, openai_image_model (the API key is optional "
+            "for local gateways)"
         )
     if "pexels_api_keys" in missing:
         print(f"PEXELS_API_KEY_URL={PEXELS_API_KEY_URL}")

--- a/test/services/test_mpt_agent_skill.py
+++ b/test/services/test_mpt_agent_skill.py
@@ -31,6 +31,9 @@ coverr_api_keys = []
 volcengine_seedance_api_key = ""
 ofox_api_key = ""
 metaso_minimax_api_key = ""
+openai_image_base_url = ""
+openai_image_model = ""
+openai_image_api_keys = []
 oneapi_api_key = ""
 oneapi_base_url = ""
 oneapi_model_name = ""
@@ -147,6 +150,55 @@ class TestMptAgentSkill(unittest.TestCase):
 
             self.assertEqual(default_missing, ["pexels_api_keys"])
             self.assertEqual(pixabay_missing, [])
+
+    def test_openai_image_source_accepts_keyless_local_gateway(self):
+        """文生图素材源只需要端点与模型名，本地网关允许不配置 API Key。"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "config.toml"
+            config_path.write_text(
+                MINIMAL_CONFIG.replace(
+                    'moonshot_api_key = ""', 'moonshot_api_key = "configured"'
+                )
+                .replace(
+                    'openai_image_base_url = ""',
+                    'openai_image_base_url = "http://127.0.0.1:7860/v1"',
+                )
+                .replace(
+                    'openai_image_model = ""', 'openai_image_model = "local-sd"'
+                ),
+                encoding="utf-8",
+            )
+
+            _, missing = mpt_agent.missing_config(
+                config_path, ["--video-source", "openai_image"]
+            )
+
+            self.assertEqual(missing, [])
+
+    def test_missing_openai_image_inputs_report_endpoint_and_model(self):
+        """端点或模型名缺失时必须回报字段名，且不能把可选的 Key 当作缺失。"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "config.toml"
+            config_path.write_text(
+                MINIMAL_CONFIG.replace(
+                    'moonshot_api_key = ""', 'moonshot_api_key = "configured"'
+                ),
+                encoding="utf-8",
+            )
+
+            _, missing = mpt_agent.missing_config(
+                config_path, ["--video-source", "openai_image"]
+            )
+            output = io.StringIO()
+            with redirect_stdout(output):
+                code = mpt_agent.report_missing_config("moonshot", missing)
+
+            self.assertEqual(
+                missing, ["openai_image_base_url", "openai_image_model"]
+            )
+            self.assertEqual(code, mpt_agent.NEEDS_INPUT_EXIT_CODE)
+            self.assertIn("OPENAI_IMAGE_REQUIRED=", output.getvalue())
+            self.assertNotIn("LLM_PROVIDER_OPTIONS_BEGIN", output.getvalue())
 
     def test_ofox_source_requires_key_and_explicit_charge_confirmation(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Problem

`docs/skill/mpt_agent.py` keeps its own allow-list of material sources and rejects anything outside it:

```python
source = selected_video_source(cli_args)
if source not in SUPPORTED_SOURCES:
    raise SkillError(f"unsupported video source: {source}")
```

That list was never updated when `openai_image` was added to the CLI (`1727d7a`, 2026-09-01), and the helper was edited twice afterwards (`ba49f34`, `44ce430`) without picking the source up. The CLI accepts the value:

```
--video-source {pexels,pixabay,coverr,volcengine_seedance,ofox,metaso_minimax,openai_image,local}
```

so an agent that forwards `--video-source openai_image` — for example because the user asked to generate the clips on their own local ComfyUI/SD gateway — gets

```
MPT_ERROR=unsupported video source: openai_image
```

and exit code 1 before any generation starts. Reproduced against the current `main`:

```text
SUPPORTED_SOURCES = ['coverr', 'local', 'metaso_minimax', 'ofox', 'pexels', 'pixabay', 'volcengine_seedance']
openai_image 在支持列表中 = False
识别出的素材源 = openai_image
missing_config 抛出 SkillError: unsupported video source: openai_image
```

A naive "add it to the set" fix would have introduced a second bug: the generic branch below requires `f"{source}_api_keys"`, but the runtime only requires a base URL and a model name for this source, and `config.example.toml` documents the key as optional:

```python
def is_openai_image_enabled(app_config: dict | None = None) -> bool:
    """
    API Key 允许为空：完全本地的 ComfyUI/SD 网关通常不需要鉴权，为空时
    请求不带 Authorization 头。
    """
    return bool(
        str(app_config.get("openai_image_base_url", "") or "").strip()
        and str(app_config.get("openai_image_model", "") or "").strip()
    )
```

## Solution

1. Add `openai_image` to `SUPPORTED_SOURCES` so the helper accepts every source the CLI accepts.
2. Give the source its own precheck branch that requires `openai_image_base_url` and `openai_image_model`, mirroring `is_openai_image_enabled()`. The API key is deliberately **not** required, so a keyless local gateway is not blocked by a false "missing credential" report.
3. Report those two fields to the agent when they are absent (`OPENAI_IMAGE_REQUIRED=...`), following the existing `OPENAI_COMPATIBLE_REQUIRED=` convention, so the agent can ask for the right values instead of a generic failure.

`SKILL.md` needs no change: it never enumerates sources, and the helper teaches the agent about the two fields through the existing `MPT_NEEDS_INPUT` protocol.

## Changes

- `docs/skill/mpt_agent.py` (+16)
  - `SUPPORTED_SOURCES`: add `openai_image`, with a comment pointing at `_CLI_VIDEO_SOURCES` in `cli.py` as the list to keep in sync.
  - `missing_config()`: new `elif source == "openai_image":` branch checking `openai_image_base_url` / `openai_image_model`.
  - `report_missing_config()`: emit `OPENAI_IMAGE_REQUIRED=` for those fields.
- `test/services/test_mpt_agent_skill.py` (+52)
  - `MINIMAL_CONFIG` gains the three `openai_image_*` keys, matching `config.example.toml`.
  - `test_openai_image_source_accepts_keyless_local_gateway` — configured base URL + model and an empty key list must report nothing missing.
  - `test_missing_openai_image_inputs_report_endpoint_and_model` — both field names are reported, the optional key is not reported, and no LLM provider prompt is printed.

No new dependencies, no interface changes, no behaviour change for the other seven sources.

## Testing

- `test/services/test_mpt_agent_skill.py` → **26 passed** (24 before, 2 new).
- Both new tests **fail on `main`** with `SkillError: unsupported video source: openai_image`, so they are real regression tests rather than restatements of the new code.
- Full suite (`pytest -q test`) → **1 failed, 1181 passed, 19 skipped, 9652 subtests passed** (1179 → 1181 is exactly the two new tests)
  - The one failure is `test_webui_headless_task_actions.py::test_headless_open_folder_shows_host_mapped_path`, which also fails on an unmodified `main` on this machine. It is an environment artefact of running the suite on Windows: the test patches `sys.platform` to `"linux"`, `webui/Main.py` is then re-executed, and numpy's `hugepage_setup()` takes the Linux branch and calls `os.uname()`, which does not exist on `win32`. It is unrelated to this change (no file in this PR is imported by that path) and does not reproduce on the Linux CI runners.
- `ruff check` (0.15.21, the version pinned in `uv.lock`) → `All checks passed!`
- `python -m compileall` on both files → OK
- End-to-end check with the reproduction script above: the same command that raised `SkillError` now returns `missing_config -> moonshot []`.

## Notes for Reviewer

- **Overlap with my earlier PRs**: `#1345` (`app/services/material_cache.py`, `test/services/test_material_cache.py`), `#1349` (`README.md`, `README-en.md`, `README-ja.md`) and `#1351` (`app/services/video.py`, `test/services/test_video.py`) are all merged. Neither file in this PR overlaps with any of them, so there is no follow-up maintenance coupling.
- **Overlap with open PRs**: neither `docs/skill/mpt_agent.py` nor `test/services/test_mpt_agent_skill.py` is touched by any of the 17 open PRs, so this branch merges cleanly today.
- One adjacency worth flagging: `docs/skill/SKILL.md` **is** modified by open PR **#1322**. This PR deliberately does not touch `SKILL.md` — no documentation change is needed for this fix — so the two do not conflict.
- The source list lives in two places (`cli.py::_CLI_VIDEO_SOURCES` and this helper). I kept the alignment as a comment rather than importing from `cli.py` because the helper is distributed standalone (it is downloaded on its own by agents that only have the remote `SKILL.md`) and must stay dependency-free.
