### PR TITLE
fix(skill): treat claude_code as a keyless LLM provider in the agent helper

### DIFF
--- a/docs/skill/mpt_agent.py
+++ b/docs/skill/mpt_agent.py
@@ -68,7 +68,13 @@ RECOMMENDED_LLM_PROVIDERS = {
         "https://platform.xiaomimimo.com/docs/zh-CN/quick-start/first-api-call",
     ),
 }
-KEYLESS_LLM_PROVIDERS = {"ollama", "litellm"}
+# Providers that generate without an API key stored in config.toml: Ollama talks
+# to a local server, LiteLLM resolves credentials through its own environment,
+# and ``claude_code`` consumes the Claude subscription through the locally
+# logged-in ``claude`` CLI. Keep this set aligned with the
+# ``requires_api_key=False`` entries of ``app/models/llm_provider.py``; asking
+# the user for a key that the provider never reads leaves the Skill stuck.
+KEYLESS_LLM_PROVIDERS = {"ollama", "litellm", "claude_code"}
 CUSTOM_OPENAI_PROVIDER = "oneapi"
 
 # Hidden providers such as Qwen, Azure, and Grok remain usable when already

--- a/test/services/test_mpt_agent_skill.py
+++ b/test/services/test_mpt_agent_skill.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from app.models.llm_provider import LLM_PROVIDER_REGISTRY
+
 
 SKILL_SCRIPT = (
     Path(__file__).parent.parent.parent / "docs" / "skill" / "mpt_agent.py"
@@ -402,6 +404,46 @@ class TestMptAgentSkill(unittest.TestCase):
                 config_path.read_text(encoding="utf-8"),
             )
             self.assertNotIn(secret, output.getvalue())
+
+    def test_keyless_providers_stay_aligned_with_the_provider_registry(self):
+        """辅助脚本的无 Key 集合必须与 Provider 注册表保持一致。"""
+        registry_keyless = {
+            provider.provider_id
+            for provider in LLM_PROVIDER_REGISTRY
+            if not provider.requires_api_key
+        }
+
+        self.assertEqual(mpt_agent.KEYLESS_LLM_PROVIDERS, registry_keyless)
+
+    def test_claude_code_subscription_provider_needs_no_api_key(self):
+        """
+        Claude Code 走本机订阅，辅助脚本不能再要求一把并不存在的 API Key。
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "config.toml"
+            config_path.write_text(
+                MINIMAL_CONFIG.replace(
+                    'llm_provider = "moonshot"', 'llm_provider = "claude_code"'
+                ).replace(
+                    'deepseek_api_key = ""',
+                    'deepseek_api_key = "already-configured-key"',
+                ).replace("pexels_api_keys = []", 'pexels_api_keys = ["pexels-key"]'),
+                encoding="utf-8",
+            )
+            output = io.StringIO()
+
+            with redirect_stdout(output):
+                provider = mpt_agent.reuse_existing_llm_provider(config_path)
+            active_provider, missing = mpt_agent.missing_config(config_path, [])
+
+            # 即使别的 Provider 已经配置了 Key，也不能悄悄把订阅用户切走。
+            self.assertEqual(provider, "claude_code")
+            self.assertEqual(active_provider, "claude_code")
+            self.assertEqual(missing, [])
+            self.assertIn(
+                'llm_provider = "claude_code"',
+                config_path.read_text(encoding="utf-8"),
+            )
 
     def test_only_missing_pexels_key_does_not_ask_for_llm_again(self):
         output = io.StringIO()


### PR DESCRIPTION
## Problem

`docs/skill/mpt_agent.py` maintains its own `KEYLESS_LLM_PROVIDERS` set, but it only
listed `ollama` and `litellm`. `claude_code` (added 2026-09-04) is also a provider that
authenticates **without** an API key: it consumes the Claude subscription through the
locally logged-in `claude` CLI, and `app/services/llm.py:313` gates generation on
`LLMProviderSpec.requires_api_key` — which is `False` for exactly
`{ollama, litellm, claude_code}` in `app/models/llm_provider.py`.

Because the helper's copy of that fact was out of date, a Skill run configured with
`llm_provider = "claude_code"` hit two user-visible failures:

1. **The Skill could never start.** `missing_config()` reported `claude_code_api_key` as
   required, so the helper emitted `MPT_NEEDS_INPUT` + `MISSING=claude_code_api_key` and
   exited with code 10 *before any generation*. It asked the agent to collect a credential
   that the provider never reads — there is no `claude_code_api_key` field at all; the
   provider's fields are `claude_code_model_name`, `claude_code_cli_path` and
   `claude_code_timeout` (`config.example.toml:362-364`).
2. **The chosen provider was silently replaced.** `_provider_is_ready()` returned `False`
   for it, so `reuse_existing_llm_provider()` scanned the recommended providers and
   switched the run to whichever one happened to have a key configured.

Reproduced against the current `main` by loading the helper and pointing it at a config
with `llm_provider = "claude_code"`:

```text
KEYLESS_LLM_PROVIDERS = ['litellm', 'ollama']

[1] _provider_is_ready('claude_code') = False
[2] missing_config -> provider='claude_code' missing=['claude_code_api_key']

[3] reuse_existing_llm_provider() with a deepseek key present -> 'deepseek'  # switched away

[5] what the agent is told to request:
MPT_NEEDS_INPUT
LLM_PROVIDER=claude_code
MISSING=claude_code_api_key
...
```

## Solution

Add `claude_code` to `KEYLESS_LLM_PROVIDERS`, and state the invariant in a comment: this
set has to stay aligned with the `requires_api_key=False` entries of
`app/models/llm_provider.py`. The helper is downloaded as a single standalone file
(`uv run --no-project`), so it cannot import that registry and must keep a literal copy —
the same reason `SUPPORTED_SOURCES` mirrors `_CLI_VIDEO_SOURCES`.

`claude_code` is intentionally **not** added to `RECOMMENDED_LLM_PROVIDERS`: like
`ollama` and `litellm`, it stays usable when already selected but is not an automatic
fallback candidate, since it needs a locally installed and logged-in CLI.

## Changes

- `docs/skill/mpt_agent.py` — add `"claude_code"` to `KEYLESS_LLM_PROVIDERS` and document
  the alignment requirement.
- `test/services/test_mpt_agent_skill.py` — two regression tests.

## Testing

Both new tests fail on unmodified `main` and pass after the change.

- `test_keyless_providers_stay_aligned_with_the_provider_registry` derives the expected set
  from `LLM_PROVIDER_REGISTRY` (`requires_api_key=False`), so a future keyless provider
  cannot drift again.
- `test_claude_code_subscription_provider_needs_no_api_key` drives `missing_config()` and
  `reuse_existing_llm_provider()` with `llm_provider = "claude_code"` and a competing
  `deepseek` key. It failed before the change with:

  ```text
  AssertionError: 'deepseek' != 'claude_code'
  ```

- `test/services/test_mpt_agent_skill.py` — **28 passed** (was 26).
- Full suite: `1 failed, 1183 passed, 19 skipped, 9652 subtests passed`. The single failure
  is `test/services/test_webui_headless_task_actions.py::test_headless_open_folder_shows_host_mapped_path`,
  a pre-existing Windows environment artifact (it patches `sys.platform = "linux"` and then
  trips `numpy`'s `os.uname()` probe) and it fails identically on unmodified `main`.
- `python -m compileall` and `ruff check` (0.15.21, the version pinned in `uv.lock`,
  including `docs/skill/mpt_agent.py`, which CI does not lint): `All checks passed!`

## Notes for Reviewer

- No open PR touches `docs/skill/mpt_agent.py` or `test/services/test_mpt_agent_skill.py`,
  so there is no textual conflict with in-flight work.
- Out of scope, and deliberately not bundled here: `apply_environment_config()` writes
  `f"{provider}_api_key"`, so passing `MPT_LLM_API_KEY` together with a keyless provider
  raises `configuration field not found: <provider>_api_key`. That predates this change and
  affects `ollama` and `litellm` identically; it is unrelated to `claude_code` being
  recognized, and the Skill never needs to pass a key for a keyless provider.
